### PR TITLE
feat: add PreToolUse hook for Bash secret scanning

### DIFF
--- a/config/hooks/scan-bash-secrets.sh
+++ b/config/hooks/scan-bash-secrets.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# scan-bash-secrets.sh — PreToolUse hook for Claude Code Bash tool calls.
+#
+# Reads hook event JSON from stdin, extracts the command, and pattern-matches
+# for leaked secrets. Blocks execution (exit 2 + stderr) if a secret is found.
+# Fails open (exit 0) if jq is missing or input is malformed — a broken hook
+# must never block all Bash commands.
+#
+# Install: cp config/hooks/scan-bash-secrets.sh ~/.claude/hooks/
+# Register in ~/.claude/settings.json under hooks.PreToolUse with matcher "Bash"
+
+set -euo pipefail
+
+# --- Dependency check ---
+if ! command -v jq &>/dev/null; then
+  echo "WARNING: jq not found — secret scanning disabled" >&2
+  exit 0
+fi
+
+# --- Read and parse stdin ---
+INPUT="$(cat)" || exit 0
+if [ -z "$INPUT" ]; then
+  exit 0
+fi
+
+COMMAND="$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)" || exit 0
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# --- Allowlist: known-safe commands exit immediately ---
+# op run is the safe path for secret injection.
+# op item / op vault are 1Password CLI management (metadata, not secrets).
+# Only check the first line — a multi-line command with op run on a later line
+# could still have secrets on earlier lines.
+FIRST_LINE="$(echo "$COMMAND" | head -1)"
+if echo "$FIRST_LINE" | grep -qE '^\s*op (run|item|vault) '; then
+  exit 0
+fi
+
+# --- Pattern checks ---
+# Each pattern has a specific block message with actionable guidance.
+
+# 1. Discord bot tokens: base64-encoded user ID . timestamp . HMAC
+#    Format: <24+ chars>.<6+ chars>.<27+ chars> (all base64url alphabet)
+if echo "$COMMAND" | grep -qE '[A-Za-z0-9_-]{24,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{27,}'; then
+  cat >&2 <<'MSG'
+BLOCK: Command contains what appears to be a Discord bot token.
+→ Use 'op run --env-file .env.op -- <command>' to inject secrets as environment variables.
+→ See the secrets-guideline skill for details.
+MSG
+  exit 2
+fi
+
+# 2. Known API key prefixes
+#    Each prefix has a minimum length to avoid false positives on short strings
+#    like `grep -r "sk-"` or variable names.
+if echo "$COMMAND" | grep -qE '(sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36,}|gho_[a-zA-Z0-9]{36,}|github_pat_[a-zA-Z0-9_]{30,}|AKIA[A-Z0-9]{16}|xox[bpras]-[a-zA-Z0-9-]{10,}|whsec_[a-zA-Z0-9]{20,})'; then
+  cat >&2 <<'MSG'
+BLOCK: Command contains a hardcoded API key.
+→ Store the key in 1Password and use 'op run --env-file .env.op -- <command>' instead.
+MSG
+  exit 2
+fi
+
+# 3. Hardcoded Authorization Bearer headers
+#    Matches literal tokens (starts with alphanumeric, 10+ chars).
+#    Does NOT match $ENV_VAR or ${ENV_VAR} references.
+if echo "$COMMAND" | grep -qE 'Authorization:.*Bearer [a-zA-Z0-9][a-zA-Z0-9_./-]{10,}'; then
+  # But allow env var references — if the Bearer value starts with $, it's safe
+  if ! echo "$COMMAND" | grep -qE 'Authorization:.*Bearer \$'; then
+    cat >&2 <<'MSG'
+BLOCK: Command contains a hardcoded Authorization header value.
+→ Use 'op run --env-file .env.op -- curl -H "Authorization: Bearer $ENV_VAR" ...' instead.
+MSG
+    exit 2
+  fi
+fi
+
+# 4. op read in command substitution — outputs secrets to stdout where they
+#    get captured in session JSONL files. The safe path is op run --env-file.
+if echo "$COMMAND" | grep -qE '(\$\(op read |`op read )'; then
+  cat >&2 <<'MSG'
+BLOCK: Command uses 'op read' in a command substitution which expands the secret into stdout where it gets logged.
+→ Use 'op run --env-file .env.op -- <command>' instead — secrets stay in env vars, never visible.
+MSG
+  exit 2
+fi
+
+# 5. Private key material
+if echo "$COMMAND" | grep -qE '\-\-\-\-\-BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY\-\-\-\-\-'; then
+  cat >&2 <<'MSG'
+BLOCK: Command contains private key material.
+→ Private keys should never appear in commands. Store in 1Password and reference via op run.
+MSG
+  exit 2
+fi
+
+# --- All checks passed ---
+exit 0

--- a/config/hooks/tests/test-scan-bash-secrets.sh
+++ b/config/hooks/tests/test-scan-bash-secrets.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# test-scan-bash-secrets.sh — Tests for the Bash secret scanning PreToolUse hook.
+#
+# Usage: bash config/hooks/tests/test-scan-bash-secrets.sh
+#
+# Each test feeds a JSON hook event to the scanner via stdin and checks
+# the exit code. Exit 0 = allowed, exit 2 = blocked.
+
+set -uo pipefail
+
+# Resolve script location so tests work from any cwd
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/../scan-bash-secrets.sh"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+# --- Helpers ---
+
+# Build a JSON hook event from a command string.
+# Uses jq to properly escape the command for JSON.
+make_event() {
+  local cmd="$1"
+  jq -n --arg cmd "$cmd" '{
+    tool_name: "Bash",
+    tool_input: { command: $cmd, description: "test", timeout: 120000 },
+    session_id: "test-session",
+    cwd: "/tmp",
+    hook_event_name: "PreToolUse"
+  }'
+}
+
+# Run the hook with a given command and check the exit code.
+# $1 = test name
+# $2 = command string
+# $3 = expected exit code (0 or 2)
+run_test() {
+  local name="$1"
+  local cmd="$2"
+  local expected="$3"
+  TOTAL=$((TOTAL + 1))
+
+  local stderr_output
+  stderr_output="$(make_event "$cmd" | bash "$HOOK" 2>&1 >/dev/null)"
+  local actual=$?
+
+  if [ "$actual" -eq "$expected" ]; then
+    echo "  PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name (expected exit $expected, got exit $actual)"
+    if [ -n "$stderr_output" ]; then
+      echo "        stderr: $(echo "$stderr_output" | head -1)"
+    fi
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# --- Must block (exit 2) ---
+
+echo ""
+echo "=== MUST BLOCK (exit 2) ==="
+echo ""
+
+run_test "Discord bot token" \
+  "curl -H \"Authorization: Bot MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kKWs\" https://discord.com/api/v10/gateway" \
+  2
+
+run_test "OpenAI API key" \
+  "curl -H \"Authorization: Bearer sk-abcdefghijklmnopqrstuvwxyz123456\" https://api.openai.com/v1/chat/completions" \
+  2
+
+run_test "GitHub PAT" \
+  "git clone https://ghp_abcdefghijklmnopqrstuvwxyz1234567890@github.com/user/repo" \
+  2
+
+run_test "GitHub OAuth token" \
+  "curl -H \"Authorization: token gho_abcdefghijklmnopqrstuvwxyz1234567890\" https://api.github.com/user" \
+  2
+
+run_test "GitHub fine-grained PAT" \
+  "curl -H \"Authorization: token github_pat_abcdefghijklmnopqrstuvwxyz12345\" https://api.github.com/user" \
+  2
+
+run_test "AWS access key" \
+  "aws configure set aws_access_key_id AKIAIOSFODNN7EXAMPLE" \
+  2
+
+run_test "Slack bot token" \
+  "curl -H \"Authorization: Bearer xoxb-fake-test-token-not-real\" https://slack.com/api/chat.postMessage" \
+  2
+
+run_test "Webhook secret" \
+  "curl -d '{\"secret\": \"whsec_abcdefghijklmnopqrstuvwxyz\"}' https://api.example.com/webhook" \
+  2
+
+run_test "Hardcoded Bearer token (JWT)" \
+  "curl -H \"Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJ0ZXN0IjoiZm9vIn0.hSwVxOGDa_THuhnV_yfwZIMC3c6_0AiJG\" https://api.example.com" \
+  2
+
+run_test "op read in \$()" \
+  'TOKEN=$(op read "op://vault/item/field") && curl -H "Authorization: Bearer $TOKEN" https://api.example.com' \
+  2
+
+run_test "op read in backticks" \
+  'curl -H "Authorization: Bearer `op read "op://vault/item/field"`" https://api.example.com' \
+  2
+
+run_test "Private RSA key" \
+  'echo "-----BEGIN RSA PRIVATE KEY-----" > /tmp/key.pem' \
+  2
+
+run_test "Private EC key" \
+  'echo "-----BEGIN EC PRIVATE KEY-----" > /tmp/key.pem' \
+  2
+
+run_test "Private key (generic)" \
+  'echo "-----BEGIN PRIVATE KEY-----" > /tmp/key.pem' \
+  2
+
+run_test "Private OPENSSH key" \
+  'echo "-----BEGIN OPENSSH PRIVATE KEY-----" > /tmp/key.pem' \
+  2
+
+# --- Must allow (exit 0) ---
+
+echo ""
+echo "=== MUST ALLOW (exit 0) ==="
+echo ""
+
+run_test "op run (safe path)" \
+  "op run --env-file .env.op -- curl https://api.example.com" \
+  0
+
+run_test "Env var in Bearer header" \
+  'curl -H "Authorization: Bearer $API_KEY" https://api.example.com' \
+  0
+
+run_test "Env var (braces) in Bearer header" \
+  'curl -H "Authorization: Bearer ${API_KEY}" https://api.example.com' \
+  0
+
+run_test "Simple git command" \
+  "git status" \
+  0
+
+run_test "Complex find command (no secrets)" \
+  'find . -name "*.ts" -exec grep -l "import" {} \;' \
+  0
+
+run_test "npm install" \
+  "npm install --save express" \
+  0
+
+run_test "op vault list" \
+  "op vault list" \
+  0
+
+run_test "op item list" \
+  "op item list --vault dev" \
+  0
+
+run_test "grep for sk- pattern (short, no real key)" \
+  'grep -r "sk-" src/' \
+  0
+
+run_test "grep for token pattern in code" \
+  'grep -rn "ghp_" src/' \
+  0
+
+run_test "Short sk- string in echo" \
+  'echo "prefix sk-short"' \
+  0
+
+# --- Edge cases ---
+
+echo ""
+echo "=== EDGE CASES ==="
+echo ""
+
+# Empty command
+TOTAL=$((TOTAL + 1))
+EMPTY_EVENT='{"tool_name":"Bash","tool_input":{"command":""},"session_id":"test","cwd":"/tmp","hook_event_name":"PreToolUse"}'
+echo "$EMPTY_EVENT" | bash "$HOOK" 2>/dev/null
+if [ $? -eq 0 ]; then
+  echo "  PASS: Empty command"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: Empty command (expected exit 0)"
+  FAIL=$((FAIL + 1))
+fi
+
+# Malformed JSON
+TOTAL=$((TOTAL + 1))
+echo "not json at all" | bash "$HOOK" 2>/dev/null
+if [ $? -eq 0 ]; then
+  echo "  PASS: Malformed JSON (fail open)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: Malformed JSON (expected exit 0, should fail open)"
+  FAIL=$((FAIL + 1))
+fi
+
+# Empty stdin
+TOTAL=$((TOTAL + 1))
+echo "" | bash "$HOOK" 2>/dev/null
+if [ $? -eq 0 ]; then
+  echo "  PASS: Empty stdin (fail open)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: Empty stdin (expected exit 0, should fail open)"
+  FAIL=$((FAIL + 1))
+fi
+
+# Missing tool_input.command field
+TOTAL=$((TOTAL + 1))
+echo '{"tool_name":"Bash","tool_input":{}}' | bash "$HOOK" 2>/dev/null
+if [ $? -eq 0 ]; then
+  echo "  PASS: Missing command field (fail open)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: Missing command field (expected exit 0)"
+  FAIL=$((FAIL + 1))
+fi
+
+# Multi-line command with secret on second line
+run_test "Multi-line command with secret" \
+  "$(printf 'cd /tmp\ncurl -H "Authorization: Bearer sk-abcdefghijklmnopqrstuvwxyz123456" https://api.openai.com')" \
+  2
+
+# Multi-line command without secret
+run_test "Multi-line command without secret" \
+  "$(printf 'cd /tmp\nls -la\ngit status')" \
+  0
+
+# op run should not trigger secret checks even with suspicious content after it
+run_test "op run with Bearer in args" \
+  'op run --env-file .env.op -- curl -H "Authorization: Bearer $TOKEN" https://api.example.com' \
+  0
+
+# Multi-line: op run on second line should NOT bypass scanning of first line
+run_test "Multi-line: secret before op run" \
+  "$(printf 'curl -H "Authorization: Bearer sk-abcdefghijklmnopqrstuvwxyz123456" https://api.openai.com\nop run --env-file .env.op -- echo done')" \
+  2
+
+# --- DSA key type ---
+run_test "Private DSA key" \
+  'echo "-----BEGIN DSA PRIVATE KEY-----" > /tmp/key.pem' \
+  2
+
+# --- Summary ---
+
+echo ""
+echo "=============================="
+echo "Results: $PASS passed, $FAIL failed, $TOTAL total"
+echo "=============================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Adds `config/hooks/scan-bash-secrets.sh` -- a standalone PreToolUse hook that intercepts Bash tool calls and blocks commands containing hardcoded secrets
- Detects 5 pattern categories: Discord tokens, API key prefixes (OpenAI, GitHub PAT/OAuth/fine-grained, AWS, Slack, webhook secrets), hardcoded Authorization Bearer headers, `op read` in command substitutions, and private key material
- Fails open (exit 0) if jq is missing, input is malformed, or command is empty -- a broken hook never blocks all Bash commands
- Allowlists `op run`, `op item`, `op vault` commands (the safe path)
- Registered in `~/.claude/settings.json` with matcher `Bash` and 5s timeout
- Installed to `~/.claude/hooks/scan-bash-secrets.sh`
- 35 tests covering all detection patterns, allowlisting, and edge cases (multi-line, malformed input, empty stdin)

## Notes for reviewer

- The existing Edit|Write hooks in settings.json are **untouched** -- fixing those is #3
- The allowlist only checks the first line of multi-line commands to prevent bypass via secrets on earlier lines followed by `op run` on a later line
- macOS grep ERE `{20,}` quantifiers work correctly -- verified during implementation
- GitHub push protection flagged a realistic Slack test token, so the test uses a clearly-fake token format instead (still triggers our regex)

## Open questions (non-blocking, all verified)

1. `grep -r "sk-"` false positive risk: verified -- our regex requires 20+ chars after the prefix, so short strings don't match
2. Multi-line commands: verified -- `jq -r` preserves newlines and `grep` processes line-by-line, so patterns work across the full string
3. macOS grep ERE: verified -- `{20,}` quantifiers work on macOS Darwin 25.3.0

## Test plan

- [x] All 35 tests pass: `bash config/hooks/tests/test-scan-bash-secrets.sh`
- [x] Smoke test of installed hook: safe commands pass (exit 0), secrets blocked (exit 2)
- [x] settings.json validates as clean JSON
- [ ] Reviewer: verify hook is live by checking `~/.claude/settings.json` and `~/.claude/hooks/scan-bash-secrets.sh`

Closes #2

Closes #2