### PR TITLE
Fix Edit|Write hooks to use stdin JSON API

### DIFF
--- a/config/hooks/README.md
+++ b/config/hooks/README.md
@@ -6,6 +6,14 @@ Claude Code hook scripts that run before tool invocations. Registered in `~/.cla
 
 - `scan-bash-secrets.sh` -- Scans Bash tool commands for leaked secrets before execution. Pattern-matches for Discord bot tokens, known API key prefixes (sk-, ghp_, AKIA, xox, etc.), hardcoded Authorization headers, `op read` in command substitutions, and private key material. Allowlists `op run` and `op item/vault` commands. Fails open if jq is missing or input is malformed.
 
+- `scan-edit-write-secrets.sh` -- Scans Edit/Write tool content for leaked secrets before file writes. Extracts `tool_input.new_string` (Edit) or `tool_input.content` (Write) from stdin JSON and pattern-matches for Discord bot tokens, known API key prefixes, and private key material. Does not scan `old_string` (existing content being replaced). Fails open if jq is missing or input is malformed.
+
+- `protect-branch.sh` -- Prevents Edit/Write operations on main/master branches. Extracts `tool_input.file_path` from stdin JSON, checks if the file is inside the current git repo, and blocks if the current branch is main or master. Fails open if not in a git repo, jq is missing, or input is malformed.
+
 ### tests/
 
-- `test-scan-bash-secrets.sh` -- Test suite for the secret scanner. Exercises each pattern category with both positive (should block) and negative (should allow) cases.
+- `test-scan-bash-secrets.sh` -- Test suite for the Bash secret scanner. Exercises each pattern category with both positive (should block) and negative (should allow) cases.
+
+- `test-scan-edit-write-secrets.sh` -- Test suite for the Edit/Write secret scanner. Tests all 3 pattern categories for both Edit and Write tools, plus edge cases (empty stdin, malformed JSON, missing jq, secret in old_string only).
+
+- `test-protect-branch.sh` -- Test suite for the branch protector. Tests blocking on main/master, allowing on feature branches, files outside repo, and fail-open edge cases.

--- a/config/hooks/protect-branch.sh
+++ b/config/hooks/protect-branch.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# protect-branch.sh — PreToolUse hook that prevents Edit/Write on main/master.
+#
+# Reads hook event JSON from stdin, extracts the file path, checks if the file
+# is inside the current git repo, and blocks the operation if the current branch
+# is main or master. Fails open (exit 0) if jq is missing, not in a git repo,
+# or input is malformed — a broken hook must never block all Edit/Write operations.
+#
+# Install: cp config/hooks/protect-branch.sh ~/.claude/hooks/
+# Register in ~/.claude/settings.json under hooks.PreToolUse with matcher "Edit|Write"
+
+set -euo pipefail
+
+# --- Dependency check ---
+if ! command -v jq &>/dev/null; then
+  echo "WARNING: jq not found — branch protection disabled" >&2
+  exit 0
+fi
+
+# --- Read and parse stdin ---
+INPUT="$(cat)" || exit 0
+if [ -z "$INPUT" ]; then
+  exit 0
+fi
+
+FILE_PATH="$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)" || exit 0
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# --- Check if file is inside a git repo ---
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+
+case "$FILE_PATH" in
+  "$REPO_ROOT"/*) ;;
+  *) exit 0 ;;
+esac
+
+# --- Check current branch ---
+BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)" || exit 0
+
+if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
+  cat >&2 <<MSG
+BLOCK: Direct edits to '$BRANCH' are not allowed.
+→ Create a feature branch first: git checkout -b feature/<issue#>-<slug>
+MSG
+  exit 2
+fi
+
+# --- Not on a protected branch ---
+exit 0

--- a/config/hooks/scan-edit-write-secrets.sh
+++ b/config/hooks/scan-edit-write-secrets.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# scan-edit-write-secrets.sh — PreToolUse hook for Claude Code Edit/Write tool calls.
+#
+# Reads hook event JSON from stdin, extracts the content being written
+# (new_string for Edit, content for Write), and pattern-matches for hardcoded
+# secrets. Blocks execution (exit 2 + stderr) if a secret is found.
+# Fails open (exit 0) if jq is missing or input is malformed — a broken hook
+# must never block all Edit/Write operations.
+#
+# Install: cp config/hooks/scan-edit-write-secrets.sh ~/.claude/hooks/
+# Register in ~/.claude/settings.json under hooks.PreToolUse with matcher "Edit|Write"
+
+set -euo pipefail
+
+# --- Dependency check ---
+if ! command -v jq &>/dev/null; then
+  echo "WARNING: jq not found — secret scanning disabled" >&2
+  exit 0
+fi
+
+# --- Read and parse stdin ---
+INPUT="$(cat)" || exit 0
+if [ -z "$INPUT" ]; then
+  exit 0
+fi
+
+CONTENT="$(echo "$INPUT" | jq -r '(.tool_input.new_string // .tool_input.content // empty)' 2>/dev/null)" || exit 0
+if [ -z "$CONTENT" ]; then
+  exit 0
+fi
+
+# --- Pattern checks ---
+# Each pattern has a specific block message with actionable guidance.
+
+# 1. Discord bot tokens: base64-encoded user ID . timestamp . HMAC
+#    Format: <24+ chars>.<6+ chars>.<27+ chars> (all base64url alphabet)
+if echo "$CONTENT" | grep -qE '[A-Za-z0-9_-]{24,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{27,}'; then
+  cat >&2 <<'MSG'
+BLOCK: File content contains what appears to be a Discord bot token.
+→ Store the token in 1Password and reference it via environment variable.
+→ See the secrets-guideline skill for details.
+MSG
+  exit 2
+fi
+
+# 2. Known API key prefixes
+#    Each prefix has a minimum length to avoid false positives on short strings.
+if echo "$CONTENT" | grep -qE '(sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36,}|gho_[a-zA-Z0-9]{36,}|github_pat_[a-zA-Z0-9_]{30,}|AKIA[A-Z0-9]{16}|xox[bpras]-[a-zA-Z0-9-]{10,}|whsec_[a-zA-Z0-9]{20,})'; then
+  cat >&2 <<'MSG'
+BLOCK: File content contains a hardcoded API key.
+→ Store the key in 1Password and reference it via environment variable or op run.
+MSG
+  exit 2
+fi
+
+# 3. Private key material
+if echo "$CONTENT" | grep -qE '\-\-\-\-\-BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY\-\-\-\-\-'; then
+  cat >&2 <<'MSG'
+BLOCK: File content contains private key material.
+→ Private keys should never appear in source files. Store in 1Password and reference via op run.
+MSG
+  exit 2
+fi
+
+# --- All checks passed ---
+exit 0

--- a/config/hooks/tests/test-protect-branch.sh
+++ b/config/hooks/tests/test-protect-branch.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# test-protect-branch.sh — Tests for the branch protection PreToolUse hook.
+#
+# Usage: bash config/hooks/tests/test-protect-branch.sh
+#
+# Creates temporary git repos to simulate different branch states.
+# Each test feeds a JSON hook event to the hook via stdin and checks
+# the exit code. Exit 0 = allowed, exit 2 = blocked.
+
+set -uo pipefail
+
+# Resolve script location so tests work from any cwd
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/../protect-branch.sh"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+# --- Test repo setup ---
+# Create a temporary git repo so we can control the branch name
+# Resolve real path to handle macOS /var -> /private/var symlink.
+# git rev-parse --show-toplevel returns the real path, so file paths
+# must also use the real path for the case comparison to match.
+TEST_DIR="$(cd "$(mktemp -d)" && pwd -P)"
+cleanup() { rm -rf "$TEST_DIR"; }
+trap cleanup EXIT
+
+git -C "$TEST_DIR" init -b main --quiet
+git -C "$TEST_DIR" commit --allow-empty -m "init" --quiet
+
+# --- Helpers ---
+
+# Build a JSON hook event with a file path.
+# $1 = tool name ("Edit" or "Write")
+# $2 = file path
+make_event() {
+  local tool="$1"
+  local file_path="$2"
+  if [ "$tool" = "Edit" ]; then
+    jq -n --arg path "$file_path" '{
+      tool_name: "Edit",
+      tool_input: { file_path: $path, old_string: "old", new_string: "new" },
+      session_id: "test-session",
+      cwd: "/tmp",
+      hook_event_name: "PreToolUse"
+    }'
+  else
+    jq -n --arg path "$file_path" '{
+      tool_name: "Write",
+      tool_input: { file_path: $path, content: "file content" },
+      session_id: "test-session",
+      cwd: "/tmp",
+      hook_event_name: "PreToolUse"
+    }'
+  fi
+}
+
+# Run the hook from within a specific directory and check exit code.
+# $1 = test name
+# $2 = tool name ("Edit" or "Write")
+# $3 = file path
+# $4 = working directory for the hook
+# $5 = expected exit code (0 or 2)
+run_test() {
+  local name="$1"
+  local tool="$2"
+  local file_path="$3"
+  local work_dir="$4"
+  local expected="$5"
+  TOTAL=$((TOTAL + 1))
+
+  local stderr_output
+  stderr_output="$(make_event "$tool" "$file_path" | bash -c "cd '$work_dir' && bash '$HOOK'" 2>&1 >/dev/null)"
+  local actual=$?
+
+  if [ "$actual" -eq "$expected" ]; then
+    echo "  PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name (expected exit $expected, got exit $actual)"
+    if [ -n "$stderr_output" ]; then
+      echo "        stderr: $(echo "$stderr_output" | head -1)"
+    fi
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# --- Must block (exit 2) — on main/master ---
+
+echo ""
+echo "=== MUST BLOCK — protected branches (exit 2) ==="
+echo ""
+
+# On main branch (default after init)
+run_test "Edit on main branch" \
+  "Edit" "$TEST_DIR/src/index.ts" "$TEST_DIR" 2
+
+run_test "Write on main branch" \
+  "Write" "$TEST_DIR/src/index.ts" "$TEST_DIR" 2
+
+# Switch to master and test
+git -C "$TEST_DIR" checkout -b master --quiet
+run_test "Edit on master branch" \
+  "Edit" "$TEST_DIR/src/index.ts" "$TEST_DIR" 2
+
+run_test "Write on master branch" \
+  "Write" "$TEST_DIR/src/index.ts" "$TEST_DIR" 2
+
+# --- Must allow (exit 0) — feature branch ---
+
+echo ""
+echo "=== MUST ALLOW — feature branches (exit 0) ==="
+echo ""
+
+git -C "$TEST_DIR" checkout -b feature/test-branch --quiet
+
+run_test "Edit on feature branch" \
+  "Edit" "$TEST_DIR/src/index.ts" "$TEST_DIR" 0
+
+run_test "Write on feature branch" \
+  "Write" "$TEST_DIR/src/index.ts" "$TEST_DIR" 0
+
+# --- Must allow (exit 0) — file outside repo ---
+
+echo ""
+echo "=== MUST ALLOW — file outside repo (exit 0) ==="
+echo ""
+
+# Switch back to main so we can verify it would block repo files
+git -C "$TEST_DIR" checkout main --quiet
+
+run_test "Edit file outside repo (on main)" \
+  "Edit" "/tmp/outside-file.ts" "$TEST_DIR" 0
+
+run_test "Write file outside repo (on main)" \
+  "Write" "/tmp/outside-file.ts" "$TEST_DIR" 0
+
+# --- Edge cases ---
+
+echo ""
+echo "=== EDGE CASES ==="
+echo ""
+
+# Empty stdin
+TOTAL=$((TOTAL + 1))
+echo "" | bash -c "cd '$TEST_DIR' && bash '$HOOK'" 2>/dev/null
+if [ $? -eq 0 ]; then
+  echo "  PASS: Empty stdin (fail open)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: Empty stdin (expected exit 0, should fail open)"
+  FAIL=$((FAIL + 1))
+fi
+
+# Malformed JSON
+TOTAL=$((TOTAL + 1))
+echo "not json" | bash -c "cd '$TEST_DIR' && bash '$HOOK'" 2>/dev/null
+if [ $? -eq 0 ]; then
+  echo "  PASS: Malformed JSON (fail open)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: Malformed JSON (expected exit 0, should fail open)"
+  FAIL=$((FAIL + 1))
+fi
+
+# Missing file_path in tool_input
+TOTAL=$((TOTAL + 1))
+echo '{"tool_name":"Edit","tool_input":{}}' | bash -c "cd '$TEST_DIR' && bash '$HOOK'" 2>/dev/null
+if [ $? -eq 0 ]; then
+  echo "  PASS: Missing file_path (fail open)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: Missing file_path (expected exit 0)"
+  FAIL=$((FAIL + 1))
+fi
+
+# Not in a git repo
+TOTAL=$((TOTAL + 1))
+NON_GIT_DIR="$(mktemp -d)"
+make_event "Edit" "$NON_GIT_DIR/file.ts" | bash -c "cd '$NON_GIT_DIR' && bash '$HOOK'" 2>/dev/null
+if [ $? -eq 0 ]; then
+  echo "  PASS: Not in git repo (fail open)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: Not in git repo (expected exit 0, should fail open)"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$NON_GIT_DIR"
+
+# Missing jq (create a minimal PATH without jq)
+# Write event to file first to avoid SIGPIPE — the hook exits before reading
+# stdin when jq is missing, which kills the pipe writer under pipefail.
+TOTAL=$((TOTAL + 1))
+FAKE_PATH="$(mktemp -d)"
+JQ_TEST_EVENT="$(mktemp)"
+for cmd in bash cat grep echo head git; do
+  real="$(command -v "$cmd" 2>/dev/null)" && [ -n "$real" ] && ln -sf "$real" "$FAKE_PATH/$cmd"
+done
+make_event "Edit" "$TEST_DIR/file.ts" > "$JQ_TEST_EVENT"
+PATH="$FAKE_PATH" bash -c "cd '$TEST_DIR' && bash '$HOOK'" < "$JQ_TEST_EVENT" 2>/dev/null
+if [ $? -eq 0 ]; then
+  echo "  PASS: Missing jq (fail open)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: Missing jq (expected exit 0, should fail open)"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$FAKE_PATH" "$JQ_TEST_EVENT"
+
+# --- Summary ---
+
+echo ""
+echo "=============================="
+echo "Results: $PASS passed, $FAIL failed, $TOTAL total"
+echo "=============================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/config/hooks/tests/test-scan-edit-write-secrets.sh
+++ b/config/hooks/tests/test-scan-edit-write-secrets.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+# test-scan-edit-write-secrets.sh — Tests for the Edit/Write secret scanning PreToolUse hook.
+#
+# Usage: bash config/hooks/tests/test-scan-edit-write-secrets.sh
+#
+# Each test feeds a JSON hook event to the scanner via stdin and checks
+# the exit code. Exit 0 = allowed, exit 2 = blocked.
+
+set -uo pipefail
+
+# Resolve script location so tests work from any cwd
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/../scan-edit-write-secrets.sh"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+# --- Helpers ---
+
+# Build a JSON hook event for an Edit or Write tool call.
+# Uses jq to properly escape the content for JSON.
+# $1 = tool name ("Edit" or "Write")
+# $2 = content string (goes into new_string for Edit, content for Write)
+make_event() {
+  local tool="$1"
+  local content="$2"
+  if [ "$tool" = "Edit" ]; then
+    jq -n --arg content "$content" '{
+      tool_name: "Edit",
+      tool_input: { file_path: "/tmp/test.ts", old_string: "placeholder", new_string: $content },
+      session_id: "test-session",
+      cwd: "/tmp",
+      hook_event_name: "PreToolUse"
+    }'
+  else
+    jq -n --arg content "$content" '{
+      tool_name: "Write",
+      tool_input: { file_path: "/tmp/test.ts", content: $content },
+      session_id: "test-session",
+      cwd: "/tmp",
+      hook_event_name: "PreToolUse"
+    }'
+  fi
+}
+
+# Run the hook with given content and check the exit code.
+# $1 = test name
+# $2 = tool name ("Edit" or "Write")
+# $3 = content string
+# $4 = expected exit code (0 or 2)
+run_test() {
+  local name="$1"
+  local tool="$2"
+  local content="$3"
+  local expected="$4"
+  TOTAL=$((TOTAL + 1))
+
+  local stderr_output
+  stderr_output="$(make_event "$tool" "$content" | bash "$HOOK" 2>&1 >/dev/null)"
+  local actual=$?
+
+  if [ "$actual" -eq "$expected" ]; then
+    echo "  PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name (expected exit $expected, got exit $actual)"
+    if [ -n "$stderr_output" ]; then
+      echo "        stderr: $(echo "$stderr_output" | head -1)"
+    fi
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# --- Must block (exit 2) — Edit tool ---
+
+echo ""
+echo "=== MUST BLOCK — Edit tool (exit 2) ==="
+echo ""
+
+run_test "Edit: Discord bot token" \
+  "Edit" \
+  'const TOKEN = "MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kKWs";' \
+  2
+
+run_test "Edit: OpenAI API key" \
+  "Edit" \
+  'const OPENAI_KEY = "sk-abcdefghijklmnopqrstuvwxyz123456";' \
+  2
+
+run_test "Edit: GitHub PAT" \
+  "Edit" \
+  'const GH_TOKEN = "ghp_abcdefghijklmnopqrstuvwxyz1234567890";' \
+  2
+
+run_test "Edit: GitHub OAuth token" \
+  "Edit" \
+  'const GH_OAUTH = "gho_abcdefghijklmnopqrstuvwxyz1234567890";' \
+  2
+
+run_test "Edit: GitHub fine-grained PAT" \
+  "Edit" \
+  'const GH_PAT = "github_pat_abcdefghijklmnopqrstuvwxyz12345";' \
+  2
+
+run_test "Edit: AWS access key" \
+  "Edit" \
+  'AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE' \
+  2
+
+run_test "Edit: Slack bot token" \
+  "Edit" \
+  'const SLACK_TOKEN = "xoxb-fake-test-token-not-real";' \
+  2
+
+run_test "Edit: Webhook secret" \
+  "Edit" \
+  'const WEBHOOK_SECRET = "whsec_abcdefghijklmnopqrstuvwxyz";' \
+  2
+
+run_test "Edit: Private RSA key" \
+  "Edit" \
+  '-----BEGIN RSA PRIVATE KEY-----' \
+  2
+
+run_test "Edit: Private EC key" \
+  "Edit" \
+  '-----BEGIN EC PRIVATE KEY-----' \
+  2
+
+run_test "Edit: Private key (generic)" \
+  "Edit" \
+  '-----BEGIN PRIVATE KEY-----' \
+  2
+
+run_test "Edit: Private OPENSSH key" \
+  "Edit" \
+  '-----BEGIN OPENSSH PRIVATE KEY-----' \
+  2
+
+# --- Must block (exit 2) — Write tool ---
+
+echo ""
+echo "=== MUST BLOCK — Write tool (exit 2) ==="
+echo ""
+
+run_test "Write: Discord bot token" \
+  "Write" \
+  'const TOKEN = "MTk4NjIyNDgzNDcxOTI1MjQ4.Cl2FMQ.ZnCjm1XVW7vRze4b7Cq4se7kKWs";' \
+  2
+
+run_test "Write: OpenAI API key" \
+  "Write" \
+  'const OPENAI_KEY = "sk-abcdefghijklmnopqrstuvwxyz123456";' \
+  2
+
+run_test "Write: GitHub PAT" \
+  "Write" \
+  'const GH_TOKEN = "ghp_abcdefghijklmnopqrstuvwxyz1234567890";' \
+  2
+
+run_test "Write: GitHub OAuth token" \
+  "Write" \
+  'const GH_OAUTH = "gho_abcdefghijklmnopqrstuvwxyz1234567890";' \
+  2
+
+run_test "Write: GitHub fine-grained PAT" \
+  "Write" \
+  'const GH_PAT = "github_pat_abcdefghijklmnopqrstuvwxyz12345";' \
+  2
+
+run_test "Write: AWS access key" \
+  "Write" \
+  'AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE' \
+  2
+
+run_test "Write: Slack bot token" \
+  "Write" \
+  'const SLACK_TOKEN = "xoxb-fake-test-token-not-real";' \
+  2
+
+run_test "Write: Webhook secret" \
+  "Write" \
+  'const WEBHOOK_SECRET = "whsec_abcdefghijklmnopqrstuvwxyz";' \
+  2
+
+run_test "Write: Private RSA key" \
+  "Write" \
+  '-----BEGIN RSA PRIVATE KEY-----' \
+  2
+
+run_test "Write: Private DSA key" \
+  "Write" \
+  '-----BEGIN DSA PRIVATE KEY-----' \
+  2
+
+# --- Must allow (exit 0) ---
+
+echo ""
+echo "=== MUST ALLOW (exit 0) ==="
+echo ""
+
+run_test "Clean TypeScript code" \
+  "Edit" \
+  'const greeting = "hello world";' \
+  0
+
+run_test "Env var reference (not a secret)" \
+  "Edit" \
+  'const key = process.env.SECRET_KEY;' \
+  0
+
+run_test "Short sk- string (not a key)" \
+  "Edit" \
+  'const prefix = "sk-short";' \
+  0
+
+run_test "Short ghp_ string (not a key)" \
+  "Write" \
+  'grep -r "ghp_" src/' \
+  0
+
+run_test "Empty content (Write)" \
+  "Write" \
+  '' \
+  0
+
+run_test "Comment about keys (no actual key)" \
+  "Edit" \
+  '// API keys should be stored in 1Password, never hardcoded' \
+  0
+
+run_test "Public key (not private)" \
+  "Write" \
+  '-----BEGIN PUBLIC KEY-----' \
+  0
+
+run_test "Certificate (not private key)" \
+  "Write" \
+  '-----BEGIN CERTIFICATE-----' \
+  0
+
+run_test "sk- in variable name (no real key)" \
+  "Edit" \
+  'const sk_prefix_check = /^sk-/;' \
+  0
+
+run_test "Slack mention without real token" \
+  "Edit" \
+  '// Configure xoxb token via environment variable' \
+  0
+
+# --- Edge cases ---
+
+echo ""
+echo "=== EDGE CASES ==="
+echo ""
+
+# Empty stdin
+TOTAL=$((TOTAL + 1))
+echo "" | bash "$HOOK" 2>/dev/null
+if [ $? -eq 0 ]; then
+  echo "  PASS: Empty stdin (fail open)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: Empty stdin (expected exit 0, should fail open)"
+  FAIL=$((FAIL + 1))
+fi
+
+# Malformed JSON
+TOTAL=$((TOTAL + 1))
+echo "not json at all" | bash "$HOOK" 2>/dev/null
+if [ $? -eq 0 ]; then
+  echo "  PASS: Malformed JSON (fail open)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: Malformed JSON (expected exit 0, should fail open)"
+  FAIL=$((FAIL + 1))
+fi
+
+# Missing tool_input fields
+TOTAL=$((TOTAL + 1))
+echo '{"tool_name":"Edit","tool_input":{}}' | bash "$HOOK" 2>/dev/null
+if [ $? -eq 0 ]; then
+  echo "  PASS: Missing tool_input fields (fail open)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: Missing tool_input fields (expected exit 0)"
+  FAIL=$((FAIL + 1))
+fi
+
+# Missing jq (create a minimal PATH without jq)
+# Write event to file first to avoid SIGPIPE — the hook exits before reading
+# stdin when jq is missing, which kills the pipe writer under pipefail.
+TOTAL=$((TOTAL + 1))
+FAKE_PATH="$(mktemp -d)"
+JQ_TEST_EVENT="$(mktemp)"
+for cmd in bash cat grep echo head; do
+  real="$(command -v "$cmd" 2>/dev/null)" && [ -n "$real" ] && ln -sf "$real" "$FAKE_PATH/$cmd"
+done
+make_event "Edit" "sk-abcdefghijklmnopqrstuvwxyz123456" > "$JQ_TEST_EVENT"
+stderr_output="$(PATH="$FAKE_PATH" bash "$HOOK" < "$JQ_TEST_EVENT" 2>&1 >/dev/null)"
+if [ $? -eq 0 ]; then
+  echo "  PASS: Missing jq (fail open)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: Missing jq (expected exit 0, should fail open)"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$FAKE_PATH" "$JQ_TEST_EVENT"
+
+# Multi-line content with secret on later line
+run_test "Multi-line content with secret" \
+  "Write" \
+  "$(printf 'const a = 1;\nconst key = \"sk-abcdefghijklmnopqrstuvwxyz123456\";\nconst b = 2;')" \
+  2
+
+# Multi-line content without secret
+run_test "Multi-line content without secret" \
+  "Write" \
+  "$(printf 'const a = 1;\nconst b = 2;\nconst c = 3;')" \
+  0
+
+# Edit with secret in old_string but clean new_string (should allow)
+TOTAL=$((TOTAL + 1))
+EVENT="$(jq -n '{
+  tool_name: "Edit",
+  tool_input: {
+    file_path: "/tmp/test.ts",
+    old_string: "sk-abcdefghijklmnopqrstuvwxyz123456",
+    new_string: "process.env.OPENAI_API_KEY"
+  },
+  session_id: "test-session",
+  cwd: "/tmp",
+  hook_event_name: "PreToolUse"
+}')"
+echo "$EVENT" | bash "$HOOK" 2>/dev/null
+if [ $? -eq 0 ]; then
+  echo "  PASS: Secret in old_string only (correctly allows — replacing a secret)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: Secret in old_string only (should allow — we're removing the secret)"
+  FAIL=$((FAIL + 1))
+fi
+
+# --- Summary ---
+
+echo ""
+echo "=============================="
+echo "Results: $PASS passed, $FAIL failed, $TOTAL total"
+echo "=============================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Replace two broken inline `$TOOL_INPUT` hooks in `~/.claude/settings.json` with proper scripts that read stdin JSON
- `scan-edit-write-secrets.sh` scans `new_string` (Edit) / `content` (Write) for Discord bot tokens, API key prefixes (sk-, ghp_, gho_, github_pat_, AKIA, xox[bpras]-, whsec_), and private key material
- `protect-branch.sh` blocks file edits when on main/master branches
- Both scripts fail open on missing jq, malformed input, or non-git directories
- Installed to `~/.claude/hooks/` and registered in settings.json with 5s timeout

## Test plan

- [x] `test-scan-edit-write-secrets.sh` — 39 tests pass (12 Edit blocks, 10 Write blocks, 10 allows, 7 edge cases including missing jq, old_string-only secret)
- [x] `test-protect-branch.sh` — 13 tests pass (4 blocks on main/master, 2 allows on feature branch, 2 outside-repo allows, 5 edge cases)
- [x] `test-scan-bash-secrets.sh` — existing 35 tests still pass (no regressions)
- [x] Live validation: protect-branch.sh correctly blocked Edit on main during development, allowed after switching to feature branch

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)