### PR TITLE
Fix session spawn bugs: wrong resume and ID extraction

### DIFF
--- a/packages/daemon/src/features.ts
+++ b/packages/daemon/src/features.ts
@@ -425,9 +425,11 @@ export class FeatureManager extends EventEmitter {
     const prompt = resolve_prompt(phase_config.prompt_template, feature);
     const worktree_path = feature.worktreePath ?? expand_home_safe(entity.entity.repos[0]?.path ?? ".");
 
-    // Resume prior session if same archetype is being re-spawned for this feature
-    // (e.g., builder picks up where it left off after being unblocked)
-    const resume_id = feature.lastSessionId ?? undefined;
+    // Resume prior session only if the same archetype is being re-spawned
+    // (e.g., builder picks up where it left off after being unblocked or review bounce).
+    // Different archetype (e.g., plan→build) always gets a fresh session.
+    const same_archetype = feature.activeArchetype === phase_config.archetype;
+    const resume_id = same_archetype ? (feature.lastSessionId ?? undefined) : undefined;
 
     const task_id = this.queue.submit({
       entity_id: feature.entity,

--- a/packages/daemon/src/session.ts
+++ b/packages/daemon/src/session.ts
@@ -225,8 +225,10 @@ export class ClaudeSessionManager extends EventEmitter implements SessionManager
     }
 
     const { command, args } = await this.build_command(options);
-    // Extract session_id from the args (we passed it via --session-id)
-    const session_id_idx = args.indexOf("--session-id");
+    // Extract session_id from args — could be --session-id (fresh) or --resume (resumed)
+    const fresh_idx = args.indexOf("--session-id");
+    const resume_idx = args.indexOf("--resume");
+    const session_id_idx = fresh_idx !== -1 ? fresh_idx : resume_idx;
     const session_id = args[session_id_idx + 1]!;
 
     const session: ActiveSession = {


### PR DESCRIPTION
## Summary
- Prevents resuming a planner session when spawning a builder (only resume when same archetype is re-spawned)
- Fixes session ID extraction to look for both `--session-id` and `--resume` flags, preventing the `-p` fallback bug

## Context
Discovered while kicking off feature #7 build. The plan→build transition tried to resume the planner's session for the builder, and the session ID extraction fell through to `args[0]` (`"-p"`) because `--session-id` wasn't in the args on a resume path.

## Test plan
- [ ] Advance a feature from plan→build — verify fresh session (no resume)
- [ ] Unblock a builder and re-spawn — verify session IS resumed (same archetype)
- [ ] Daemon builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)