### PR TITLE
feat: work room assignment & notification routing

### DIFF
--- a/packages/daemon/src/__tests__/work-rooms.test.ts
+++ b/packages/daemon/src/__tests__/work-rooms.test.ts
@@ -1,0 +1,542 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { EntityConfigSchema, LobsterFarmConfigSchema } from "@lobster-farm/shared";
+import type {
+  LobsterFarmConfig,
+  EntityConfig,
+  FeatureState,
+  ChannelMapping,
+} from "@lobster-farm/shared";
+import * as actions from "../actions.js";
+
+// ── Helpers ──
+
+function make_config(): LobsterFarmConfig {
+  return LobsterFarmConfigSchema.parse({
+    user: { name: "Test" },
+    concurrency: { max_active_sessions: 2, max_queue_depth: 20 },
+  });
+}
+
+function make_entity_config(channels: ChannelMapping[] = []): EntityConfig {
+  return EntityConfigSchema.parse({
+    entity: {
+      id: "alpha",
+      name: "Alpha Project",
+      repos: [{ name: "alpha", url: "git@github.com:test/alpha.git", path: "/tmp/test-repo" }],
+      channels: {
+        category_id: "cat-123",
+        list: channels,
+      },
+      memory: { path: "/tmp/.memory" },
+      secrets: { vault_name: "entity-alpha" },
+    },
+  });
+}
+
+function make_feature(overrides: Partial<FeatureState> = {}): FeatureState {
+  return {
+    id: "alpha-42",
+    entity: "alpha",
+    githubIssue: 42,
+    title: "Test Feature",
+    phase: "build",
+    priority: "medium",
+    branch: "feature/42-test-feature",
+    worktreePath: "/tmp/worktree",
+    discordWorkRoom: null,
+    activeArchetype: "builder",
+    activeDna: ["coding-dna"],
+    sessionId: null,
+    lastSessionId: null,
+    blocked: false,
+    blockedReason: null,
+    approved: false,
+    labels: [],
+    prNumber: null,
+    agentDone: false,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function make_static_work_rooms(): ChannelMapping[] {
+  return [
+    { type: "general", id: "gen-1" },
+    { type: "work_room", id: "wr-1", purpose: "Work room 1" },
+    { type: "work_room", id: "wr-2", purpose: "Work room 2" },
+    { type: "work_room", id: "wr-3", purpose: "Work room 3" },
+    { type: "work_log", id: "wl-1" },
+    { type: "alerts", id: "al-1" },
+  ];
+}
+
+// ── Mock Discord Bot ──
+
+function make_mock_discord() {
+  return {
+    send: vi.fn().mockResolvedValue(undefined),
+    send_as_agent: vi.fn().mockResolvedValue(undefined),
+    send_to_entity: vi.fn().mockResolvedValue(undefined),
+    set_channel_topic: vi.fn().mockResolvedValue(undefined),
+    create_channel: vi.fn().mockResolvedValue("dynamic-wr-4"),
+    delete_channel: vi.fn().mockResolvedValue(undefined),
+    build_channel_map: vi.fn(),
+    is_connected: vi.fn().mockReturnValue(true),
+  };
+}
+
+// ── Mock Feature Manager ──
+
+function make_mock_feature_manager(features: FeatureState[] = []) {
+  return {
+    get_features_by_entity: vi.fn().mockReturnValue(features),
+    get_feature: vi.fn((id: string) => features.find(f => f.id === id)),
+    list_features: vi.fn().mockReturnValue(features),
+  };
+}
+
+// ── Tests ──
+
+describe("Work Room Assignment", () => {
+  let discord: ReturnType<typeof make_mock_discord>;
+
+  beforeEach(() => {
+    discord = make_mock_discord();
+    // @ts-expect-error — mock does not implement full DiscordBot interface
+    actions.set_discord_bot(discord);
+  });
+
+  describe("assign_work_room", () => {
+    it("assigns a free static room when one is available", async () => {
+      const feature = make_feature();
+      const entity = make_entity_config(make_static_work_rooms());
+      // @ts-expect-error — mock feature manager
+      actions.set_feature_manager(make_mock_feature_manager([]));
+
+      const room_id = await actions.assign_work_room(feature, entity);
+
+      expect(room_id).toBe("wr-1");
+      // Verify assigned_feature was set on the channel entry
+      const wr1 = entity.entity.channels.list.find(c => c.id === "wr-1");
+      expect(wr1?.assigned_feature).toBe("alpha-42");
+    });
+
+    it("skips rooms occupied by active features", async () => {
+      const feature = make_feature({ id: "alpha-42" });
+      const existing_feature = make_feature({
+        id: "alpha-10",
+        discordWorkRoom: "wr-1",
+        phase: "build",
+      });
+      const entity = make_entity_config(make_static_work_rooms());
+      // @ts-expect-error — mock feature manager
+      actions.set_feature_manager(make_mock_feature_manager([existing_feature]));
+
+      const room_id = await actions.assign_work_room(feature, entity);
+
+      expect(room_id).toBe("wr-2");
+    });
+
+    it("skips rooms occupied by multiple active features", async () => {
+      const feature = make_feature({ id: "alpha-42" });
+      const features = [
+        make_feature({ id: "alpha-10", discordWorkRoom: "wr-1", phase: "build" }),
+        make_feature({ id: "alpha-11", discordWorkRoom: "wr-2", phase: "review" }),
+      ];
+      const entity = make_entity_config(make_static_work_rooms());
+      // @ts-expect-error — mock feature manager
+      actions.set_feature_manager(make_mock_feature_manager(features));
+
+      const room_id = await actions.assign_work_room(feature, entity);
+
+      expect(room_id).toBe("wr-3");
+    });
+
+    it("creates a dynamic room when all static rooms are occupied", async () => {
+      const feature = make_feature({ id: "alpha-42" });
+      const features = [
+        make_feature({ id: "alpha-10", discordWorkRoom: "wr-1", phase: "build" }),
+        make_feature({ id: "alpha-11", discordWorkRoom: "wr-2", phase: "review" }),
+        make_feature({ id: "alpha-12", discordWorkRoom: "wr-3", phase: "build" }),
+      ];
+      const entity = make_entity_config(make_static_work_rooms());
+      // @ts-expect-error — mock feature manager
+      actions.set_feature_manager(make_mock_feature_manager(features));
+
+      const room_id = await actions.assign_work_room(feature, entity);
+
+      expect(room_id).toBe("dynamic-wr-4");
+      expect(discord.create_channel).toHaveBeenCalledWith(
+        "cat-123",
+        "work-room-4",
+        "Overflow for alpha-42",
+      );
+    });
+
+    it("tags dynamic room with dynamic: true in entity config", async () => {
+      const feature = make_feature({ id: "alpha-42" });
+      const features = [
+        make_feature({ id: "alpha-10", discordWorkRoom: "wr-1", phase: "build" }),
+        make_feature({ id: "alpha-11", discordWorkRoom: "wr-2", phase: "build" }),
+        make_feature({ id: "alpha-12", discordWorkRoom: "wr-3", phase: "build" }),
+      ];
+      const entity = make_entity_config(make_static_work_rooms());
+      // @ts-expect-error — mock feature manager
+      actions.set_feature_manager(make_mock_feature_manager(features));
+
+      await actions.assign_work_room(feature, entity);
+
+      const dynamic_entry = entity.entity.channels.list.find(c => c.id === "dynamic-wr-4");
+      expect(dynamic_entry).toBeDefined();
+      expect(dynamic_entry?.dynamic).toBe(true);
+      expect(dynamic_entry?.type).toBe("work_room");
+      expect(dynamic_entry?.assigned_feature).toBe("alpha-42");
+    });
+
+    it("does not assign a room to features still in done phase", async () => {
+      const feature = make_feature({ id: "alpha-42" });
+      // The done feature should not count as occupying wr-1
+      const done_feature = make_feature({
+        id: "alpha-10",
+        discordWorkRoom: "wr-1",
+        phase: "done",
+      });
+      const entity = make_entity_config(make_static_work_rooms());
+      // @ts-expect-error — mock feature manager
+      actions.set_feature_manager(make_mock_feature_manager([done_feature]));
+
+      const room_id = await actions.assign_work_room(feature, entity);
+
+      expect(room_id).toBe("wr-1");
+    });
+
+    it("sets channel topic on assignment", async () => {
+      const feature = make_feature();
+      const entity = make_entity_config(make_static_work_rooms());
+      // @ts-expect-error — mock feature manager
+      actions.set_feature_manager(make_mock_feature_manager([]));
+
+      await actions.assign_work_room(feature, entity);
+
+      expect(discord.set_channel_topic).toHaveBeenCalledWith(
+        "wr-1",
+        "🔵 alpha-42 — #42 — Building",
+      );
+    });
+
+    it("rebuilds channel map after assignment", async () => {
+      const feature = make_feature();
+      const entity = make_entity_config(make_static_work_rooms());
+      // @ts-expect-error — mock feature manager
+      actions.set_feature_manager(make_mock_feature_manager([]));
+
+      await actions.assign_work_room(feature, entity);
+
+      expect(discord.build_channel_map).toHaveBeenCalled();
+    });
+
+    it("returns null when no discord bot is available for dynamic room creation", async () => {
+      const feature = make_feature({ id: "alpha-42" });
+      const features = [
+        make_feature({ id: "alpha-10", discordWorkRoom: "wr-1", phase: "build" }),
+        make_feature({ id: "alpha-11", discordWorkRoom: "wr-2", phase: "build" }),
+        make_feature({ id: "alpha-12", discordWorkRoom: "wr-3", phase: "build" }),
+      ];
+      const entity = make_entity_config(make_static_work_rooms());
+      // @ts-expect-error — mock feature manager
+      actions.set_feature_manager(make_mock_feature_manager(features));
+      actions.set_discord_bot(null);
+
+      const room_id = await actions.assign_work_room(feature, entity);
+
+      expect(room_id).toBeNull();
+    });
+  });
+
+  describe("release_work_room", () => {
+    it("resets static room topic to Available", async () => {
+      const feature = make_feature({ discordWorkRoom: "wr-1" });
+      const channels = make_static_work_rooms();
+      channels[1]!.assigned_feature = "alpha-42";
+      const entity = make_entity_config(channels);
+
+      await actions.release_work_room(feature, entity);
+
+      expect(discord.set_channel_topic).toHaveBeenCalledWith("wr-1", "🟢 Available");
+    });
+
+    it("clears assigned_feature on static room", async () => {
+      const feature = make_feature({ discordWorkRoom: "wr-1" });
+      const channels = make_static_work_rooms();
+      channels[1]!.assigned_feature = "alpha-42";
+      const entity = make_entity_config(channels);
+
+      await actions.release_work_room(feature, entity);
+
+      const wr1 = entity.entity.channels.list.find(c => c.id === "wr-1");
+      expect(wr1?.assigned_feature).toBeNull();
+    });
+
+    it("sends farewell message in static room", async () => {
+      const feature = make_feature({ discordWorkRoom: "wr-1" });
+      const entity = make_entity_config(make_static_work_rooms());
+
+      await actions.release_work_room(feature, entity);
+
+      expect(discord.send).toHaveBeenCalledWith(
+        "wr-1",
+        "Feature alpha-42 complete. This work room is now available.",
+      );
+    });
+
+    it("deletes dynamic room", async () => {
+      const feature = make_feature({ discordWorkRoom: "dynamic-wr-4" });
+      const channels = make_static_work_rooms();
+      channels.push({
+        type: "work_room",
+        id: "dynamic-wr-4",
+        purpose: "Dynamic workspace",
+        assigned_feature: "alpha-42",
+        dynamic: true,
+      });
+      const entity = make_entity_config(channels);
+
+      await actions.release_work_room(feature, entity);
+
+      expect(discord.delete_channel).toHaveBeenCalledWith("dynamic-wr-4");
+    });
+
+    it("removes dynamic room from entity config", async () => {
+      const feature = make_feature({ discordWorkRoom: "dynamic-wr-4" });
+      const channels = make_static_work_rooms();
+      channels.push({
+        type: "work_room",
+        id: "dynamic-wr-4",
+        purpose: "Dynamic workspace",
+        assigned_feature: "alpha-42",
+        dynamic: true,
+      });
+      const entity = make_entity_config(channels);
+
+      await actions.release_work_room(feature, entity);
+
+      const remaining = entity.entity.channels.list.find(c => c.id === "dynamic-wr-4");
+      expect(remaining).toBeUndefined();
+    });
+
+    it("sends farewell message before deleting dynamic room", async () => {
+      const feature = make_feature({ discordWorkRoom: "dynamic-wr-4" });
+      const channels = make_static_work_rooms();
+      channels.push({
+        type: "work_room",
+        id: "dynamic-wr-4",
+        dynamic: true,
+        assigned_feature: "alpha-42",
+      });
+      const entity = make_entity_config(channels);
+
+      await actions.release_work_room(feature, entity);
+
+      // send should be called before delete_channel
+      const send_order = discord.send.mock.invocationCallOrder[0];
+      const delete_order = discord.delete_channel.mock.invocationCallOrder[0];
+      expect(send_order).toBeLessThan(delete_order!);
+    });
+
+    it("rebuilds channel map after release", async () => {
+      const feature = make_feature({ discordWorkRoom: "wr-1" });
+      const entity = make_entity_config(make_static_work_rooms());
+
+      await actions.release_work_room(feature, entity);
+
+      expect(discord.build_channel_map).toHaveBeenCalled();
+    });
+
+    it("is a no-op when feature has no work room", async () => {
+      const feature = make_feature({ discordWorkRoom: null });
+      const entity = make_entity_config(make_static_work_rooms());
+
+      await actions.release_work_room(feature, entity);
+
+      expect(discord.send).not.toHaveBeenCalled();
+      expect(discord.set_channel_topic).not.toHaveBeenCalled();
+      expect(discord.delete_channel).not.toHaveBeenCalled();
+    });
+
+    it("does not keep static room in list after release", async () => {
+      const feature = make_feature({ discordWorkRoom: "wr-2" });
+      const entity = make_entity_config(make_static_work_rooms());
+
+      await actions.release_work_room(feature, entity);
+
+      // Static room should still be in the list
+      const wr2 = entity.entity.channels.list.find(c => c.id === "wr-2");
+      expect(wr2).toBeDefined();
+      expect(wr2?.type).toBe("work_room");
+    });
+  });
+});
+
+describe("Notification Routing", () => {
+  let discord: ReturnType<typeof make_mock_discord>;
+
+  beforeEach(() => {
+    discord = make_mock_discord();
+    // @ts-expect-error — mock does not implement full DiscordBot interface
+    actions.set_discord_bot(discord);
+  });
+
+  describe("notify_feature", () => {
+    it("routes to work room when assigned", async () => {
+      const feature = make_feature({
+        discordWorkRoom: "wr-1",
+        activeArchetype: "builder",
+      });
+
+      await actions.notify_feature(feature, "Build started");
+
+      expect(discord.send_as_agent).toHaveBeenCalledWith("wr-1", "Build started", "builder");
+    });
+
+    it("falls back to work_log when no work room assigned", async () => {
+      const feature = make_feature({ discordWorkRoom: null, activeArchetype: null });
+      const entity = make_entity_config(make_static_work_rooms());
+
+      await actions.notify_feature(feature, "Build started", entity);
+
+      expect(discord.send_to_entity).toHaveBeenCalledWith(
+        "alpha", "work_log", "Build started", "system",
+      );
+    });
+
+    it("also sends to alerts when also_alerts is true", async () => {
+      const feature = make_feature({ discordWorkRoom: "wr-1" });
+      const entity = make_entity_config(make_static_work_rooms());
+
+      await actions.notify_feature(feature, "Awaiting approval", entity, { also_alerts: true });
+
+      // Primary: work room
+      expect(discord.send_as_agent).toHaveBeenCalledWith("wr-1", "Awaiting approval", "builder");
+      // Secondary: alerts
+      expect(discord.send_to_entity).toHaveBeenCalledWith(
+        "alpha", "alerts", "Awaiting approval", "builder",
+      );
+    });
+
+    it("also sends to general when also_general is true", async () => {
+      const feature = make_feature({ discordWorkRoom: "wr-1" });
+      const entity = make_entity_config(make_static_work_rooms());
+
+      await actions.notify_feature(feature, "Shipped!", entity, { also_general: true });
+
+      // Primary: work room
+      expect(discord.send_as_agent).toHaveBeenCalledWith("wr-1", "Shipped!", "builder");
+      // Secondary: general
+      expect(discord.send_to_entity).toHaveBeenCalledWith(
+        "alpha", "general", "Shipped!", "builder",
+      );
+    });
+
+    it("sends to both alerts and general when both options are true", async () => {
+      const feature = make_feature({ discordWorkRoom: "wr-1" });
+      const entity = make_entity_config(make_static_work_rooms());
+
+      await actions.notify_feature(feature, "Urgent!", entity, {
+        also_alerts: true,
+        also_general: true,
+      });
+
+      expect(discord.send_as_agent).toHaveBeenCalledTimes(1);
+      expect(discord.send_to_entity).toHaveBeenCalledTimes(2);
+    });
+
+    it("uses 'system' archetype when feature has no active archetype", async () => {
+      const feature = make_feature({
+        discordWorkRoom: "wr-1",
+        activeArchetype: null,
+      });
+
+      await actions.notify_feature(feature, "Phase change");
+
+      expect(discord.send_as_agent).toHaveBeenCalledWith("wr-1", "Phase change", "system");
+    });
+
+    it("routes to specific channel ID, not first work_room", async () => {
+      // Verify it routes to wr-2, not wr-1 (which send_to_entity would pick)
+      const feature = make_feature({ discordWorkRoom: "wr-2" });
+
+      await actions.notify_feature(feature, "Test message");
+
+      expect(discord.send_as_agent).toHaveBeenCalledWith("wr-2", "Test message", "builder");
+      // Should NOT have called send_to_entity
+      expect(discord.send_to_entity).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("Channel Topic Updates", () => {
+  let discord: ReturnType<typeof make_mock_discord>;
+
+  beforeEach(() => {
+    discord = make_mock_discord();
+    // @ts-expect-error — mock does not implement full DiscordBot interface
+    actions.set_discord_bot(discord);
+  });
+
+  describe("update_work_room_topic", () => {
+    it("updates topic when work room is assigned", async () => {
+      const feature = make_feature({ discordWorkRoom: "wr-1" });
+
+      await actions.update_work_room_topic(feature, "🟣 alpha-42 — #42 — In Review");
+
+      expect(discord.set_channel_topic).toHaveBeenCalledWith(
+        "wr-1",
+        "🟣 alpha-42 — #42 — In Review",
+      );
+    });
+
+    it("is a no-op when no work room is assigned", async () => {
+      const feature = make_feature({ discordWorkRoom: null });
+
+      await actions.update_work_room_topic(feature, "some topic");
+
+      expect(discord.set_channel_topic).not.toHaveBeenCalled();
+    });
+
+    it("is a no-op when no discord bot is available", async () => {
+      actions.set_discord_bot(null);
+      const feature = make_feature({ discordWorkRoom: "wr-1" });
+
+      await actions.update_work_room_topic(feature, "some topic");
+
+      // No error thrown, function returns silently
+    });
+  });
+});
+
+describe("Schema — ChannelMapping", () => {
+  it("accepts dynamic: true", () => {
+    const entity = make_entity_config([
+      { type: "work_room", id: "wr-1", dynamic: true },
+    ]);
+    const wr = entity.entity.channels.list[0];
+    expect(wr?.dynamic).toBe(true);
+  });
+
+  it("accepts dynamic: false", () => {
+    const entity = make_entity_config([
+      { type: "work_room", id: "wr-1", dynamic: false },
+    ]);
+    const wr = entity.entity.channels.list[0];
+    expect(wr?.dynamic).toBe(false);
+  });
+
+  it("defaults to undefined when dynamic is omitted", () => {
+    const entity = make_entity_config([
+      { type: "work_room", id: "wr-1" },
+    ]);
+    const wr = entity.entity.channels.list[0];
+    expect(wr?.dynamic).toBeUndefined();
+  });
+});

--- a/packages/daemon/src/actions.ts
+++ b/packages/daemon/src/actions.ts
@@ -1,9 +1,10 @@
 import { execFile } from "node:child_process";
 import { rm } from "node:fs/promises";
 import { promisify } from "node:util";
-import type { FeatureState, LobsterFarmConfig, EntityConfig, ChannelType } from "@lobster-farm/shared";
-import { expand_home } from "@lobster-farm/shared";
+import type { FeatureState, EntityConfig, ChannelType, ArchetypeRole, ChannelMapping } from "@lobster-farm/shared";
+import { expand_home, entity_config_path, write_yaml } from "@lobster-farm/shared";
 import type { DiscordBot } from "./discord.js";
+import type { FeatureManager } from "./features.js";
 
 const exec = promisify(execFile);
 
@@ -155,8 +156,15 @@ export async function run_tests(
 /** Global Discord bot reference, set by the daemon on startup. */
 let _discord: DiscordBot | null = null;
 
+/** Global feature manager reference, set by the daemon on startup. */
+let _features: FeatureManager | null = null;
+
 export function set_discord_bot(bot: DiscordBot | null): void {
   _discord = bot;
+}
+
+export function set_feature_manager(fm: FeatureManager | null): void {
+  _features = fm;
 }
 
 /** Send a notification to an entity's Discord channel (or log if not connected). */
@@ -173,24 +181,162 @@ export async function notify(
       entity_config.entity.id,
       channel_type as ChannelType,
       message,
-      (archetype as import("@lobster-farm/shared").ArchetypeRole) ?? "system",
+      (archetype as ArchetypeRole) ?? "system",
     );
   }
 }
 
-/** Stub: assign a work room to a feature. */
-export async function assign_work_room(
+/** Send a feature-scoped notification. Routes to work room if assigned, work_log as fallback. */
+export async function notify_feature(
   feature: FeatureState,
-  _entity_config: EntityConfig,
-): Promise<string | null> {
-  console.log(`[actions:stub] Would assign work room for ${feature.id}`);
-  return null;
+  message: string,
+  entity_config?: EntityConfig,
+  options?: { also_alerts?: boolean; also_general?: boolean },
+): Promise<void> {
+  const archetype = (feature.activeArchetype ?? "system") as ArchetypeRole | "system";
+
+  // Primary: send to work room (by channel ID) or work_log fallback
+  if (feature.discordWorkRoom && _discord) {
+    await _discord.send_as_agent(feature.discordWorkRoom, message, archetype);
+    console.log(`[actions:notify] [work_room:${feature.discordWorkRoom}] ${message}`);
+  } else {
+    await notify("work_log", message, entity_config, archetype);
+  }
+
+  // Secondary channels
+  if (options?.also_alerts) {
+    await notify("alerts", message, entity_config, archetype);
+  }
+  if (options?.also_general) {
+    await notify("general", message, entity_config, archetype);
+  }
 }
 
-/** Stub: release a work room. */
+// ── Entity config persistence ──
+
+/** Persist an entity's config back to YAML. Used after modifying dynamic channels. */
+export async function persist_entity_config(
+  entity_config: EntityConfig,
+): Promise<void> {
+  // The config object contains the full entity config; write it back to its YAML path.
+  // entity_config_path needs the paths config — extract from the path convention.
+  const config_path = entity_config_path(undefined, entity_config.entity.id);
+  await write_yaml(config_path, entity_config);
+  console.log(`[actions] Persisted entity config for ${entity_config.entity.id}`);
+}
+
+// ── Work room management ──
+
+/** Assign a work room to a feature. Finds a free static room or creates a dynamic one. */
+export async function assign_work_room(
+  feature: FeatureState,
+  entity_config: EntityConfig,
+): Promise<string | null> {
+  const channels = entity_config.entity.channels;
+  const work_rooms = channels.list.filter((c: ChannelMapping) => c.type === "work_room");
+
+  // Find rooms not assigned to an active (non-done) feature
+  const active = _features?.get_features_by_entity(feature.entity)
+    .filter(f => f.phase !== "done" && f.id !== feature.id) ?? [];
+  const occupied = new Set(
+    active.map(f => f.discordWorkRoom).filter((id): id is string => Boolean(id)),
+  );
+  const free_room = work_rooms.find((r: ChannelMapping) => !occupied.has(r.id));
+
+  let channel_id: string | null = null;
+
+  if (free_room) {
+    channel_id = free_room.id;
+    free_room.assigned_feature = feature.id;
+  } else {
+    // Overflow: create a dynamic room
+    const room_number = work_rooms.length + 1;
+    const name = `work-room-${String(room_number)}`;
+    const category_id = channels.category_id;
+
+    if (!_discord || !category_id) {
+      console.log("[actions] Cannot create dynamic room — no discord or category_id");
+      return null;
+    }
+
+    channel_id = await _discord.create_channel(
+      category_id, name, `Overflow for ${feature.id}`,
+    );
+    if (!channel_id) return null;
+
+    // Register in entity config
+    channels.list.push({
+      type: "work_room",
+      id: channel_id,
+      purpose: `Dynamic workspace for ${feature.id}`,
+      assigned_feature: feature.id,
+      dynamic: true,
+    });
+
+    // Persist entity config change to YAML
+    await persist_entity_config(entity_config);
+  }
+
+  // Set channel topic
+  if (_discord && channel_id) {
+    await _discord.set_channel_topic(
+      channel_id,
+      `🔵 ${feature.id} — #${String(feature.githubIssue)} — Building`,
+    );
+  }
+
+  // Rebuild channel map so Discord bot routes messages correctly
+  _discord?.build_channel_map();
+
+  console.log(`[actions] Assigned work room ${channel_id} to ${feature.id}`);
+  return channel_id;
+}
+
+/** Release a work room from a feature. Resets static rooms, deletes dynamic ones. */
 export async function release_work_room(
   feature: FeatureState,
-  _entity_config: EntityConfig,
+  entity_config: EntityConfig,
 ): Promise<void> {
-  console.log(`[actions:stub] Would release work room for ${feature.id}`);
+  if (!feature.discordWorkRoom) return;
+
+  const channel_id = feature.discordWorkRoom;
+  const channels = entity_config.entity.channels;
+  const entry = channels.list.find((c: ChannelMapping) => c.id === channel_id);
+
+  if (entry?.dynamic) {
+    // Dynamic room — farewell message, then delete
+    if (_discord) {
+      await _discord.send(
+        channel_id,
+        `Feature ${feature.id} complete. Cleaning up this work room.`,
+      );
+      await _discord.delete_channel(channel_id);
+    }
+    channels.list = channels.list.filter((c: ChannelMapping) => c.id !== channel_id);
+    await persist_entity_config(entity_config);
+  } else if (entry) {
+    // Static room — reset topic and clear assignment
+    entry.assigned_feature = null;
+    if (_discord) {
+      await _discord.set_channel_topic(channel_id, "🟢 Available");
+      await _discord.send(
+        channel_id,
+        `Feature ${feature.id} complete. This work room is now available.`,
+      );
+    }
+  }
+
+  // Rebuild channel map
+  _discord?.build_channel_map();
+
+  console.log(`[actions] Released work room ${channel_id} from ${feature.id}`);
+}
+
+/** Update the topic of a feature's work room. */
+export async function update_work_room_topic(
+  feature: FeatureState,
+  topic: string,
+): Promise<void> {
+  if (!feature.discordWorkRoom || !_discord) return;
+  await _discord.set_channel_topic(feature.discordWorkRoom, topic);
 }

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -174,6 +174,57 @@ export class DiscordBot extends EventEmitter {
     }
   }
 
+  // ── Channel management ──
+
+  /** Set a channel's topic. No-op if disconnected or channel not found. */
+  async set_channel_topic(channel_id: string, topic: string): Promise<void> {
+    if (!this.connected) return;
+    try {
+      const channel = await this.client.channels.fetch(channel_id);
+      if (channel?.isTextBased() && !channel.isDMBased()) {
+        await (channel as TextChannel).setTopic(topic);
+      }
+    } catch (err) {
+      console.error(`[discord] Failed to set topic for ${channel_id}: ${String(err)}`);
+    }
+  }
+
+  /** Create a text channel under a category. Returns the channel ID, or null on failure. */
+  async create_channel(
+    category_id: string,
+    name: string,
+    reason?: string,
+  ): Promise<string | null> {
+    const guild = await this.get_guild();
+    if (!guild) return null;
+    try {
+      const channel = await guild.channels.create({
+        name,
+        type: DiscordChannelType.GuildText,
+        parent: category_id,
+        reason: reason ?? "LobsterFarm dynamic channel",
+      });
+      console.log(`[discord] Created #${name} (${channel.id})`);
+      return channel.id;
+    } catch (err) {
+      console.error(`[discord] Failed to create channel "${name}": ${String(err)}`);
+      return null;
+    }
+  }
+
+  /** Delete a channel by ID. No-op if disconnected or DM channel. */
+  async delete_channel(channel_id: string): Promise<void> {
+    if (!this.connected) return;
+    try {
+      const channel = await this.client.channels.fetch(channel_id);
+      if (!channel || channel.isDMBased()) return;
+      await channel.delete("LobsterFarm work room cleanup");
+      console.log(`[discord] Deleted channel ${channel_id}`);
+    } catch (err) {
+      console.error(`[discord] Failed to delete channel ${channel_id}: ${String(err)}`);
+    }
+  }
+
   // ── Agent identity ──
 
   private resolve_agent_identity(archetype: ArchetypeRole | "system"): { name: string; avatar_url: string | undefined } {
@@ -236,7 +287,7 @@ export class DiscordBot extends EventEmitter {
   // ── Server & Entity Scaffolding ──
 
   /** Get the guild (Discord server) from config. */
-  private async get_guild(): Promise<Guild | null> {
+  protected async get_guild(): Promise<Guild | null> {
     const server_id = this.config.discord?.server_id;
     if (!server_id) {
       console.log("[discord] No server_id in config — cannot scaffold");

--- a/packages/daemon/src/features.ts
+++ b/packages/daemon/src/features.ts
@@ -340,11 +340,11 @@ export class FeatureManager extends EventEmitter {
     } else {
       // Notify that the phase is done and awaiting approval
       const entity = this.registry.get(feature.entity);
-      await actions.notify(
-        "alerts",
+      await actions.notify_feature(
+        feature,
         `Feature ${feature_id}: ${feature.phase} phase complete. Awaiting approval.`,
         entity,
-        feature.activeArchetype ?? undefined,
+        { also_alerts: true },
       );
     }
   }
@@ -463,6 +463,10 @@ export class FeatureManager extends EventEmitter {
         // Create worktree
         const worktree_path = await actions.create_worktree(feature, entity);
         feature.worktreePath = worktree_path;
+
+        // Assign work room
+        const room_id = await actions.assign_work_room(feature, entity);
+        feature.discordWorkRoom = room_id;
         break;
       }
       case "review": {
@@ -479,11 +483,23 @@ export class FeatureManager extends EventEmitter {
         break;
     }
 
-    await actions.notify(
-      "work_log",
+    // Update work room topic on phase change
+    if (feature.discordWorkRoom) {
+      const topic_map: Partial<Record<Phase, string>> = {
+        build: `🔵 ${feature.id} — #${String(feature.githubIssue)} — Building`,
+        review: `🟣 ${feature.id} — #${String(feature.githubIssue)} — In Review`,
+        ship: `✅ ${feature.id} — #${String(feature.githubIssue)} — Shipping`,
+      };
+      const topic = topic_map[phase];
+      if (topic) {
+        await actions.update_work_room_topic(feature, topic);
+      }
+    }
+
+    await actions.notify_feature(
+      feature,
       `${feature.id}: entered ${phase} phase`,
       entity,
-      "system",
     );
   }
 
@@ -507,16 +523,18 @@ export class FeatureManager extends EventEmitter {
     await actions.cleanup_worktree(feature, entity);
     feature.worktreePath = null;
 
-    // Release work room
-    await actions.release_work_room(feature, entity);
-    feature.discordWorkRoom = null;
-
-    await actions.notify(
-      "general",
+    // Send "shipped" notification BEFORE releasing work room
+    // so the message arrives in the work room before it's cleaned up / reset.
+    await actions.notify_feature(
+      feature,
       `Feature #${String(feature.githubIssue)} shipped and merged to main: ${feature.title}`,
       entity,
-      "system",
+      { also_general: true },
     );
+
+    // Release work room (after notification so the room still exists)
+    await actions.release_work_room(feature, entity);
+    feature.discordWorkRoom = null;
   }
 }
 

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -5,7 +5,7 @@ import { ClaudeSessionManager } from "./session.js";
 import { TaskQueue } from "./queue.js";
 import { FeatureManager } from "./features.js";
 import { DiscordBot, resolve_bot_token } from "./discord.js";
-import { set_discord_bot } from "./actions.js";
+import { set_discord_bot, set_feature_manager } from "./actions.js";
 import { start_server } from "./server.js";
 import { write_pid, remove_pid } from "./pid.js";
 import { CommanderProcess } from "./commander-process.js";
@@ -32,6 +32,7 @@ async function main(): Promise<void> {
   const queue = new TaskQueue(session_manager, config);
   const feature_manager = new FeatureManager(registry, queue, config);
   await feature_manager.load_persisted();
+  set_feature_manager(feature_manager);
 
   // Wire up session events to feature manager
   session_manager.on("session:started", (session) => {

--- a/packages/shared/src/schemas/entity.ts
+++ b/packages/shared/src/schemas/entity.ts
@@ -10,6 +10,7 @@ export const ChannelMappingSchema = z.object({
   id: z.string(),
   purpose: z.string().optional(),
   assigned_feature: z.string().nullable().optional(),
+  dynamic: z.boolean().optional(),
 });
 export type ChannelMapping = z.infer<typeof ChannelMappingSchema>;
 


### PR DESCRIPTION
## Summary
- **Work room assignment**: Features get assigned a free static room on `build` phase entry. When all 3 rooms are occupied, a dynamic overflow room is created (tagged `dynamic: true`). Dynamic rooms are deleted on feature completion; static rooms get their topic reset to "🟢 Available".
- **Notification routing**: New `notify_feature()` routes to the assigned work room by channel ID (not channel type), with `work_log` fallback and optional `also_alerts`/`also_general` secondary routing. All 3 existing hardcoded `notify()` calls migrated.
- **Channel topics**: Update on each phase transition (🔵 Building, 🟣 In Review, ✅ Shipping, 🟢 Available).
- **Discord bot**: Adds `set_channel_topic()`, `create_channel()`, `delete_channel()` public methods.
- **Entity config persistence**: Dynamic channel mutations written back to YAML via `persist_entity_config()`.
- **Ship notification reorder**: "Shipped" message now fires BEFORE `release_work_room()` so it arrives in the work room before cleanup.

### Files changed
| File | What changed |
|---|---|
| `packages/shared/src/schemas/entity.ts` | Added `dynamic: boolean` to `ChannelMappingSchema` |
| `packages/daemon/src/discord.ts` | Added 3 public channel management methods |
| `packages/daemon/src/actions.ts` | Replaced stubs with full assign/release/notify_feature/topic/persist |
| `packages/daemon/src/features.ts` | Wired assign into build, migrated 3 notify calls, reordered ship, added topic updates |
| `packages/daemon/src/index.ts` | Called `set_feature_manager()` on startup |
| `packages/daemon/src/__tests__/work-rooms.test.ts` | 31 new tests covering all acceptance criteria |

## Test plan
- [x] 31 tests pass covering:
  - Work room assignment (free room selection, occupied room skipping, dynamic creation, dynamic tagging)
  - Work room release (static topic reset, dynamic deletion, farewell message ordering)
  - Notification routing (work room primary, work_log fallback, alerts/general secondary, channel ID routing)
  - Channel topic updates (set/no-op behavior)
  - Schema validation (dynamic field accepted/omitted)
- [x] All 93 daemon tests pass (62 existing + 31 new)
- [x] All 54 shared tests pass

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)