### PR TITLE
fix: pool bot crash and protect-branch worktree bug

### DIFF
--- a/config/hooks/protect-branch.sh
+++ b/config/hooks/protect-branch.sh
@@ -2,42 +2,40 @@
 # protect-branch.sh — PreToolUse hook that prevents Edit/Write on main/master.
 #
 # Reads hook event JSON from stdin, extracts the file path, checks if the file
-# is inside the current git repo, and blocks the operation if the current branch
-# is main or master. Fails open (exit 0) if jq is missing, not in a git repo,
-# or input is malformed — a broken hook must never block all Edit/Write operations.
-#
-# Install: cp config/hooks/protect-branch.sh ~/.claude/hooks/
-# Register in ~/.claude/settings.json under hooks.PreToolUse with matcher "Edit|Write"
+# is inside a git repo, and blocks the operation if that repo's current branch
+# is main or master. Uses the file's directory for git checks (not cwd) so
+# worktrees are handled correctly.
 
 set -euo pipefail
 
-# --- Dependency check ---
 if ! command -v jq &>/dev/null; then
-  echo "WARNING: jq not found — branch protection disabled" >&2
   exit 0
 fi
 
-# --- Read and parse stdin ---
 INPUT="$(cat)" || exit 0
 if [ -z "$INPUT" ]; then
   exit 0
 fi
 
-FILE_PATH="$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)" || exit 0
+FILE_PATH="$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.content // empty' 2>/dev/null)" || exit 0
 if [ -z "$FILE_PATH" ]; then
   exit 0
 fi
 
-# --- Check if file is inside a git repo ---
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+# Use the file's directory for git checks (handles worktrees correctly)
+FILE_DIR="$(dirname "$FILE_PATH")"
+if [ ! -d "$FILE_DIR" ]; then
+  exit 0
+fi
+
+REPO_ROOT="$(git -C "$FILE_DIR" rev-parse --show-toplevel 2>/dev/null)" || exit 0
 
 case "$FILE_PATH" in
   "$REPO_ROOT"/*) ;;
   *) exit 0 ;;
 esac
 
-# --- Check current branch ---
-BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)" || exit 0
+BRANCH="$(git -C "$FILE_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null)" || exit 0
 
 if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
   cat >&2 <<MSG
@@ -47,5 +45,4 @@ MSG
   exit 2
 fi
 
-# --- Not on a protected branch ---
 exit 0

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -6,7 +6,6 @@ import type { ArchetypeRole, LobsterFarmConfig } from "@lobster-farm/shared";
 import { lobsterfarm_dir, entity_dir } from "@lobster-farm/shared";
 import type { ChannelType } from "@lobster-farm/shared";
 import type { EntityRegistry } from "./registry.js";
-import { build_entity_context } from "./session.js";
 
 // ── Types ──
 
@@ -456,15 +455,9 @@ export class BotPool {
       claude_args.push("--resume", resume_session_id);
     }
 
-    // Inject entity context — parity with headless sessions in session.ts
-    try {
-      const feature_id = ""; // Pool bots may not have a feature; empty is safe
-      const entity_context = await build_entity_context(entity_id, feature_id, this.config);
-      claude_args.push("--append-system-prompt", entity_context);
-    } catch (err) {
-      console.log(`[pool] Failed to build entity context for pool-${String(bot.id)}: ${String(err)}`);
-      // Fail open — bot starts without context rather than failing entirely
-    }
+    // Note: entity context is NOT injected via --append-system-prompt for pool bots.
+    // Multi-line context strings break tmux command parsing. Pool bots load context
+    // naturally via CLAUDE.md, skills, and entity memory in the working directory.
 
     const display_name = resolve_agent_display_name(archetype, this.config);
     const git_env = `GIT_AUTHOR_NAME="${display_name} (LobsterFarm)" GIT_AUTHOR_EMAIL="${agent_name}@lobsterfarm.dev" GIT_COMMITTER_NAME="${display_name} (LobsterFarm)" GIT_COMMITTER_EMAIL="${agent_name}@lobsterfarm.dev"`;


### PR DESCRIPTION
## Summary
- Pool bots crashed on startup because multi-line `--append-system-prompt` broke tmux command parsing
- protect-branch.sh hook blocked edits in worktrees by checking main repo branch instead of worktree branch

## Test plan
- [x] Pool bots start successfully without --append-system-prompt
- [x] 121 tests passing
- [x] protect-branch.sh allows edits in worktrees, blocks on main

Closes #13