### PR TITLE
fix: persist PR review state to stop review loop (#17)

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -103,7 +103,7 @@ async function main(): Promise<void> {
     discord_connected ? discord : null,
     feature_manager,
   );
-  pr_cron.start();
+  await pr_cron.start();
 
   // Write PID file
   await write_pid(config);

--- a/packages/daemon/src/persistence.ts
+++ b/packages/daemon/src/persistence.ts
@@ -5,6 +5,7 @@ import { lobsterfarm_dir } from "@lobster-farm/shared";
 
 const STATE_DIR = "state";
 const FEATURES_FILE = "features.json";
+const PR_REVIEWS_FILE = "pr-reviews.json";
 
 function state_dir(config: LobsterFarmConfig): string {
   return join(lobsterfarm_dir(config.paths), STATE_DIR);
@@ -12,6 +13,10 @@ function state_dir(config: LobsterFarmConfig): string {
 
 function features_path(config: LobsterFarmConfig): string {
   return join(state_dir(config), FEATURES_FILE);
+}
+
+function pr_reviews_path(config: LobsterFarmConfig): string {
+  return join(state_dir(config), PR_REVIEWS_FILE);
 }
 
 /** Save all features to disk. */
@@ -36,5 +41,42 @@ export async function load_features(
     return data as FeatureState[];
   } catch {
     return [];
+  }
+}
+
+// ── PR Review State ──
+
+export interface ProcessedPR {
+  entity_id: string;
+  pr_number: number;
+  reviewed_at: string;       // ISO timestamp
+  outcome: "approved" | "changes_requested" | "pending";
+}
+
+/** Keyed by "entity_id:pr_number" */
+export type PRReviewState = Record<string, ProcessedPR>;
+
+/** Save PR review state to disk. */
+export async function save_pr_reviews(
+  state: PRReviewState,
+  config: LobsterFarmConfig,
+): Promise<void> {
+  const path = pr_reviews_path(config);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(state, null, 2), "utf-8");
+}
+
+/** Load PR review state from disk. Returns empty object if file doesn't exist. */
+export async function load_pr_reviews(
+  config: LobsterFarmConfig,
+): Promise<PRReviewState> {
+  const path = pr_reviews_path(config);
+  try {
+    const content = await readFile(path, "utf-8");
+    const data: unknown = JSON.parse(content);
+    if (typeof data !== "object" || data === null || Array.isArray(data)) return {};
+    return data as PRReviewState;
+  } catch {
+    return {};
   }
 }

--- a/packages/daemon/src/pr-cron.ts
+++ b/packages/daemon/src/pr-cron.ts
@@ -7,6 +7,8 @@ import type { ClaudeSessionManager } from "./session.js";
 import type { DiscordBot } from "./discord.js";
 import type { FeatureManager } from "./features.js";
 import { detect_review_outcome } from "./actions.js";
+import { load_pr_reviews, save_pr_reviews } from "./persistence.js";
+import type { PRReviewState } from "./persistence.js";
 
 const exec = promisify(execFile);
 
@@ -20,7 +22,7 @@ interface OpenPR {
   url: string;
 }
 
-interface PRReviewState {
+interface ActiveReview {
   pr_number: number;
   entity_id: string;
   repo_url: string;
@@ -34,7 +36,8 @@ const DEFAULT_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 
 export class PRReviewCron {
   private timer: ReturnType<typeof setInterval> | null = null;
-  private active_reviews = new Map<string, PRReviewState>(); // key: "entity:pr#"
+  private active_reviews = new Map<string, ActiveReview>(); // key: "entity:pr#"
+  private processed: PRReviewState = {}; // persisted to disk — tracks completed reviews
   private running = false;
 
   constructor(
@@ -45,9 +48,16 @@ export class PRReviewCron {
     private feature_manager: FeatureManager | null = null,
   ) {}
 
-  /** Start the polling cron. */
-  start(interval_ms: number = DEFAULT_INTERVAL_MS): void {
+  /** Start the polling cron. Loads persisted review state before first poll. */
+  async start(interval_ms: number = DEFAULT_INTERVAL_MS): Promise<void> {
     if (this.timer) return;
+
+    // Load persisted review state so we don't re-review after restart
+    this.processed = await load_pr_reviews(this.config);
+    const count = Object.keys(this.processed).length;
+    if (count > 0) {
+      console.log(`[pr-cron] Loaded ${String(count)} processed PR reviews from disk`);
+    }
 
     console.log(`[pr-cron] Starting PR review cron (every ${String(interval_ms / 1000)}s)`);
 
@@ -66,7 +76,7 @@ export class PRReviewCron {
   }
 
   /** Get active review states. */
-  get_active_reviews(): PRReviewState[] {
+  get_active_reviews(): ActiveReview[] {
     return [...this.active_reviews.values()];
   }
 
@@ -120,8 +130,32 @@ export class PRReviewCron {
 
     if (prs.length === 0) return;
 
+    // Clean stale entries: remove processed PRs that are no longer open
+    const open_keys = new Set(prs.map(pr => `${entity_id}:${String(pr.number)}`));
+    let stale_cleaned = false;
+    for (const key of Object.keys(this.processed)) {
+      if (key.startsWith(`${entity_id}:`) && !open_keys.has(key)) {
+        delete this.processed[key];
+        stale_cleaned = true;
+      }
+    }
+    if (stale_cleaned) {
+      await save_pr_reviews(this.processed, this.config);
+    }
+
     for (const pr of prs) {
       const key = `${entity_id}:${String(pr.number)}`;
+
+      // Skip if already processed — unless PR was updated since our review
+      const prior = this.processed[key];
+      if (prior && new Date(pr.updatedAt) <= new Date(prior.reviewed_at)) {
+        continue;
+      }
+      if (prior) {
+        // PR updated after our review — allow re-review
+        console.log(`[pr-cron] PR #${String(pr.number)} updated since last review, allowing re-review`);
+        delete this.processed[key];
+      }
 
       // Skip if already being reviewed
       if (this.active_reviews.has(key)) {
@@ -142,13 +176,13 @@ export class PRReviewCron {
     }
   }
 
-  /** Check if a PR already has a review. */
+  /** Check if a PR already has a review (formal reviews OR comments). */
   private async pr_has_review(repo_path: string, pr_number: number): Promise<boolean> {
     try {
       const { stdout } = await exec("gh", [
         "pr", "view", String(pr_number),
-        "--json", "reviews",
-        "--jq", ".reviews | length",
+        "--json", "reviews,comments",
+        "--jq", "(.reviews | length) + (.comments | length)",
       ], { cwd: repo_path, timeout: 15_000 });
 
       return parseInt(stdout.trim(), 10) > 0;
@@ -212,8 +246,8 @@ export class PRReviewCron {
         this.active_reviews.delete(key);
         console.log(`[pr-cron] Review completed for PR #${String(pr.number)} in ${entity_id}`);
 
-        // Detect review outcome and handle external PRs
-        void this.handle_review_completion(entity_id, repo_path, pr);
+        // Persist completion so we don't re-review after restart
+        void this.persist_review_completion(entity_id, pr, repo_path);
       };
 
       const on_fail = (session_id: string, error: string) => {
@@ -233,13 +267,36 @@ export class PRReviewCron {
     }
   }
 
+  /** Persist review completion to disk, then hand off to outcome routing. */
+  private async persist_review_completion(
+    entity_id: string,
+    pr: OpenPR,
+    repo_path: string,
+  ): Promise<void> {
+    const key = `${entity_id}:${String(pr.number)}`;
+    const outcome = await detect_review_outcome(pr.number, repo_path);
+
+    this.processed[key] = {
+      entity_id,
+      pr_number: pr.number,
+      reviewed_at: new Date().toISOString(),
+      outcome,
+    };
+    await save_pr_reviews(this.processed, this.config);
+    console.log(`[pr-cron] Persisted review for PR #${String(pr.number)} (${outcome})`);
+
+    // Route the outcome (alerts, fix spawning, etc.)
+    await this.handle_review_completion(entity_id, repo_path, pr, outcome);
+  }
+
   /** After a reviewer session completes, detect the outcome and route accordingly. */
   private async handle_review_completion(
     entity_id: string,
     repo_path: string,
     pr: OpenPR,
+    review_outcome?: "approved" | "changes_requested" | "pending",
   ): Promise<void> {
-    const review_state = await detect_review_outcome(pr.number, repo_path);
+    const review_state = review_outcome ?? await detect_review_outcome(pr.number, repo_path);
     const linked_feature = this.feature_manager?.find_by_pr(pr.number) ?? null;
 
     if (linked_feature) {


### PR DESCRIPTION
## Summary

- **Bug 1 fix:** `pr_has_review()` now checks both `.reviews` and `.comments` via jq, so comment-based reviews (posted when reviewer can't formally review own PRs) are correctly detected
- **Bug 2 fix:** Completed reviews are persisted to `~/.lobsterfarm/state/pr-reviews.json` and loaded on daemon startup, surviving both cron cycles and daemon restarts
- **Stale cleanup:** Entries for closed/merged PRs are automatically removed each poll cycle; PRs with new commits after review are allowed to be re-reviewed

## Test plan

- [ ] With fixes applied, cron does NOT re-spawn reviewer for already-reviewed PR
- [ ] Daemon restart -> reviewed PR still skipped (persistence works)
- [ ] PR with new commits after review -> re-review triggered correctly
- [ ] PR merged -> entry cleaned from state file on next poll
- [ ] `pr_has_review()` returns true when PR has comments but no formal reviews
- [ ] `pr_has_review()` returns true when PR has formal reviews
- [ ] Multiple entities with open PRs -> independent tracking (keyed by entity_id:pr_number)

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)