### PR TITLE
feat: enforce max_queue_depth (Part 1 of #11)

### DIFF
--- a/packages/daemon/src/__tests__/queue-depth.test.ts
+++ b/packages/daemon/src/__tests__/queue-depth.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { writeFile, mkdir, rm, chmod } from "node:fs/promises";
+import { execSync } from "node:child_process";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { LobsterFarmConfigSchema, EntityConfigSchema } from "@lobster-farm/shared";
+import type { LobsterFarmConfig, EntityConfig } from "@lobster-farm/shared";
+import { ClaudeSessionManager } from "../session.js";
+import { TaskQueue, QueueFullError } from "../queue.js";
+import { EntityRegistry } from "../registry.js";
+import { FeatureManager } from "../features.js";
+
+function make_config(overrides?: Record<string, unknown>): LobsterFarmConfig {
+  return LobsterFarmConfigSchema.parse({
+    user: { name: "Test" },
+    ...overrides,
+  });
+}
+
+function make_entity_config(tmp: string): EntityConfig {
+  return EntityConfigSchema.parse({
+    entity: {
+      id: "alpha",
+      name: "Alpha Project",
+      repos: [{ name: "alpha", url: "git@github.com:test/alpha.git", path: tmp }],
+      memory: { path: `${tmp}/.memory` },
+      secrets: { vault_name: "entity-alpha" },
+    },
+  });
+}
+
+class MockRegistry extends EntityRegistry {
+  private mock_entity: EntityConfig;
+
+  constructor(config: LobsterFarmConfig, entity: EntityConfig) {
+    super(config);
+    this.mock_entity = entity;
+  }
+
+  override async load_all(): Promise<void> {}
+
+  override get(id: string): EntityConfig | undefined {
+    return id === this.mock_entity.entity.id ? this.mock_entity : undefined;
+  }
+
+  override get_all(): EntityConfig[] {
+    return [this.mock_entity];
+  }
+
+  override get_active(): EntityConfig[] {
+    return [this.mock_entity];
+  }
+
+  override count(): number {
+    return 1;
+  }
+}
+
+describe("Queue depth enforcement", () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = join(tmpdir(), `lf-qdepth-test-${Date.now()}`);
+    await mkdir(tmp, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true });
+    delete process.env["CLAUDE_BIN"];
+  });
+
+  describe("TaskQueue.submit() with max_queue_depth", () => {
+    it("throws QueueFullError when pending queue is at max_queue_depth", async () => {
+      const mock_claude = join(tmp, "mock-claude-slow");
+      await writeFile(mock_claude, "#!/bin/bash\nsleep 30\n", "utf-8");
+      await chmod(mock_claude, 0o755);
+      process.env["CLAUDE_BIN"] = mock_claude;
+
+      // max_active=1, max_queue_depth=2: first task goes active, next 2 can queue, 4th should fail
+      const config = make_config({
+        concurrency: { max_active_sessions: 1, max_queue_depth: 2 },
+      });
+      const mgr = new ClaudeSessionManager(config);
+      const queue = new TaskQueue(mgr, config);
+
+      const make_submission = (i: number) => ({
+        entity_id: "alpha",
+        feature_id: `alpha-${String(i)}`,
+        archetype: "builder" as const,
+        dna: [],
+        model: { model: "opus" as const, think: "high" as const },
+        prompt: `task ${String(i)}`,
+        interactive: false,
+        worktree_path: tmp,
+      });
+
+      // Task 1: goes active (slot available)
+      queue.submit(make_submission(1));
+      await new Promise((r) => setTimeout(r, 50));
+      expect(queue.get_stats().active).toBe(1);
+      expect(queue.get_stats().pending).toBe(0);
+
+      // Task 2: queues (1/2 pending slots)
+      queue.submit(make_submission(2));
+      expect(queue.get_stats().pending).toBe(1);
+
+      // Task 3: queues (2/2 pending slots)
+      queue.submit(make_submission(3));
+      expect(queue.get_stats().pending).toBe(2);
+
+      // Task 4: should throw QueueFullError
+      expect(() => queue.submit(make_submission(4))).toThrow(QueueFullError);
+      expect(() => queue.submit(make_submission(4))).toThrow(/max_queue_depth: 2/);
+
+      // Pending count unchanged
+      expect(queue.get_stats().pending).toBe(2);
+
+      await mgr.kill_all();
+    });
+
+    it("QueueFullError has correct properties", () => {
+      const err = new QueueFullError(5);
+      expect(err.name).toBe("QueueFullError");
+      expect(err.code).toBe("QUEUE_FULL");
+      expect(err.message).toContain("max_queue_depth: 5");
+      expect(err).toBeInstanceOf(Error);
+      expect(err).toBeInstanceOf(QueueFullError);
+    });
+
+    it("allows submissions again after queue drains", async () => {
+      const mock_claude = join(tmp, "mock-claude-fast");
+      await writeFile(mock_claude, "#!/bin/bash\nexit 0\n", "utf-8");
+      await chmod(mock_claude, 0o755);
+      process.env["CLAUDE_BIN"] = mock_claude;
+
+      const config = make_config({
+        concurrency: { max_active_sessions: 1, max_queue_depth: 1 },
+      });
+      const mgr = new ClaudeSessionManager(config);
+      const queue = new TaskQueue(mgr, config);
+
+      const make_submission = (i: number) => ({
+        entity_id: "alpha",
+        feature_id: `alpha-${String(i)}`,
+        archetype: "builder" as const,
+        dna: [],
+        model: { model: "opus" as const, think: "high" as const },
+        prompt: `task ${String(i)}`,
+        interactive: false,
+        worktree_path: tmp,
+      });
+
+      // Submit first task (goes active), second queues (1/1 pending), third should fail
+      queue.submit(make_submission(1));
+      await new Promise((r) => setTimeout(r, 50));
+
+      queue.submit(make_submission(2));
+      expect(() => queue.submit(make_submission(3))).toThrow(QueueFullError);
+
+      // Wait for tasks to complete
+      await new Promise((r) => setTimeout(r, 1000));
+
+      // Queue should be empty now — new submissions should work
+      expect(queue.get_stats().pending).toBe(0);
+      expect(() => queue.submit(make_submission(4))).not.toThrow();
+    });
+
+    it("pending_count getter reflects current queue length", async () => {
+      const mock_claude = join(tmp, "mock-claude-slow");
+      await writeFile(mock_claude, "#!/bin/bash\nsleep 30\n", "utf-8");
+      await chmod(mock_claude, 0o755);
+      process.env["CLAUDE_BIN"] = mock_claude;
+
+      const config = make_config({
+        concurrency: { max_active_sessions: 1, max_queue_depth: 10 },
+      });
+      const mgr = new ClaudeSessionManager(config);
+      const queue = new TaskQueue(mgr, config);
+
+      expect(queue.pending_count).toBe(0);
+
+      queue.submit({
+        entity_id: "alpha",
+        feature_id: "alpha-1",
+        archetype: "builder",
+        dna: [],
+        model: { model: "opus", think: "high" },
+        prompt: "task",
+        interactive: false,
+        worktree_path: tmp,
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+      // First task should go active
+      expect(queue.pending_count).toBe(0);
+
+      queue.submit({
+        entity_id: "alpha",
+        feature_id: "alpha-2",
+        archetype: "builder",
+        dna: [],
+        model: { model: "opus", think: "high" },
+        prompt: "task",
+        interactive: false,
+        worktree_path: tmp,
+      });
+
+      expect(queue.pending_count).toBe(1);
+
+      await mgr.kill_all();
+    });
+  });
+
+  describe("FeatureManager blocks on QueueFullError", () => {
+    it("feature creation succeeds but marks feature blocked when queue is full", async () => {
+      const mock_claude = join(tmp, "mock-claude-slow");
+      await writeFile(mock_claude, "#!/bin/bash\nsleep 30\n", "utf-8");
+      await chmod(mock_claude, 0o755);
+      process.env["CLAUDE_BIN"] = mock_claude;
+
+      // max_active=1, max_queue_depth=1: first feature goes active, second queues, third blocks
+      const config = make_config({
+        concurrency: { max_active_sessions: 1, max_queue_depth: 1 },
+      });
+
+      execSync("git init && git commit --allow-empty -m 'init'", { cwd: tmp, stdio: "ignore" });
+
+      const entity_config = make_entity_config(tmp);
+      const registry = new MockRegistry(config, entity_config);
+      const session_manager = new ClaudeSessionManager(config);
+      const queue = new TaskQueue(session_manager, config);
+      const fm = new FeatureManager(registry, queue, config);
+
+      // Feature 1: planner goes active
+      const f1 = await fm.create_feature({
+        entity_id: "alpha",
+        title: "Feature One",
+        github_issue: 1,
+      });
+      await new Promise((r) => setTimeout(r, 50));
+      expect(f1.blocked).toBe(false);
+
+      // Feature 2: queues (1/1 pending slot)
+      const f2 = await fm.create_feature({
+        entity_id: "alpha",
+        title: "Feature Two",
+        github_issue: 2,
+      });
+      expect(f2.blocked).toBe(false);
+
+      // Feature 3: queue is full — feature should be created but blocked
+      await fm.create_feature({
+        entity_id: "alpha",
+        title: "Feature Three",
+        github_issue: 3,
+      });
+
+      // Wait for the async spawn_phase_agent to complete and block
+      await new Promise((r) => setTimeout(r, 100));
+
+      const f3_state = fm.get_feature("alpha-3")!;
+      expect(f3_state).toBeTruthy();
+      expect(f3_state.phase).toBe("plan"); // Feature exists and is in plan phase
+      expect(f3_state.blocked).toBe(true);
+      expect(f3_state.blockedReason).toContain("Queue full");
+
+      await session_manager.kill_all();
+    }, 15_000);
+  });
+
+  describe("on_drain callback", () => {
+    it("calls the registered drain callback when a task completes", async () => {
+      const mock_claude = join(tmp, "mock-claude-fast");
+      await writeFile(mock_claude, "#!/bin/bash\nexit 0\n", "utf-8");
+      await chmod(mock_claude, 0o755);
+      process.env["CLAUDE_BIN"] = mock_claude;
+
+      const config = make_config({
+        concurrency: { max_active_sessions: 1, max_queue_depth: 10 },
+      });
+      const mgr = new ClaudeSessionManager(config);
+      const queue = new TaskQueue(mgr, config);
+
+      let drain_called = 0;
+      queue.on_drain(() => {
+        drain_called++;
+      });
+
+      queue.submit({
+        entity_id: "alpha",
+        feature_id: "alpha-1",
+        archetype: "builder",
+        dna: [],
+        model: { model: "opus", think: "high" },
+        prompt: "task",
+        interactive: false,
+        worktree_path: tmp,
+      });
+
+      // Wait for the fast mock to complete
+      await new Promise((r) => setTimeout(r, 500));
+
+      expect(drain_called).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/packages/daemon/src/features.ts
+++ b/packages/daemon/src/features.ts
@@ -9,6 +9,7 @@ import type {
 } from "@lobster-farm/shared";
 import { PHASE_TRANSITIONS } from "@lobster-farm/shared";
 import type { EntityRegistry } from "./registry.js";
+import { QueueFullError } from "./queue.js";
 import type { TaskQueue } from "./queue.js";
 import type { SessionResult } from "./session.js";
 import * as actions from "./actions.js";
@@ -127,6 +128,9 @@ export class FeatureManager extends EventEmitter {
     private config: LobsterFarmConfig,
   ) {
     super();
+
+    // When the queue drains (a task completes), retry features blocked due to queue-full
+    this.queue.on_drain(() => this.retry_queue_blocked());
   }
 
   /** Load persisted features from disk. Call on daemon startup. */
@@ -473,6 +477,34 @@ export class FeatureManager extends EventEmitter {
     return feature;
   }
 
+  /**
+   * Retry spawning agents for features that were blocked because the queue was full.
+   * Called by the queue's drain callback when a task completes and capacity frees up.
+   */
+  private retry_queue_blocked(): void {
+    const blocked = [...this.features.values()].filter(
+      (f) => f.blocked && f.blockedReason?.includes("Queue full"),
+    );
+
+    for (const feature of blocked) {
+      const phase_config = PHASE_CONFIG[feature.phase];
+      if (!phase_config.archetype || !phase_config.model || !phase_config.prompt_template) {
+        continue;
+      }
+
+      // Clear the block before retrying so the feature isn't stuck if spawn succeeds
+      feature.blocked = false;
+      feature.blockedReason = null;
+      feature.updatedAt = new Date().toISOString();
+
+      console.log(`[features] Retrying spawn for queue-blocked feature ${feature.id}`);
+
+      // spawn_phase_agent will re-block if the queue is still full
+      void this.spawn_phase_agent(feature, phase_config);
+      void this.persist();
+    }
+  }
+
   // ── Queries ──
 
   get_feature(id: string): FeatureState | undefined {
@@ -533,18 +565,35 @@ export class FeatureManager extends EventEmitter {
     const is_builder_bounce = phase_config.archetype === "builder" && Boolean(feature.lastBuilderSessionId);
     const resume_id = is_builder_bounce ? (feature.lastBuilderSessionId ?? undefined) : undefined;
 
-    const task_id = this.queue.submit({
-      entity_id: feature.entity,
-      feature_id: feature.id,
-      archetype: phase_config.archetype,
-      dna: phase_config.dna,
-      model: phase_config.model,
-      prompt,
-      interactive: false,
-      priority: feature.priority,
-      worktree_path,
-      resume_session_id: resume_id,
-    });
+    let task_id: string;
+    try {
+      task_id = this.queue.submit({
+        entity_id: feature.entity,
+        feature_id: feature.id,
+        archetype: phase_config.archetype,
+        dna: phase_config.dna,
+        model: phase_config.model,
+        prompt,
+        interactive: false,
+        priority: feature.priority,
+        worktree_path,
+        resume_session_id: resume_id,
+      });
+    } catch (err) {
+      if (err instanceof QueueFullError) {
+        // Feature is created and persisted — only the agent spawn is deferred.
+        // It will auto-retry when capacity frees up via retry_queue_blocked().
+        feature.blocked = true;
+        feature.blockedReason = "Queue full — will retry when capacity frees up";
+        feature.updatedAt = new Date().toISOString();
+        void this.persist();
+
+        console.log(`[features] Queue full — ${feature.id} blocked, will retry on drain`);
+        this.emit("feature:blocked", feature, feature.blockedReason);
+        return;
+      }
+      throw err;
+    }
 
     feature.activeArchetype = phase_config.archetype;
     feature.activeDna = phase_config.dna;

--- a/packages/daemon/src/queue.ts
+++ b/packages/daemon/src/queue.ts
@@ -40,6 +40,18 @@ export interface QueueStats {
   failed_total: number;
 }
 
+// ── Errors ──
+
+/** Thrown when the queue is at max_queue_depth and cannot accept more tasks. */
+export class QueueFullError extends Error {
+  readonly code = "QUEUE_FULL";
+
+  constructor(max_depth: number) {
+    super(`Queue is full (max_queue_depth: ${String(max_depth)}). Try again later.`);
+    this.name = "QueueFullError";
+  }
+}
+
 // ── Priority ordering ──
 
 const PRIORITY_ORDER: Record<Priority, number> = {
@@ -56,6 +68,7 @@ export class TaskQueue {
   private active = new Map<string, QueuedTask>();
   private completed_count = 0;
   private failed_count = 0;
+  private on_drain_callback: (() => void) | null = null;
 
   constructor(
     private session_manager: ClaudeSessionManager,
@@ -71,8 +84,13 @@ export class TaskQueue {
     });
   }
 
-  /** Submit a new task. Returns the task ID. */
+  /** Submit a new task. Returns the task ID. Throws QueueFullError if at max_queue_depth. */
   submit(submission: TaskSubmission): string {
+    const max_depth = this.config.concurrency.max_queue_depth;
+    if (this.pending.length >= max_depth) {
+      throw new QueueFullError(max_depth);
+    }
+
     const task: QueuedTask = {
       ...submission,
       id: randomUUID(),
@@ -169,6 +187,19 @@ export class TaskQueue {
     return [...this.active.values()];
   }
 
+  /** Number of tasks waiting to be processed. */
+  get pending_count(): number {
+    return this.pending.length;
+  }
+
+  /**
+   * Register a callback to be invoked when a task completes and capacity frees up.
+   * Used by FeatureManager to retry features blocked due to queue-full.
+   */
+  on_drain(callback: () => void): void {
+    this.on_drain_callback = callback;
+  }
+
   /** Get queue statistics for the /status endpoint. */
   get_stats(): QueueStats {
     return {
@@ -195,8 +226,9 @@ export class TaskQueue {
       }
     }
 
-    // Process next pending task
+    // Process next pending task, then notify drain listeners so blocked features can retry
     void this.process_next();
+    this.notify_drain();
   }
 
   private on_session_failed(session_id: string, error: string): void {
@@ -213,8 +245,19 @@ export class TaskQueue {
       }
     }
 
-    // Process next pending task
+    // Process next pending task, then notify drain listeners so blocked features can retry
     void this.process_next();
+    this.notify_drain();
+  }
+
+  private notify_drain(): void {
+    if (this.on_drain_callback) {
+      try {
+        this.on_drain_callback();
+      } catch (err) {
+        console.error("[queue] Drain callback error:", err);
+      }
+    }
   }
 
   private sort_pending(): void {

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -3,6 +3,7 @@ import type { LobsterFarmConfig, Phase } from "@lobster-farm/shared";
 import { DAEMON_PORT } from "@lobster-farm/shared";
 import type { EntityRegistry } from "./registry.js";
 import type { ClaudeSessionManager } from "./session.js";
+import { QueueFullError } from "./queue.js";
 import type { TaskQueue, TaskSubmission } from "./queue.js";
 import type { FeatureManager, CreateFeatureOptions } from "./features.js";
 import type { CommanderProcess } from "./commander-process.js";
@@ -176,8 +177,16 @@ const handle_submit_task: RouteHandler = async (req, res, ctx) => {
     }
   }
 
-  const task_id = ctx.queue.submit(submission);
-  json_response(res, 201, { task_id });
+  try {
+    const task_id = ctx.queue.submit(submission);
+    json_response(res, 201, { task_id });
+  } catch (err) {
+    if (err instanceof QueueFullError) {
+      json_response(res, 429, { error: err.message });
+      return;
+    }
+    throw err;
+  }
 };
 
 const handle_list_tasks: RouteHandler = (_req, res, ctx) => {


### PR DESCRIPTION
## Summary

- Enforce the previously-configured-but-unenforced `max_queue_depth` limit in `TaskQueue.submit()` with a typed `QueueFullError`
- Features created when the queue is full are persisted and marked `blocked` with reason "Queue full" -- nothing is lost, only the agent spawn is deferred
- Auto-retry: when a task completes and capacity frees up, the queue's drain callback triggers `FeatureManager.retry_queue_blocked()` to re-attempt spawning blocked features
- HTTP API returns 429 when `POST /tasks` hits the queue depth limit

## Files changed

| File | Change |
|------|--------|
| `packages/daemon/src/queue.ts` | `QueueFullError` class, depth check in `submit()`, `on_drain` callback, `pending_count` getter |
| `packages/daemon/src/features.ts` | Catch `QueueFullError` in `spawn_phase_agent()`, `retry_queue_blocked()` method, drain callback registration |
| `packages/daemon/src/server.ts` | Catch `QueueFullError` in `handle_submit_task()`, return HTTP 429 |
| `packages/daemon/src/__tests__/queue-depth.test.ts` | 6 tests covering depth enforcement, error properties, drain recovery, feature blocking, and callback invocation |

## Test plan

- [x] `QueueFullError` thrown when pending queue reaches `max_queue_depth`
- [x] Error has correct `name`, `code`, and `message` properties
- [x] Submissions succeed again after queue drains below limit
- [x] `pending_count` getter tracks queue length accurately
- [x] Feature creation succeeds but marks feature blocked when queue is full
- [x] `on_drain` callback fires when tasks complete
- [x] All 136 existing + new tests pass (`npx vitest run packages/daemon/src/__tests__/`)

Closes Part 1 of #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)