### PR TITLE
feat: activity-aware eviction & demand-based channel assignment

### DIFF
--- a/packages/daemon/src/__tests__/pool.test.ts
+++ b/packages/daemon/src/__tests__/pool.test.ts
@@ -1,0 +1,431 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
+import type { LobsterFarmConfig } from "@lobster-farm/shared";
+import { BotPool } from "../pool.js";
+import type { PoolBot } from "../pool.js";
+
+function make_config(): LobsterFarmConfig {
+  return LobsterFarmConfigSchema.parse({
+    user: { name: "Test" },
+  });
+}
+
+/**
+ * Test-friendly subclass of BotPool that exposes internals for unit testing.
+ * Overrides tmux/filesystem operations to avoid real side effects.
+ */
+class TestBotPool extends BotPool {
+  // Override the tmux-dependent methods to make tests deterministic.
+  // The real pool checks tmux pane output; we control what is_bot_idle returns
+  // by mapping bot IDs to idle status.
+  private idle_overrides = new Map<number, boolean>();
+
+  /** Inject test bots directly into the pool without filesystem/tmux. */
+  inject_bots(bots: PoolBot[]): void {
+    // Access private field via bracket notation for testing
+    (this as unknown as { bots: PoolBot[] }).bots = bots;
+  }
+
+  /** Set whether a bot is idle at its tmux prompt (true) or working (false). */
+  set_bot_idle(bot_id: number, idle: boolean): void {
+    this.idle_overrides.set(bot_id, idle);
+  }
+
+  /**
+   * Override is_bot_idle to use our test overrides instead of real tmux.
+   * This is the single point of tmux dependency — overriding it makes both
+   * compute_activity_state() and has_active_work() work in tests.
+   */
+  protected override is_bot_idle(bot: PoolBot): boolean {
+    return this.idle_overrides.get(bot.id) ?? true;
+  }
+}
+
+/** Create a PoolBot with sensible defaults for testing. */
+function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
+  return {
+    state: "free",
+    channel_id: null,
+    entity_id: null,
+    archetype: null,
+    channel_type: null,
+    session_id: null,
+    tmux_session: `pool-${String(overrides.id)}`,
+    last_active: null,
+    state_dir: `/tmp/test-pool-${String(overrides.id)}`,
+    ...overrides,
+  };
+}
+
+/** Minutes ago as a Date. */
+function minutes_ago(n: number): Date {
+  return new Date(Date.now() - n * 60_000);
+}
+
+describe("BotPool", () => {
+  let config: LobsterFarmConfig;
+  let pool: TestBotPool;
+
+  beforeEach(() => {
+    config = make_config();
+    pool = new TestBotPool(config);
+
+    // Stub out assign's side effects (tmux start, access.json, nickname)
+    // by mocking the private methods via prototype
+    vi.spyOn(pool as unknown as { kill_tmux: (s: string) => void }, "kill_tmux" as never)
+      .mockImplementation(() => {});
+    vi.spyOn(pool as unknown as { write_access_json: (d: string, c: string | null) => Promise<void> }, "write_access_json" as never)
+      .mockResolvedValue(undefined);
+    vi.spyOn(pool as unknown as { set_bot_nickname: (d: string, a: string) => Promise<void> }, "set_bot_nickname" as never)
+      .mockResolvedValue(undefined);
+    vi.spyOn(pool as unknown as { start_tmux: (...args: unknown[]) => Promise<void> }, "start_tmux" as never)
+      .mockResolvedValue(undefined);
+    vi.spyOn(pool as unknown as { is_tmux_alive: (s: string) => boolean }, "is_tmux_alive" as never)
+      .mockReturnValue(false);
+    vi.spyOn(pool as unknown as { park_bot: (b: PoolBot) => Promise<void> }, "park_bot" as never)
+      .mockImplementation(async (bot: PoolBot) => {
+        bot.state = "parked";
+      });
+  });
+
+  describe("compute_activity_state", () => {
+    it("returns 'idle' for non-assigned bots", () => {
+      const bot = make_bot({ id: 1, state: "free" });
+      expect(pool.compute_activity_state(bot)).toBe("idle");
+    });
+
+    it("returns 'idle' for parked bots", () => {
+      const bot = make_bot({ id: 1, state: "parked" });
+      expect(pool.compute_activity_state(bot)).toBe("idle");
+    });
+
+    it("returns 'working' when tmux pane has no prompt", () => {
+      const bot = make_bot({
+        id: 1,
+        state: "assigned",
+        last_active: new Date(),
+      });
+      pool.set_bot_idle(1, false);
+      expect(pool.compute_activity_state(bot)).toBe("working");
+    });
+
+    it("returns 'active_conversation' when last_active < 3 min ago", () => {
+      const bot = make_bot({
+        id: 1,
+        state: "assigned",
+        last_active: minutes_ago(1),
+      });
+      pool.set_bot_idle(1, true);
+      expect(pool.compute_activity_state(bot)).toBe("active_conversation");
+    });
+
+    it("returns 'waiting_for_human' when last_active 3-30 min ago", () => {
+      const bot = make_bot({
+        id: 1,
+        state: "assigned",
+        last_active: minutes_ago(10),
+      });
+      pool.set_bot_idle(1, true);
+      expect(pool.compute_activity_state(bot)).toBe("waiting_for_human");
+    });
+
+    it("returns 'idle' when last_active > 30 min ago", () => {
+      const bot = make_bot({
+        id: 1,
+        state: "assigned",
+        last_active: minutes_ago(45),
+      });
+      pool.set_bot_idle(1, true);
+      expect(pool.compute_activity_state(bot)).toBe("idle");
+    });
+
+    it("returns 'idle' when last_active is null", () => {
+      const bot = make_bot({
+        id: 1,
+        state: "assigned",
+        last_active: null,
+      });
+      pool.set_bot_idle(1, true);
+      expect(pool.compute_activity_state(bot)).toBe("idle");
+    });
+
+    it("returns 'waiting_for_human' at exactly 3 min boundary", () => {
+      const bot = make_bot({
+        id: 1,
+        state: "assigned",
+        last_active: minutes_ago(3),
+      });
+      pool.set_bot_idle(1, true);
+      // At exactly 3 min, idle_minutes >= 3 so it should be waiting_for_human
+      expect(pool.compute_activity_state(bot)).toBe("waiting_for_human");
+    });
+
+    it("returns 'idle' at exactly 30 min boundary", () => {
+      const bot = make_bot({
+        id: 1,
+        state: "assigned",
+        last_active: minutes_ago(30),
+      });
+      pool.set_bot_idle(1, true);
+      // At exactly 30 min, idle_minutes >= 30 so it should be idle
+      expect(pool.compute_activity_state(bot)).toBe("idle");
+    });
+  });
+
+  describe("eviction priority in assign()", () => {
+    it("assigns a free bot without eviction", async () => {
+      pool.inject_bots([
+        make_bot({ id: 1, state: "free" }),
+        make_bot({ id: 2, state: "assigned", channel_id: "ch-x", entity_id: "e1", last_active: minutes_ago(5) }),
+      ]);
+
+      const result = await pool.assign("ch-new", "e1", "planner", undefined, "general");
+      expect(result).not.toBeNull();
+      expect(result!.bot_id).toBe(1);
+    });
+
+    it("evicts parked bot before idle assigned", async () => {
+      pool.inject_bots([
+        make_bot({ id: 1, state: "parked", channel_id: "ch-1", entity_id: "e1", last_active: minutes_ago(60), channel_type: "general" }),
+        make_bot({ id: 2, state: "assigned", channel_id: "ch-2", entity_id: "e1", last_active: minutes_ago(60), channel_type: "general" }),
+      ]);
+      pool.set_bot_idle(2, true);
+
+      const result = await pool.assign("ch-new", "e1", "planner", undefined, "general");
+      expect(result).not.toBeNull();
+      expect(result!.bot_id).toBe(1);
+    });
+
+    it("evicts idle assigned before waiting_for_human", async () => {
+      pool.inject_bots([
+        make_bot({ id: 1, state: "assigned", channel_id: "ch-1", entity_id: "e1", last_active: minutes_ago(45), channel_type: "general" }),
+        make_bot({ id: 2, state: "assigned", channel_id: "ch-2", entity_id: "e1", last_active: minutes_ago(10), channel_type: "general" }),
+      ]);
+      pool.set_bot_idle(1, true); // idle (>30 min)
+      pool.set_bot_idle(2, true); // waiting_for_human (3-30 min)
+
+      const result = await pool.assign("ch-new", "e1", "planner", undefined, "general");
+      expect(result).not.toBeNull();
+      expect(result!.bot_id).toBe(1); // idle evicted first
+    });
+
+    it("evicts waiting_for_human when no idle bots remain", async () => {
+      pool.inject_bots([
+        make_bot({ id: 1, state: "assigned", channel_id: "ch-1", entity_id: "e1", last_active: minutes_ago(10), channel_type: "general" }),
+        make_bot({ id: 2, state: "assigned", channel_id: "ch-2", entity_id: "e1", last_active: new Date(), channel_type: "general" }),
+      ]);
+      pool.set_bot_idle(1, true); // waiting_for_human
+      pool.set_bot_idle(2, false); // working
+
+      const result = await pool.assign("ch-new", "e1", "planner", undefined, "general");
+      expect(result).not.toBeNull();
+      expect(result!.bot_id).toBe(1);
+    });
+
+    it("hits floor when all bots are working — returns null", async () => {
+      pool.inject_bots([
+        make_bot({ id: 1, state: "assigned", channel_id: "ch-1", entity_id: "e1", last_active: new Date() }),
+        make_bot({ id: 2, state: "assigned", channel_id: "ch-2", entity_id: "e1", last_active: new Date() }),
+      ]);
+      pool.set_bot_idle(1, false); // working
+      pool.set_bot_idle(2, false); // working
+
+      const result = await pool.assign("ch-new", "e1", "planner", undefined, "general");
+      expect(result).toBeNull();
+    });
+
+    it("hits floor when all bots are in active_conversation — returns null", async () => {
+      pool.inject_bots([
+        make_bot({ id: 1, state: "assigned", channel_id: "ch-1", entity_id: "e1", last_active: minutes_ago(1) }),
+        make_bot({ id: 2, state: "assigned", channel_id: "ch-2", entity_id: "e1", last_active: minutes_ago(2) }),
+      ]);
+      pool.set_bot_idle(1, true); // active_conversation
+      pool.set_bot_idle(2, true); // active_conversation
+
+      const result = await pool.assign("ch-new", "e1", "planner", undefined, "general");
+      expect(result).toBeNull();
+    });
+
+    it("idle general evicted before idle work_room", async () => {
+      pool.inject_bots([
+        make_bot({ id: 1, state: "assigned", channel_id: "ch-1", entity_id: "e1", last_active: minutes_ago(45), channel_type: "work_room" }),
+        make_bot({ id: 2, state: "assigned", channel_id: "ch-2", entity_id: "e1", last_active: minutes_ago(45), channel_type: "general" }),
+      ]);
+      pool.set_bot_idle(1, true);
+      pool.set_bot_idle(2, true);
+
+      const result = await pool.assign("ch-new", "e1", "planner", undefined, "general");
+      expect(result).not.toBeNull();
+      expect(result!.bot_id).toBe(2); // general evicted first
+    });
+
+    it("within same tier and channel type, LRU ordering applies", async () => {
+      pool.inject_bots([
+        make_bot({ id: 1, state: "assigned", channel_id: "ch-1", entity_id: "e1", last_active: minutes_ago(60), channel_type: "general" }),
+        make_bot({ id: 2, state: "assigned", channel_id: "ch-2", entity_id: "e1", last_active: minutes_ago(45), channel_type: "general" }),
+      ]);
+      pool.set_bot_idle(1, true);
+      pool.set_bot_idle(2, true);
+
+      const result = await pool.assign("ch-new", "e1", "planner", undefined, "general");
+      expect(result).not.toBeNull();
+      expect(result!.bot_id).toBe(1); // older last_active evicted first
+    });
+
+    it("emits bot:parked_with_context when waiting_for_human bot is evicted", async () => {
+      pool.inject_bots([
+        make_bot({ id: 1, state: "assigned", channel_id: "ch-1", entity_id: "e1", last_active: minutes_ago(10), channel_type: "general" }),
+      ]);
+      pool.set_bot_idle(1, true); // waiting_for_human
+
+      const events: unknown[] = [];
+      pool.on("bot:parked_with_context", (info: unknown) => events.push(info));
+
+      await pool.assign("ch-new", "e2", "planner", undefined, "general");
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        bot_id: 1,
+        channel_id: "ch-1",
+        entity_id: "e1",
+      });
+    });
+
+    it("does NOT emit bot:parked_with_context for idle assigned eviction", async () => {
+      pool.inject_bots([
+        make_bot({ id: 1, state: "assigned", channel_id: "ch-1", entity_id: "e1", last_active: minutes_ago(45), channel_type: "general" }),
+      ]);
+      pool.set_bot_idle(1, true); // idle
+
+      const events: unknown[] = [];
+      pool.on("bot:parked_with_context", (info: unknown) => events.push(info));
+
+      await pool.assign("ch-new", "e2", "planner", undefined, "general");
+
+      expect(events).toHaveLength(0);
+    });
+
+    it("does NOT emit bot:parked_with_context for parked bot eviction", async () => {
+      pool.inject_bots([
+        make_bot({ id: 1, state: "parked", channel_id: "ch-1", entity_id: "e1", last_active: minutes_ago(60), channel_type: "general" }),
+      ]);
+
+      const events: unknown[] = [];
+      pool.on("bot:parked_with_context", (info: unknown) => events.push(info));
+
+      await pool.assign("ch-new", "e2", "planner", undefined, "general");
+
+      expect(events).toHaveLength(0);
+    });
+  });
+
+  describe("has_active_work() with is_bot_idle() extraction", () => {
+    it("returns active: false when no bots are assigned", () => {
+      pool.inject_bots([
+        make_bot({ id: 1, state: "free" }),
+        make_bot({ id: 2, state: "parked" }),
+      ]);
+
+      const result = pool.has_active_work();
+      expect(result.active).toBe(false);
+      expect(result.working_bots).toHaveLength(0);
+    });
+
+    it("returns active: true when an assigned bot is not idle", () => {
+      const bot = make_bot({
+        id: 1,
+        state: "assigned",
+        channel_id: "ch-1",
+        archetype: "builder",
+        last_active: new Date(),
+      });
+      pool.inject_bots([bot]);
+      pool.set_bot_idle(1, false);
+
+      const result = pool.has_active_work();
+      expect(result.active).toBe(true);
+      expect(result.working_bots).toHaveLength(1);
+      expect(result.working_bots[0]!.id).toBe(1);
+      expect(result.working_bots[0]!.archetype).toBe("builder");
+    });
+
+    it("returns active: false when all assigned bots are idle", () => {
+      pool.inject_bots([
+        make_bot({ id: 1, state: "assigned", channel_id: "ch-1", last_active: new Date() }),
+        make_bot({ id: 2, state: "assigned", channel_id: "ch-2", last_active: new Date() }),
+      ]);
+      pool.set_bot_idle(1, true);
+      pool.set_bot_idle(2, true);
+
+      const result = pool.has_active_work();
+      expect(result.active).toBe(false);
+    });
+  });
+
+  describe("pre_assign_generals removed", () => {
+    it("BotPool does not have pre_assign_generals method", () => {
+      // Verify the method was removed
+      expect((pool as unknown as Record<string, unknown>)["pre_assign_generals"]).toBeUndefined();
+    });
+  });
+
+  describe("eviction with mixed scenarios", () => {
+    it("full pool: 10 idle generals + new feature request evicts oldest general", async () => {
+      const bots = Array.from({ length: 10 }, (_, i) =>
+        make_bot({
+          id: i + 1,
+          state: "assigned",
+          channel_id: `ch-${String(i + 1)}`,
+          entity_id: `e${String(i + 1)}`,
+          last_active: minutes_ago(60 - i), // bot 1 is oldest, bot 10 is newest
+          channel_type: "general",
+          archetype: "planner",
+        }),
+      );
+      pool.inject_bots(bots);
+      for (let i = 1; i <= 10; i++) {
+        pool.set_bot_idle(i, true); // all idle
+      }
+
+      const result = await pool.assign("ch-new", "e-new", "builder", undefined, "work_room");
+      expect(result).not.toBeNull();
+      expect(result!.bot_id).toBe(1); // oldest idle general
+    });
+
+    it("mixed states: working + active_conversation + waiting + idle — evicts idle", async () => {
+      pool.inject_bots([
+        make_bot({ id: 1, state: "assigned", channel_id: "ch-1", entity_id: "e1", last_active: new Date(), channel_type: "general" }),       // working
+        make_bot({ id: 2, state: "assigned", channel_id: "ch-2", entity_id: "e1", last_active: minutes_ago(1), channel_type: "general" }),   // active_conversation
+        make_bot({ id: 3, state: "assigned", channel_id: "ch-3", entity_id: "e1", last_active: minutes_ago(10), channel_type: "general" }),  // waiting_for_human
+        make_bot({ id: 4, state: "assigned", channel_id: "ch-4", entity_id: "e1", last_active: minutes_ago(45), channel_type: "general" }),  // idle
+      ]);
+      pool.set_bot_idle(1, false); // working
+      pool.set_bot_idle(2, true);  // active_conversation
+      pool.set_bot_idle(3, true);  // waiting_for_human
+      pool.set_bot_idle(4, true);  // idle
+
+      const result = await pool.assign("ch-new", "e1", "planner", undefined, "general");
+      expect(result).not.toBeNull();
+      expect(result!.bot_id).toBe(4); // idle evicted
+    });
+
+    it("auto-resumes returning parked bot for same channel", async () => {
+      pool.inject_bots([
+        make_bot({
+          id: 1,
+          state: "parked",
+          channel_id: "ch-returning",
+          entity_id: "e1",
+          session_id: "sess-abc123",
+          channel_type: "general",
+          last_active: minutes_ago(10),
+        }),
+        make_bot({ id: 2, state: "free" }),
+      ]);
+
+      const result = await pool.assign("ch-returning", "e1", "planner", undefined, "general");
+      expect(result).not.toBeNull();
+      expect(result!.bot_id).toBe(1); // returning parked bot, not the free one
+    });
+  });
+});

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -478,6 +478,17 @@ export class DiscordBot extends EventEmitter {
 
   set_pool(pool: BotPool): void {
     this._pool = pool;
+
+    // When a waiting-for-human bot is evicted, notify the channel
+    pool.on("bot:parked_with_context", (info: { bot_id: number; channel_id: string | null; entity_id: string | null }) => {
+      if (info.channel_id) {
+        void this.send(
+          info.channel_id,
+          "This session was parked to free up a bot slot. " +
+          "Your conversation is saved — it will resume when you send a new message.",
+        );
+      }
+    });
   }
 
   // ── Internal message handling ──
@@ -588,7 +599,7 @@ export class DiscordBot extends EventEmitter {
           } catch { /* ignore */ }
           await this.reply(
             message,
-            "All agent slots are in use. Create another pool bot or try again shortly.",
+            "All bots are busy right now. Your message will be picked up when a slot opens.",
           );
         }
       } else {

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -56,10 +56,9 @@ async function main(): Promise<void> {
     `Session manager ready (max ${String(config.concurrency.max_active_sessions)} concurrent sessions)`,
   );
 
-  // Initialize bot pool and pre-assign planners to #general channels
+  // Initialize bot pool — bots are assigned on first message, not on startup
   const pool = new BotPool(config);
   await pool.initialize();
-  await pool.pre_assign_generals(registry);
 
   // Initialize Discord bot (optional — daemon works without it via HTTP API)
   const discord = new DiscordBot(config, registry);

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "node:events";
 import { execFileSync, spawn } from "node:child_process";
 import { writeFile, readFile } from "node:fs/promises";
 import { join } from "node:path";
@@ -5,7 +6,6 @@ import { homedir } from "node:os";
 import type { ArchetypeRole, LobsterFarmConfig } from "@lobster-farm/shared";
 import { lobsterfarm_dir, entity_dir } from "@lobster-farm/shared";
 import type { ChannelType } from "@lobster-farm/shared";
-import type { EntityRegistry } from "./registry.js";
 
 // ── Types ──
 
@@ -45,6 +45,9 @@ export interface PoolStatus {
     last_active: string | null;
   }>;
 }
+
+/** Activity state computed on demand from observable signals (tmux pane, timestamps). */
+export type ActivityState = "idle" | "working" | "waiting_for_human" | "active_conversation";
 
 // ── Agent name resolution ──
 
@@ -89,12 +92,13 @@ function bot_user_id_from_token(token: string): string | null {
 
 // ── Pool Manager ──
 
-export class BotPool {
+export class BotPool extends EventEmitter {
   private bots: PoolBot[] = [];
   private config: LobsterFarmConfig;
   private _draining = false;
 
   constructor(config: LobsterFarmConfig) {
+    super();
     this.config = config;
   }
 
@@ -221,43 +225,62 @@ export class BotPool {
       bot = this.bots.find(b => b.state === "free");
     }
 
-    // If none free, evict the least recently active (parked first, then assigned)
-    // Eviction priority: general-channel bots evicted before work-room bots
+    // Activity-aware eviction: free → parked → idle assigned → waiting_for_human → FLOOR
+    // Within each tier: general channels before work rooms, then LRU.
+    const eviction_sort = (a: PoolBot, b: PoolBot) => {
+      const type_a = a.channel_type === "work_room" ? 1 : 0;
+      const type_b = b.channel_type === "work_room" ? 1 : 0;
+      if (type_a !== type_b) return type_a - type_b;
+      return (a.last_active?.getTime() ?? 0) - (b.last_active?.getTime() ?? 0);
+    };
+
+    // Tier 2: Parked bots (cheapest eviction — already suspended)
     if (!bot) {
       const parked = this.bots
         .filter(b => b.state === "parked")
-        .sort((a, b) => {
-          // General channels evicted before work rooms
-          const type_a = a.channel_type === "work_room" ? 1 : 0;
-          const type_b = b.channel_type === "work_room" ? 1 : 0;
-          if (type_a !== type_b) return type_a - type_b;
-          return (a.last_active?.getTime() ?? 0) - (b.last_active?.getTime() ?? 0);
-        });
+        .sort(eviction_sort);
 
       if (parked.length > 0) {
         bot = parked[0];
         console.log(`[pool] Evicting parked bot pool-${String(bot!.id)} (${bot!.channel_type ?? "unknown"} channel, LRU)`);
-      } else {
-        // Evict least recently active assigned bot (general first)
-        const assigned = this.bots
-          .filter(b => b.state === "assigned")
-          .sort((a, b) => {
-            const type_a = a.channel_type === "work_room" ? 1 : 0;
-            const type_b = b.channel_type === "work_room" ? 1 : 0;
-            if (type_a !== type_b) return type_a - type_b;
-            return (a.last_active?.getTime() ?? 0) - (b.last_active?.getTime() ?? 0);
-          });
-
-        if (assigned.length > 0) {
-          bot = assigned[0];
-          console.log(`[pool] Evicting assigned bot pool-${String(bot!.id)} (LRU) — parking session`);
-          await this.park_bot(bot!);
-        }
       }
     }
 
+    // Tier 3: Idle assigned bots (>= 30 min since last human interaction)
     if (!bot) {
-      console.error("[pool] No bots available — pool exhausted");
+      const idle_assigned = this.bots
+        .filter(b => b.state === "assigned" && this.compute_activity_state(b) === "idle")
+        .sort(eviction_sort);
+
+      if (idle_assigned.length > 0) {
+        bot = idle_assigned[0];
+        console.log(`[pool] Evicting idle bot pool-${String(bot!.id)} — parking`);
+        await this.park_bot(bot!);
+      }
+    }
+
+    // Tier 4: Waiting-for-human bots (3-30 min since last interaction — expensive but necessary)
+    if (!bot) {
+      const waiting = this.bots
+        .filter(b => b.state === "assigned" && this.compute_activity_state(b) === "waiting_for_human")
+        .sort(eviction_sort);
+
+      if (waiting.length > 0) {
+        bot = waiting[0];
+        console.log(`[pool] Evicting waiting-for-human bot pool-${String(bot!.id)} — parking`);
+        await this.park_bot(bot!);
+        // Notify that this session was parked with active context
+        this.emit("bot:parked_with_context", {
+          bot_id: bot!.id,
+          channel_id: bot!.channel_id,
+          entity_id: bot!.entity_id,
+        });
+      }
+    }
+
+    // FLOOR: active_conversation and working bots are NEVER evicted
+    if (!bot) {
+      console.log("[pool] All bots at floor (active/working) — no eviction possible");
       return null;
     }
 
@@ -356,6 +379,48 @@ export class BotPool {
     };
   }
 
+  /**
+   * Compute the activity state of a bot from observable signals.
+   * Derived on demand from tmux pane state and last_active timestamp — never stored.
+   */
+  compute_activity_state(bot: PoolBot): ActivityState {
+    if (bot.state !== "assigned") return "idle";
+
+    // Check if bot is actively processing (tmux pane has no prompt)
+    if (!this.is_bot_idle(bot)) return "working";
+
+    // Check recency of last human interaction
+    const idle_minutes = bot.last_active
+      ? (Date.now() - bot.last_active.getTime()) / 60_000
+      : Infinity;
+
+    // < 3 min: active conversation — don't touch
+    if (idle_minutes < 3) return "active_conversation";
+    // 3-30 min: bot asked a question or showed output recently — evictable as last resort
+    if (idle_minutes < 30) return "waiting_for_human";
+    // >= 30 min: fair game
+    return "idle";
+  }
+
+  /**
+   * Check if a single bot is idle at the prompt (not actively processing).
+   * Returns true when the tmux pane shows a ❯ prompt or bypass permissions dialog.
+   * Fails open (returns true) when the tmux pane can't be read — safe for eviction checks.
+   */
+  protected is_bot_idle(bot: PoolBot): boolean {
+    try {
+      const output = execFileSync(
+        "tmux", ["capture-pane", "-t", bot.tmux_session, "-p"],
+        { encoding: "utf-8", timeout: 2000 },
+      );
+      const lines = output.trim().split("\n");
+      const last_line = lines[lines.length - 1] ?? "";
+      return last_line.includes("❯") || last_line.includes("bypass permissions");
+    } catch {
+      return true; // Can't check — assume idle (fail-open for eviction)
+    }
+  }
+
   /** Check if any pool bots are actively working (not idle at prompt). */
   has_active_work(): { active: boolean; working_bots: Array<{ id: number; archetype: string; channel_id: string }> } {
     const working: Array<{ id: number; archetype: string; channel_id: string }> = [];
@@ -363,25 +428,12 @@ export class BotPool {
     for (const bot of this.bots) {
       if (bot.state !== "assigned") continue;
 
-      try {
-        const output = execFileSync(
-          "tmux", ["capture-pane", "-t", bot.tmux_session, "-p"],
-          { encoding: "utf-8", timeout: 2000 },
-        );
-        // If the pane shows a spinner/working indicator (no ❯ prompt at the end),
-        // the bot is actively processing
-        const lines = output.trim().split("\n");
-        const last_line = lines[lines.length - 1] ?? "";
-        const is_idle = last_line.includes("❯") || last_line.includes("bypass permissions");
-        if (!is_idle) {
-          working.push({
-            id: bot.id,
-            archetype: bot.archetype ?? "unknown",
-            channel_id: bot.channel_id ?? "",
-          });
-        }
-      } catch {
-        // Can't check — assume not working
+      if (!this.is_bot_idle(bot)) {
+        working.push({
+          id: bot.id,
+          archetype: bot.archetype ?? "unknown",
+          channel_id: bot.channel_id ?? "",
+        });
       }
     }
 
@@ -543,22 +595,6 @@ export class BotPool {
       }
     } catch (err) {
       console.log(`[pool] Nickname set failed: ${String(err)}`);
-    }
-  }
-
-  /** Pre-assign bots to entity #general channels on daemon startup. */
-  async pre_assign_generals(registry: EntityRegistry): Promise<void> {
-    for (const entity_config of registry.get_active()) {
-      const entity_id = entity_config.entity.id;
-      const general_channel = entity_config.entity.channels.list.find(
-        ch => ch.type === "general",
-      );
-      if (!general_channel) continue;
-
-      const existing = this.get_assignment(general_channel.id);
-      if (existing) continue;
-
-      await this.assign(general_channel.id, entity_id, "planner");
     }
   }
 


### PR DESCRIPTION
## Summary

Closes #23.

- **Demand-based assignment**: Removed `pre_assign_generals()` -- bots are no longer pre-assigned to entity general channels on daemon startup. All bots start free and are assigned on first message via the existing `handle_message()` path in discord.ts.
- **Activity-aware eviction**: Replaced blunt LRU eviction in `assign()` with a tiered system that computes activity state from observable signals (tmux pane state + `last_active` timestamp). Eviction order: `free > parked > idle (>30min) > waiting_for_human (3-30min) > FLOOR`. Working and active_conversation bots are never evicted.
- **Parking notification**: When a `waiting_for_human` bot is evicted, emits `bot:parked_with_context` event with a Discord message to the affected channel.
- **Floor enforcement**: When `assign()` returns null (all bots at floor), callers provide user feedback instead of silently failing.
- **Dedup**: Extracted `is_bot_idle()` from `has_active_work()` -- single tmux pane check used by both `compute_activity_state()` and `has_active_work()`.

## Test plan

- [x] 27 unit tests covering all acceptance criteria
- [x] `compute_activity_state()` returns correct state for all thresholds (idle, working, waiting_for_human, active_conversation, boundary cases, null last_active)
- [x] Eviction order verified: free > parked > idle > waiting_for_human > floor
- [x] Floor enforcement: all-working and all-active_conversation pools return null
- [x] Channel type priority: generals evicted before work_rooms within each tier
- [x] LRU ordering within same tier and channel type
- [x] `bot:parked_with_context` emitted only for waiting_for_human eviction
- [x] `has_active_work()` still works after `is_bot_idle()` extraction
- [x] `pre_assign_generals` verified removed
- [x] All 190 existing tests still pass

Generated with [Claude Code](https://claude.com/claude-code)