### PR TITLE
fix: check merge state before sending awaiting-merge alert

### DIFF
--- a/packages/daemon/src/pr-cron.ts
+++ b/packages/daemon/src/pr-cron.ts
@@ -313,11 +313,20 @@ export class PRReviewCron {
         `External PR #${String(pr.number)} needs changes — spawning builder to fix`,
       );
     } else if (review_state === "approved") {
-      // Never auto-merge external code — escalate to human
-      await this.notify_alerts(
-        entity_id,
-        `External PR #${String(pr.number)} approved — awaiting human merge approval`,
-      );
+      // Check if the reviewer already merged (they're instructed to merge on approval)
+      const is_merged = await this.check_pr_merged(repo_path, pr.number);
+      if (is_merged) {
+        await this.notify_alerts(
+          entity_id,
+          `External PR #${String(pr.number)} approved and merged`,
+        );
+      } else {
+        // Not yet merged — escalate to human
+        await this.notify_alerts(
+          entity_id,
+          `External PR #${String(pr.number)} approved — awaiting human merge approval`,
+        );
+      }
     } else {
       // Notify completion without specific action
       await this.notify_alerts(
@@ -374,6 +383,20 @@ export class PRReviewCron {
         message,
         "reviewer" as ArchetypeRole,
       );
+    }
+  }
+
+  /** Check if a PR has been merged. */
+  private async check_pr_merged(repo_path: string, pr_number: number): Promise<boolean> {
+    try {
+      const { stdout } = await exec("gh", [
+        "pr", "view", String(pr_number),
+        "--json", "state",
+        "--jq", ".state",
+      ], { cwd: repo_path, timeout: 15_000 });
+      return stdout.trim() === "MERGED";
+    } catch {
+      return false;
     }
   }
 }


### PR DESCRIPTION
## Summary

- In `handle_review_completion()`, the "approved" branch now checks whether the PR is already merged before choosing which alert to send
- If merged: sends "External PR #X approved and merged"
- If not merged: sends the existing "awaiting human merge approval" escalation
- Adds a small `check_pr_merged()` helper that queries `gh pr view --json state`

## Why

The reviewer agent is instructed to merge on approval (`gh pr merge`), but the completion handler never checked merge state. This caused a misleading "awaiting human merge approval" alert even when the PR was already merged.

## Test plan

- [ ] Daemon builds cleanly (`pnpm --filter @lobster-farm/daemon build`)
- [ ] When reviewer merges on approval, alert says "approved and merged"
- [ ] When reviewer approves but merge fails (e.g., branch protection), alert still says "awaiting human merge approval"
- [ ] `check_pr_merged` returns `false` on gh CLI errors (safe default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)