### PR TITLE
feat: work room topic polish & channel role cleanup

### DIFF
--- a/packages/daemon/src/__tests__/work-rooms.test.ts
+++ b/packages/daemon/src/__tests__/work-rooms.test.ts
@@ -213,7 +213,7 @@ describe("Work Room Assignment", () => {
       expect(room_id).toBe("wr-1");
     });
 
-    it("sets channel topic on assignment", async () => {
+    it("sets channel topic with title on assignment", async () => {
       const feature = make_feature();
       const entity = make_entity_config(make_static_work_rooms());
       // @ts-expect-error — mock feature manager
@@ -223,7 +223,23 @@ describe("Work Room Assignment", () => {
 
       expect(discord.set_channel_topic).toHaveBeenCalledWith(
         "wr-1",
-        "🔵 alpha-42 — #42 — Building",
+        "🔨 #42: Test Feature",
+      );
+    });
+
+    it("truncates long title in channel topic on assignment", async () => {
+      const long_title = "A".repeat(80);
+      const feature = make_feature({ title: long_title });
+      const entity = make_entity_config(make_static_work_rooms());
+      // @ts-expect-error — mock feature manager
+      actions.set_feature_manager(make_mock_feature_manager([]));
+
+      await actions.assign_work_room(feature, entity);
+
+      const expected_title = "A".repeat(57) + "...";
+      expect(discord.set_channel_topic).toHaveBeenCalledWith(
+        "wr-1",
+        `🔨 #42: ${expected_title}`,
       );
     });
 
@@ -401,15 +417,15 @@ describe("Notification Routing", () => {
       expect(discord.send_as_agent).toHaveBeenCalledWith("wr-1", "Build started", "builder");
     });
 
-    it("falls back to work_log when no work room assigned", async () => {
+    it("does not send to Discord when no work room assigned (no work_log fallback)", async () => {
       const feature = make_feature({ discordWorkRoom: null, activeArchetype: null });
       const entity = make_entity_config(make_static_work_rooms());
 
       await actions.notify_feature(feature, "Build started", entity);
 
-      expect(discord.send_to_entity).toHaveBeenCalledWith(
-        "alpha", "work_log", "Build started", "system",
-      );
+      // No Discord message sent — neither work room nor work_log
+      expect(discord.send_as_agent).not.toHaveBeenCalled();
+      expect(discord.send_to_entity).not.toHaveBeenCalled();
     });
 
     it("also sends to alerts when also_alerts is true", async () => {
@@ -464,6 +480,34 @@ describe("Notification Routing", () => {
       expect(discord.send_as_agent).toHaveBeenCalledWith("wr-1", "Phase change", "system");
     });
 
+    it("still sends to alerts when no work room but also_alerts is true", async () => {
+      const feature = make_feature({ discordWorkRoom: null, activeArchetype: "builder" });
+      const entity = make_entity_config(make_static_work_rooms());
+
+      await actions.notify_feature(feature, "Blocked!", entity, { also_alerts: true });
+
+      // No primary Discord message (no work room, no fallback)
+      expect(discord.send_as_agent).not.toHaveBeenCalled();
+      // But secondary alert still fires
+      expect(discord.send_to_entity).toHaveBeenCalledWith(
+        "alpha", "alerts", "Blocked!", "builder",
+      );
+    });
+
+    it("still sends to general when no work room but also_general is true", async () => {
+      const feature = make_feature({ discordWorkRoom: null, activeArchetype: "builder" });
+      const entity = make_entity_config(make_static_work_rooms());
+
+      await actions.notify_feature(feature, "Shipped!", entity, { also_general: true });
+
+      // No primary Discord message
+      expect(discord.send_as_agent).not.toHaveBeenCalled();
+      // But secondary general still fires
+      expect(discord.send_to_entity).toHaveBeenCalledWith(
+        "alpha", "general", "Shipped!", "builder",
+      );
+    });
+
     it("routes to specific channel ID, not first work_room", async () => {
       // Verify it routes to wr-2, not wr-1 (which send_to_entity would pick)
       const feature = make_feature({ discordWorkRoom: "wr-2" });
@@ -514,6 +558,155 @@ describe("Channel Topic Updates", () => {
 
       // No error thrown, function returns silently
     });
+  });
+});
+
+describe("Startup Topic Reset", () => {
+  let discord: ReturnType<typeof make_mock_discord>;
+
+  beforeEach(() => {
+    discord = make_mock_discord();
+    // @ts-expect-error — mock does not implement full DiscordBot interface
+    actions.set_discord_bot(discord);
+  });
+
+  it("resets unoccupied work rooms to Available on startup", async () => {
+    // No active features — all work rooms should be reset
+    // @ts-expect-error — mock feature manager
+    actions.set_feature_manager(make_mock_feature_manager([]));
+
+    const entity = make_entity_config(make_static_work_rooms());
+    const registry = {
+      get_active: vi.fn().mockReturnValue([entity]),
+    };
+
+    // @ts-expect-error — mock registry
+    await actions.reset_idle_work_room_topics(registry);
+
+    // All 3 work rooms should be reset
+    expect(discord.set_channel_topic).toHaveBeenCalledWith("wr-1", "🟢 Available");
+    expect(discord.set_channel_topic).toHaveBeenCalledWith("wr-2", "🟢 Available");
+    expect(discord.set_channel_topic).toHaveBeenCalledWith("wr-3", "🟢 Available");
+    expect(discord.set_channel_topic).toHaveBeenCalledTimes(3);
+  });
+
+  it("preserves topic on work rooms with active features", async () => {
+    const active_feature = make_feature({
+      id: "alpha-10",
+      discordWorkRoom: "wr-1",
+      phase: "build",
+    });
+    // @ts-expect-error — mock feature manager
+    actions.set_feature_manager(make_mock_feature_manager([active_feature]));
+
+    const entity = make_entity_config(make_static_work_rooms());
+    const registry = {
+      get_active: vi.fn().mockReturnValue([entity]),
+    };
+
+    // @ts-expect-error — mock registry
+    await actions.reset_idle_work_room_topics(registry);
+
+    // wr-1 has an active feature — should NOT be reset
+    expect(discord.set_channel_topic).not.toHaveBeenCalledWith("wr-1", "🟢 Available");
+    // wr-2 and wr-3 should be reset
+    expect(discord.set_channel_topic).toHaveBeenCalledWith("wr-2", "🟢 Available");
+    expect(discord.set_channel_topic).toHaveBeenCalledWith("wr-3", "🟢 Available");
+    expect(discord.set_channel_topic).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not reset rooms for features in review phase", async () => {
+    const review_feature = make_feature({
+      id: "alpha-10",
+      discordWorkRoom: "wr-2",
+      phase: "review",
+    });
+    // @ts-expect-error — mock feature manager
+    actions.set_feature_manager(make_mock_feature_manager([review_feature]));
+
+    const entity = make_entity_config(make_static_work_rooms());
+    const registry = {
+      get_active: vi.fn().mockReturnValue([entity]),
+    };
+
+    // @ts-expect-error — mock registry
+    await actions.reset_idle_work_room_topics(registry);
+
+    // wr-2 has a review feature — should NOT be reset
+    expect(discord.set_channel_topic).not.toHaveBeenCalledWith("wr-2", "🟢 Available");
+    // wr-1 and wr-3 should be reset
+    expect(discord.set_channel_topic).toHaveBeenCalledWith("wr-1", "🟢 Available");
+    expect(discord.set_channel_topic).toHaveBeenCalledWith("wr-3", "🟢 Available");
+  });
+
+  it("resets rooms for done features (they are no longer active)", async () => {
+    const done_feature = make_feature({
+      id: "alpha-10",
+      discordWorkRoom: "wr-1",
+      phase: "done",
+    });
+    // @ts-expect-error — mock feature manager
+    actions.set_feature_manager(make_mock_feature_manager([done_feature]));
+
+    const entity = make_entity_config(make_static_work_rooms());
+    const registry = {
+      get_active: vi.fn().mockReturnValue([entity]),
+    };
+
+    // @ts-expect-error — mock registry
+    await actions.reset_idle_work_room_topics(registry);
+
+    // wr-1 has a done feature — should be reset
+    expect(discord.set_channel_topic).toHaveBeenCalledWith("wr-1", "🟢 Available");
+    expect(discord.set_channel_topic).toHaveBeenCalledTimes(3);
+  });
+
+  it("is a no-op when no discord bot is available", async () => {
+    actions.set_discord_bot(null);
+    // @ts-expect-error — mock feature manager
+    actions.set_feature_manager(make_mock_feature_manager([]));
+
+    const registry = {
+      get_active: vi.fn().mockReturnValue([]),
+    };
+
+    // Should not throw
+    // @ts-expect-error — mock registry
+    await actions.reset_idle_work_room_topics(registry);
+
+    expect(registry.get_active).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when no feature manager is available", async () => {
+    actions.set_feature_manager(null);
+
+    const registry = {
+      get_active: vi.fn().mockReturnValue([]),
+    };
+
+    // Should not throw
+    // @ts-expect-error — mock registry
+    await actions.reset_idle_work_room_topics(registry);
+
+    expect(registry.get_active).not.toHaveBeenCalled();
+  });
+
+  it("only touches work_room channels, not general or alerts", async () => {
+    // @ts-expect-error — mock feature manager
+    actions.set_feature_manager(make_mock_feature_manager([]));
+
+    const entity = make_entity_config(make_static_work_rooms());
+    const registry = {
+      get_active: vi.fn().mockReturnValue([entity]),
+    };
+
+    // @ts-expect-error — mock registry
+    await actions.reset_idle_work_room_topics(registry);
+
+    // Should not be called for gen-1, wl-1, or al-1
+    expect(discord.set_channel_topic).not.toHaveBeenCalledWith("gen-1", expect.anything());
+    expect(discord.set_channel_topic).not.toHaveBeenCalledWith("wl-1", expect.anything());
+    expect(discord.set_channel_topic).not.toHaveBeenCalledWith("al-1", expect.anything());
   });
 });
 

--- a/packages/daemon/src/actions.ts
+++ b/packages/daemon/src/actions.ts
@@ -5,6 +5,7 @@ import type { FeatureState, EntityConfig, ChannelType, ArchetypeRole, ChannelMap
 import { expand_home, entity_config_path, write_yaml } from "@lobster-farm/shared";
 import type { DiscordBot } from "./discord.js";
 import type { FeatureManager } from "./features.js";
+import type { EntityRegistry } from "./registry.js";
 
 const exec = promisify(execFile);
 
@@ -195,7 +196,11 @@ export async function notify(
   }
 }
 
-/** Send a feature-scoped notification. Routes to work room if assigned, work_log as fallback. */
+/**
+ * Send a feature-scoped notification. Routes to work room if assigned.
+ * No fallback — if no work room is assigned, the notification is not sent to Discord.
+ * Phase transitions are still logged to console via the log line below.
+ */
 export async function notify_feature(
   feature: FeatureState,
   message: string,
@@ -204,12 +209,14 @@ export async function notify_feature(
 ): Promise<void> {
   const archetype = (feature.activeArchetype ?? "system") as ArchetypeRole | "system";
 
-  // Primary: send to work room (by channel ID) or work_log fallback
+  // Primary: send to work room (by channel ID). No work_log fallback —
+  // interactive builders post their own progress in work rooms.
   if (feature.discordWorkRoom && _discord) {
     await _discord.send_as_agent(feature.discordWorkRoom, message, archetype);
     console.log(`[actions:notify] [work_room:${feature.discordWorkRoom}] ${message}`);
   } else {
-    await notify("work_log", message, entity_config, archetype);
+    // Still log to console so phase transitions appear in daily logs
+    console.log(`[actions:notify] [no_room] ${message}`);
   }
 
   // Secondary channels
@@ -292,11 +299,14 @@ export async function assign_work_room(
     await persist_entity_config(entity_config);
   }
 
-  // Set channel topic
+  // Set channel topic with truncated title
   if (_discord && channel_id) {
+    const short_title = feature.title.length > 60
+      ? feature.title.slice(0, 57) + "..."
+      : feature.title;
     await _discord.set_channel_topic(
       channel_id,
-      `🔵 ${feature.id} — #${String(feature.githubIssue)} — Building`,
+      `🔨 #${String(feature.githubIssue)}: ${short_title}`,
     );
   }
 
@@ -397,4 +407,40 @@ export async function update_work_room_topic(
 ): Promise<void> {
   if (!feature.discordWorkRoom || !_discord) return;
   await _discord.set_channel_topic(feature.discordWorkRoom, topic);
+}
+
+// ── Startup cleanup ──
+
+/**
+ * Reset topics on unoccupied work rooms to "Available".
+ * Called on daemon startup to clear stale topics from previous runs.
+ * Rooms with active (non-done) features keep their current topic.
+ */
+export async function reset_idle_work_room_topics(
+  registry: EntityRegistry,
+): Promise<void> {
+  if (!_discord || !_features) return;
+
+  // Collect work rooms that have an active feature
+  const active_rooms = new Set<string>();
+  for (const feature of _features.list_features()) {
+    if (feature.discordWorkRoom && feature.phase !== "done") {
+      active_rooms.add(feature.discordWorkRoom);
+    }
+  }
+
+  // Reset unoccupied work rooms
+  let reset_count = 0;
+  for (const entity_config of registry.get_active()) {
+    for (const channel of entity_config.entity.channels.list) {
+      if (channel.type === "work_room" && !active_rooms.has(channel.id)) {
+        await _discord.set_channel_topic(channel.id, "🟢 Available");
+        reset_count++;
+      }
+    }
+  }
+
+  if (reset_count > 0) {
+    console.log(`[actions] Reset ${String(reset_count)} idle work room topic(s) to Available`);
+  }
 }

--- a/packages/daemon/src/features.ts
+++ b/packages/daemon/src/features.ts
@@ -1103,10 +1103,14 @@ export class FeatureManager extends EventEmitter {
 
     // Update work room topic on phase change
     if (feature.discordWorkRoom) {
+      const short_title = feature.title.length > 60
+        ? feature.title.slice(0, 57) + "..."
+        : feature.title;
+
       const topic_map: Partial<Record<Phase, string>> = {
-        build: `🔵 ${feature.id} — #${String(feature.githubIssue)} — Building`,
-        review: `🟣 ${feature.id} — #${String(feature.githubIssue)} — In Review`,
-        ship: `✅ ${feature.id} — #${String(feature.githubIssue)} — Shipping`,
+        build: `🔨 #${String(feature.githubIssue)}: ${short_title}`,
+        review: `🔍 #${String(feature.githubIssue)}: ${short_title} — In Review`,
+        ship: `✅ #${String(feature.githubIssue)}: ${short_title} — Shipping`,
       };
       const topic = topic_map[phase];
       if (topic) {

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -5,7 +5,7 @@ import { ClaudeSessionManager } from "./session.js";
 import { TaskQueue } from "./queue.js";
 import { FeatureManager } from "./features.js";
 import { DiscordBot, resolve_bot_token } from "./discord.js";
-import { set_discord_bot, set_feature_manager } from "./actions.js";
+import { set_discord_bot, set_feature_manager, reset_idle_work_room_topics } from "./actions.js";
 import { start_server } from "./server.js";
 import { write_pid, remove_pid } from "./pid.js";
 import { CommanderProcess } from "./commander-process.js";
@@ -88,6 +88,11 @@ async function main(): Promise<void> {
       "[discord] No bot token found. Set DISCORD_BOT_TOKEN env var or configure 1Password reference.",
     );
     console.log("[discord] Daemon will run with HTTP API only.");
+  }
+
+  // Reset stale work room topics from previous daemon runs
+  if (discord_connected) {
+    await reset_idle_work_room_topics(registry);
   }
 
   // Initialize Commander (persistent Claude Code session with Discord channel)


### PR DESCRIPTION
## Summary

- **Topic format overhaul**: Work room topics now show the feature title instead of the opaque feature ID. Format changed from `🔵 entity-42 — #42 — Building` to `🔨 #42: Feature title`. Titles truncated to 60 chars.
- **Startup topic reset**: On daemon boot, all unoccupied work rooms are reset to `🟢 Available`, clearing stale topics from previous runs. Active (non-done) features keep their current topic.
- **Removed work_log fallback**: `notify_feature()` no longer falls back to work_log when no work room is assigned. Interactive builders post their own progress. Secondary notifications (`also_alerts`, `also_general`) still fire independently.

Closes #24

## Files changed

- `packages/daemon/src/features.ts` — new topic format with truncated title in `run_entry_actions()`
- `packages/daemon/src/actions.ts` — new topic in `assign_work_room()`, removed work_log fallback in `notify_feature()`, added `reset_idle_work_room_topics()`
- `packages/daemon/src/index.ts` — call `reset_idle_work_room_topics()` on startup after Discord connects
- `packages/daemon/src/__tests__/work-rooms.test.ts` — updated existing tests, added 9 new tests for startup reset and no-fallback behavior

## Test plan

- [x] Topic includes title: `sets channel topic with title on assignment` test
- [x] Long title truncated: `truncates long title in channel topic on assignment` test
- [x] Startup reset clears idle rooms: `resets unoccupied work rooms to Available on startup`
- [x] Startup preserves active rooms: `preserves topic on work rooms with active features`
- [x] Startup preserves review rooms: `does not reset rooms for features in review phase`
- [x] Done features are reset: `resets rooms for done features`
- [x] No work_log fallback: `does not send to Discord when no work room assigned`
- [x] Secondary notifications still work without work room: 2 new tests
- [x] Only work_room channels touched, not general/alerts: `only touches work_room channels`
- [x] Full test suite passes (304 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)