### PR TITLE
feat: hot restart preserves tmux sessions

### DIFF
--- a/packages/cli/src/commands/restart.ts
+++ b/packages/cli/src/commands/restart.ts
@@ -1,0 +1,38 @@
+import { Command } from "commander";
+import { execFileSync } from "node:child_process";
+import { is_service_loaded } from "../lib/launchd.js";
+import { read_pid_file, is_process_running } from "../lib/process.js";
+import { LAUNCHD_LABEL, pid_file_path } from "@lobster-farm/shared";
+
+export const restart_command = new Command("restart")
+  .description("Hot-restart the daemon (preserves tmux sessions)")
+  .action(async () => {
+    const loaded = await is_service_loaded();
+    if (!loaded) {
+      console.log("Daemon is not running. Use 'lf start' instead.");
+      return;
+    }
+
+    // launchctl kickstart -k sends SIGTERM to the running process and
+    // immediately starts a fresh one.  Because the daemon's shutdown handler
+    // no longer kills tmux sessions, pool bots survive the restart and are
+    // rediscovered on startup via pool-state.json + tmux has-session checks.
+    const uid = process.getuid?.() ?? 501;
+    execFileSync("launchctl", [
+      "kickstart", "-k",
+      `gui/${uid}/${LAUNCHD_LABEL}`,
+    ]);
+
+    console.log("Daemon restarting... tmux sessions preserved.");
+
+    // Give the new process a moment to start and write its PID file.
+    await new Promise(resolve => setTimeout(resolve, 3000));
+
+    // Verify the daemon came back
+    const pid = await read_pid_file(pid_file_path());
+    if (pid !== null && is_process_running(pid)) {
+      console.log(`Daemon is back online (PID ${pid}).`);
+    } else {
+      console.log("Warning: daemon may not have restarted. Check logs.");
+    }
+  });

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { execFileSync } from "node:child_process";
 import { unload_service, is_service_loaded } from "../lib/launchd.js";
 import { read_pid_file, is_process_running } from "../lib/process.js";
 import { pid_file_path } from "@lobster-farm/shared";
@@ -10,6 +11,15 @@ export const stop_command = new Command("stop")
     if (!loaded) {
       console.log("LobsterFarm daemon is not running.");
       return;
+    }
+
+    // Kill all pool-N tmux sessions before stopping the daemon.
+    // The daemon no longer kills tmux on SIGTERM (to support hot restart),
+    // so `lf stop` is responsible for full cleanup.
+    for (let i = 0; i < 10; i++) {
+      try {
+        execFileSync("tmux", ["kill-session", "-t", `pool-${i}`], { stdio: "ignore" });
+      } catch { /* session may not exist */ }
     }
 
     // Unload the launchd service

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import { init_command } from "./commands/init.js";
 import { start_command } from "./commands/start.js";
 import { stop_command } from "./commands/stop.js";
+import { restart_command } from "./commands/restart.js";
 import { status_command } from "./commands/status.js";
 import { entity_command } from "./commands/entity.js";
 import { update_command } from "./commands/update.js";
@@ -14,6 +15,7 @@ const program = new Command()
 program.addCommand(init_command);
 program.addCommand(start_command);
 program.addCommand(stop_command);
+program.addCommand(restart_command);
 program.addCommand(status_command);
 program.addCommand(entity_command);
 program.addCommand(update_command);

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -265,8 +265,10 @@ async function main(): Promise<void> {
       }
     }
 
-    // Stop pool bots
-    await pool.shutdown();
+    // Stop health monitor but preserve tmux sessions — `lf restart` relies
+    // on tmux bots surviving daemon restarts.  `lf stop` handles tmux cleanup
+    // from the CLI side before unloading the service.
+    pool.stop_health_monitor();
 
     // Stop Commander
     await commander.stop();


### PR DESCRIPTION
## Summary

Closes #33.

- **Daemon shutdown handler** no longer calls `pool.shutdown()` on SIGTERM. It stops the health monitor but leaves pool-N tmux sessions alive, so bots survive daemon restarts.
- **`lf stop`** now explicitly kills all pool-N tmux sessions (0-9) before unloading the launchd service, preserving full cleanup behavior for intentional stops.
- **`lf restart`** (new command) uses `launchctl kickstart -k` to SIGTERM the daemon and immediately start a fresh one. Waits 3 seconds and verifies the new process is running. When the daemon isn't loaded, suggests `lf start` instead.

Pool initialization (from PR #25) already discovers running tmux sessions and restores metadata from pool-state.json -- no changes needed there.

## Test plan

- [ ] `lf restart` -- tmux sessions survive, daemon restarts, pool metadata restored
- [ ] `lf stop` -- tmux sessions killed, daemon stops cleanly
- [ ] `lf restart` with no daemon running -- prints "Use 'lf start' instead"
- [ ] Send a message after restart -- bot responds (Discord + pool reconnected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)