### PR TITLE
fix: discord connect() race condition on startup

### DIFF
--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -69,11 +69,14 @@ export class DiscordBot extends EventEmitter {
   async connect(token: string): Promise<void> {
     this.build_channel_map();
 
-    this.client.on("ready", () => {
-      const tag = this.client.user?.tag ?? "unknown";
-      console.log(`[discord] Connected as ${tag}`);
-      this.connected = true;
-      this.emit("connected");
+    const ready = new Promise<void>(resolve => {
+      this.client.once("ready", () => {
+        const tag = this.client.user?.tag ?? "unknown";
+        console.log(`[discord] Connected as ${tag}`);
+        this.connected = true;
+        this.emit("connected");
+        resolve();
+      });
     });
 
     this.client.on("messageCreate", (message: Message) => {
@@ -81,6 +84,7 @@ export class DiscordBot extends EventEmitter {
     });
 
     await this.client.login(token);
+    await ready;
   }
 
   /** Disconnect from Discord. */


### PR DESCRIPTION
## Summary

- **Fix race condition** where `connect()` returned before the Discord `ready` event fired, leaving `this.connected = false`
- Callers like `reset_idle_work_room_topics()` that ran immediately after `connect()` hit the `if (!this.connected) return` guard and silently did nothing
- Wrap the `ready` handler in a Promise and `await` it after `login()` so `connect()` only resolves once the bot is fully ready

Closes #44

## Changes

Single-file change in `packages/daemon/src/discord.ts`:

1. `this.client.on("ready", ...)` becomes `this.client.once("ready", ...)` inside a `new Promise<void>` 
2. `await ready` added after `await this.client.login(token)`

## Test plan

- [x] All 263 existing daemon tests pass (`npx vitest run`)
- [ ] Deploy and verify work room topics reset correctly on daemon startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)