### PR TITLE
fix: status CLI reads correct daemon API response fields

### DIFF
--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -2,6 +2,53 @@ import { Command } from "commander";
 import { read_pid_file, is_process_running } from "../lib/process.js";
 import { pid_file_path, DAEMON_PORT } from "@lobster-farm/shared";
 
+/** Shape returned by the daemon's GET /status endpoint. */
+interface DaemonStatus {
+  running: boolean;
+  uptime_seconds: number;
+  entities: { total: number; active: number };
+  sessions: {
+    active: number;
+    active_details: Array<{
+      session_id: string;
+      entity_id: string;
+      feature_id: string | null;
+      archetype: string;
+      started_at: string;
+      pid: number;
+    }>;
+  };
+  queue: {
+    pending: number;
+    active: number;
+    completed_total: number;
+    failed_total: number;
+  };
+  commander: {
+    state: string;
+    pid: number | null;
+    uptime_ms: number | null;
+    restart_count: number;
+    last_started_at: string | null;
+    tmux_session: string;
+  };
+}
+
+/** Format seconds into a human-readable string like "2d 5h 13m 4s". */
+export function format_uptime(total_seconds: number): string {
+  const days = Math.floor(total_seconds / 86400);
+  const hours = Math.floor((total_seconds % 86400) / 3600);
+  const minutes = Math.floor((total_seconds % 3600) / 60);
+  const seconds = total_seconds % 60;
+
+  const parts: string[] = [];
+  if (days > 0) parts.push(`${days}d`);
+  if (hours > 0) parts.push(`${hours}h`);
+  if (minutes > 0) parts.push(`${minutes}m`);
+  if (parts.length === 0 || seconds > 0) parts.push(`${seconds}s`);
+  return parts.join(" ");
+}
+
 export const status_command = new Command("status")
   .description("Show LobsterFarm daemon status")
   .action(async () => {
@@ -29,19 +76,16 @@ export const status_command = new Command("status")
       clearTimeout(timeout);
 
       if (response.ok) {
-        const data = (await response.json()) as Record<string, unknown>;
-        if (data["entities"] !== undefined) {
-          console.log(`  Entities: ${data["entities"]}`);
-        }
-        if (data["queue_depth"] !== undefined) {
-          console.log(`  Queue depth: ${data["queue_depth"]}`);
-        }
-        if (data["active_sessions"] !== undefined) {
-          console.log(`  Active sessions: ${data["active_sessions"]}`);
-        }
-        if (data["uptime"] !== undefined) {
-          console.log(`  Uptime: ${data["uptime"]}`);
-        }
+        const data = (await response.json()) as DaemonStatus;
+        console.log(`  Uptime:     ${format_uptime(data.uptime_seconds)}`);
+        console.log(
+          `  Entities:   ${data.entities.active} active / ${data.entities.total} total`,
+        );
+        console.log(`  Sessions:   ${data.sessions.active} active`);
+        console.log(
+          `  Queue:      ${data.queue.pending} pending, ${data.queue.active} active`,
+        );
+        console.log(`  Commander:  ${data.commander.state}`);
       } else {
         console.log(`  HTTP status endpoint returned ${response.status}`);
       }


### PR DESCRIPTION
## Summary

- Fixed `lf status` CLI command which read wrong field names from the daemon `/status` response, causing it to display nothing useful
- Added typed `DaemonStatus` interface matching the actual server response shape (`uptime_seconds`, `entities.total/active`, `sessions.active`, `queue.pending/active`, `commander.state`)
- Added human-readable uptime formatting (e.g. "2d 5h 13m 4s")

## Test plan

- [x] Type-checks cleanly against the CLI tsconfig
- [x] Existing CLI tests pass (`npx vitest run`)
- [ ] Manual: run `lf status` with daemon running, verify uptime/entities/sessions/queue/commander all display correctly
- [ ] Manual: run `lf status` with daemon stopped, verify "not running" message still works

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)