### PR TITLE
fix: quote interpolated values in tmux command construction

### DIFF
--- a/packages/daemon/src/__tests__/shell.test.ts
+++ b/packages/daemon/src/__tests__/shell.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { sq } from "../shell.js";
+
+describe("sq (shell quote)", () => {
+  it("wraps a simple string in single quotes", () => {
+    expect(sq("hello")).toBe("'hello'");
+  });
+
+  it("handles paths with spaces", () => {
+    expect(sq("/Users/farm/my project/dir")).toBe("'/Users/farm/my project/dir'");
+  });
+
+  it("escapes embedded single quotes", () => {
+    expect(sq("it's")).toBe("'it'\\''s'");
+  });
+
+  it("handles empty string", () => {
+    expect(sq("")).toBe("''");
+  });
+
+  it("handles shell metacharacters safely", () => {
+    // All of these are inert inside single quotes
+    expect(sq('$(rm -rf /)')).toBe("'$(rm -rf /)'");
+    expect(sq('`whoami`')).toBe("'`whoami`'");
+    expect(sq('foo; bar')).toBe("'foo; bar'");
+    expect(sq('a && b')).toBe("'a && b'");
+    expect(sq('$HOME')).toBe("'$HOME'");
+  });
+
+  it("handles multiple single quotes", () => {
+    expect(sq("a'b'c")).toBe("'a'\\''b'\\''c'");
+  });
+});

--- a/packages/daemon/src/commander-process.ts
+++ b/packages/daemon/src/commander-process.ts
@@ -6,6 +6,7 @@ import { readFile } from "node:fs/promises";
 import type { LobsterFarmConfig } from "@lobster-farm/shared";
 import { lobsterfarm_dir } from "@lobster-farm/shared";
 import { resolve_model_id } from "./models.js";
+import { sq } from "./shell.js";
 
 export interface CommanderHealth {
   state: "stopped" | "starting" | "running" | "crashed";
@@ -109,13 +110,13 @@ export class CommanderProcess extends EventEmitter {
     const working_dir = lobsterfarm_dir(this.config.paths);
 
     const claude_cmd = [
-      claude_bin,
+      sq(claude_bin),
       "--channels", "plugin:discord@claude-plugins-official",
-      "--agent", agent_name,
+      "--agent", sq(agent_name),
       "--model", resolve_model_id(this.config.defaults.models.planning),
       "--permission-mode", "bypassPermissions",
-      "--add-dir", working_dir,
-      "--add-dir", homedir(),
+      "--add-dir", sq(working_dir),
+      "--add-dir", sq(homedir()),
     ].join(" ");
 
     console.log(`[commander] Starting ${agent_name} in tmux session "${TMUX_SESSION}"...`);
@@ -126,7 +127,7 @@ export class CommanderProcess extends EventEmitter {
       "new-session", "-d",
       "-s", TMUX_SESSION,
       "-x", "200", "-y", "50",
-      `DISCORD_STATE_DIR=${this.state_dir()} GIT_AUTHOR_NAME="Pat (LobsterFarm)" GIT_AUTHOR_EMAIL="pat@lobsterfarm.dev" GIT_COMMITTER_NAME="Pat (LobsterFarm)" GIT_COMMITTER_EMAIL="pat@lobsterfarm.dev" ${claude_cmd}`,
+      `DISCORD_STATE_DIR=${sq(this.state_dir())} GIT_AUTHOR_NAME=${sq("Pat (LobsterFarm)")} GIT_AUTHOR_EMAIL=${sq("pat@lobsterfarm.dev")} GIT_COMMITTER_NAME=${sq("Pat (LobsterFarm)")} GIT_COMMITTER_EMAIL=${sq("pat@lobsterfarm.dev")} ${claude_cmd}`,
     ], {
       cwd: working_dir,
       stdio: "ignore",

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -9,6 +9,7 @@ import type { ChannelType } from "@lobster-farm/shared";
 import { save_pool_state, load_pool_state } from "./persistence.js";
 import type { PersistedPoolBot } from "./persistence.js";
 import type { EntityRegistry } from "./registry.js";
+import { sq } from "./shell.js";
 
 // ── Types ──
 
@@ -678,17 +679,17 @@ export class BotPool extends EventEmitter {
     const agent_name = resolve_agent_name(archetype, this.config);
 
     const claude_args = [
-      claude_bin,
+      sq(claude_bin),
       "--channels", "plugin:discord@claude-plugins-official",
-      "--agent", agent_name,
+      "--agent", sq(agent_name),
       "--model", "claude-opus-4-6",
       "--permission-mode", "bypassPermissions",
-      "--add-dir", working_dir,
-      "--add-dir", homedir(),
+      "--add-dir", sq(working_dir),
+      "--add-dir", sq(homedir()),
     ];
 
     if (resume_session_id) {
-      claude_args.push("--resume", resume_session_id);
+      claude_args.push("--resume", sq(resume_session_id));
     }
 
     // Note: entity context is NOT injected via --append-system-prompt for pool bots.
@@ -696,7 +697,7 @@ export class BotPool extends EventEmitter {
     // naturally via CLAUDE.md, skills, and entity memory in the working directory.
 
     const display_name = resolve_agent_display_name(archetype, this.config);
-    const git_env = `GIT_AUTHOR_NAME="${display_name} (LobsterFarm)" GIT_AUTHOR_EMAIL="${agent_name}@lobsterfarm.dev" GIT_COMMITTER_NAME="${display_name} (LobsterFarm)" GIT_COMMITTER_EMAIL="${agent_name}@lobsterfarm.dev"`;
+    const git_env = `GIT_AUTHOR_NAME=${sq(`${display_name} (LobsterFarm)`)} GIT_AUTHOR_EMAIL=${sq(`${agent_name}@lobsterfarm.dev`)} GIT_COMMITTER_NAME=${sq(`${display_name} (LobsterFarm)`)} GIT_COMMITTER_EMAIL=${sq(`${agent_name}@lobsterfarm.dev`)}`;
     const claude_cmd = claude_args.join(" ");
 
     return new Promise<void>((resolve, reject) => {
@@ -704,7 +705,7 @@ export class BotPool extends EventEmitter {
         "new-session", "-d",
         "-s", bot.tmux_session,
         "-x", "200", "-y", "50",
-        `DISCORD_STATE_DIR=${bot.state_dir} ${git_env} ${claude_cmd}`,
+        `DISCORD_STATE_DIR=${sq(bot.state_dir)} ${git_env} ${claude_cmd}`,
       ], {
         cwd: working_dir,
         stdio: "ignore",

--- a/packages/daemon/src/shell.ts
+++ b/packages/daemon/src/shell.ts
@@ -1,0 +1,11 @@
+/**
+ * Shell-quote a string for safe interpolation into a shell command.
+ * Wraps the value in single quotes and escapes any embedded single quotes
+ * using the standard '\'' idiom (end quote, escaped literal quote, restart quote).
+ *
+ * This is the safest general-purpose quoting strategy — single-quoted strings
+ * in POSIX shells treat every character literally except the single quote itself.
+ */
+export function sq(value: string): string {
+  return "'" + value.replace(/'/g, "'\\''") + "'";
+}


### PR DESCRIPTION
## Summary

- Add `sq()` shell-quoting helper (`packages/daemon/src/shell.ts`) that wraps values in POSIX single quotes, escaping embedded single quotes with the `'\''` idiom
- Apply `sq()` to all interpolated values in tmux `new-session` command strings in `pool.ts` and `commander-process.ts` -- paths, agent names, env var values, and the claude binary path
- Add test coverage for the `sq()` helper covering spaces, metacharacters, embedded quotes, and empty strings

## Test plan

- [x] All 269 existing daemon tests pass (16 test files)
- [x] 6 new tests for `sq()` helper covering edge cases (empty string, spaces, shell metacharacters, embedded single quotes)
- [ ] Verify pool bot tmux sessions still start correctly in staging

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)