### PR TITLE
fix: guard against duplicate feature creation

### DIFF
--- a/packages/daemon/src/__tests__/features.test.ts
+++ b/packages/daemon/src/__tests__/features.test.ts
@@ -256,6 +256,83 @@ describe("FeatureManager", () => {
     });
   });
 
+  describe("duplicate feature guard", () => {
+    it("rejects duplicate creation when existing feature is active", async () => {
+      await fm.create_feature({
+        entity_id: "alpha",
+        title: "Active Feature",
+        github_issue: 100,
+      });
+
+      // Same entity + issue should be rejected because the feature is in "plan" (active)
+      await expect(
+        fm.create_feature({
+          entity_id: "alpha",
+          title: "Active Feature Again",
+          github_issue: 100,
+        }),
+      ).rejects.toThrow('Feature "alpha-100" already exists and is active (phase: plan)');
+    });
+
+    it("rejects duplicate during non-terminal phases: build", async () => {
+      const feature = await fm.create_feature({
+        entity_id: "alpha",
+        title: "Building Feature",
+        github_issue: 101,
+      });
+      // Simulate advancing to build phase
+      feature.phase = "build";
+
+      await expect(
+        fm.create_feature({
+          entity_id: "alpha",
+          title: "Building Feature Dup",
+          github_issue: 101,
+        }),
+      ).rejects.toThrow('Feature "alpha-101" already exists and is active (phase: build)');
+    });
+
+    it("allows re-creation after feature reaches done", async () => {
+      const original = await fm.create_feature({
+        entity_id: "alpha",
+        title: "Completed Feature",
+        github_issue: 102,
+      });
+      // Simulate the feature reaching terminal state
+      original.phase = "done";
+
+      const recreated = await fm.create_feature({
+        entity_id: "alpha",
+        title: "Completed Feature v2",
+        github_issue: 102,
+      });
+
+      expect(recreated.id).toBe("alpha-102");
+      expect(recreated.phase).toBe("plan");
+      expect(recreated.title).toBe("Completed Feature v2");
+    });
+
+    it("re-created feature replaces the old one in the map", async () => {
+      const original = await fm.create_feature({
+        entity_id: "alpha",
+        title: "Original",
+        github_issue: 103,
+      });
+      original.phase = "done";
+
+      await fm.create_feature({
+        entity_id: "alpha",
+        title: "Replacement",
+        github_issue: 103,
+      });
+
+      const features = fm.get_features_by_entity("alpha");
+      const matching = features.filter((f) => f.githubIssue === 103);
+      expect(matching).toHaveLength(1);
+      expect(matching[0]!.title).toBe("Replacement");
+    });
+  });
+
   describe("approve_phase", () => {
     it("approves a gated phase", async () => {
       await fm.create_feature({ entity_id: "alpha", title: "Test", github_issue: 1 });

--- a/packages/daemon/src/features.ts
+++ b/packages/daemon/src/features.ts
@@ -213,6 +213,24 @@ export class FeatureManager extends EventEmitter {
     }
 
     const id = `${opts.entity_id}-${String(opts.github_issue)}`;
+
+    // Guard against duplicate creation.
+    // If the feature already exists and is active, reject the request to avoid
+    // orphaning an in-progress session or pool bot assignment.
+    // If the feature is in a terminal state ("done"), allow re-creation by
+    // removing the old entry first.
+    const existing = this.features.get(id);
+    if (existing) {
+      if (existing.phase === "done") {
+        this.features.delete(id);
+      } else {
+        throw new Error(
+          `Feature "${id}" already exists and is active (phase: ${existing.phase}). ` +
+            `Finish or remove the existing feature before re-creating it.`,
+        );
+      }
+    }
+
     const branch = `feature/${String(opts.github_issue)}-${slugify(opts.title)}`;
     const depends_on = opts.depends_on ?? [];
 


### PR DESCRIPTION
## Summary

- `create_feature` now checks `this.features.has(id)` before inserting a new feature
- If the existing feature is in a terminal state (`phase === "done"`), the old entry is removed and re-creation proceeds normally
- If the existing feature is active (any non-terminal phase), throws an error with the current phase to prevent orphaning in-progress sessions or pool bot assignments

## Test plan

- [x] Test that duplicate creation of an active feature throws (tested in `plan` and `build` phases)
- [x] Test that re-creation after terminal state (`done`) succeeds with fresh state
- [x] Test that the re-created feature replaces the old one (no duplicates in the map)
- [x] Full daemon test suite passes (267 tests)

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)