### PR TITLE
refactor: queue-based persistence for feature state

### DIFF
--- a/packages/daemon/src/__tests__/persist-queue.test.ts
+++ b/packages/daemon/src/__tests__/persist-queue.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { PersistQueue } from "../persist-queue.js";
+
+/** Zero-delay retries for tests that exercise retry logic. */
+const FAST_RETRIES = { retry_delays: [0, 0, 0] as const };
+
+describe("PersistQueue", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("enqueue triggers persist", async () => {
+    const persist_fn = vi.fn().mockResolvedValue(undefined);
+    const queue = new PersistQueue(persist_fn);
+
+    queue.enqueue();
+    await queue.drain();
+
+    expect(persist_fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("multiple rapid enqueues collapse into fewer writes", async () => {
+    // persist_fn takes time so we can stack up enqueues while it's writing.
+    let resolve_write: (() => void) | null = null;
+    const persist_fn = vi.fn().mockImplementation(
+      () => new Promise<void>((resolve) => { resolve_write = resolve; }),
+    );
+
+    const queue = new PersistQueue(persist_fn);
+
+    // First enqueue starts the write immediately.
+    queue.enqueue();
+
+    // These three enqueues happen while the first write is in progress.
+    // They should collapse into a single follow-up write.
+    queue.enqueue();
+    queue.enqueue();
+    queue.enqueue();
+
+    // Complete the first write.
+    resolve_write!();
+    // Yield so the queue can start the next write.
+    await tick();
+
+    // Should have started the coalesced second write.
+    expect(persist_fn).toHaveBeenCalledTimes(2);
+
+    // Complete the second write.
+    resolve_write!();
+    await queue.drain();
+
+    // Still only 2 writes total — all the rapid enqueues collapsed.
+    expect(persist_fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on failure then succeeds", async () => {
+    const persist_fn = vi.fn()
+      .mockRejectedValueOnce(new Error("disk full"))
+      .mockRejectedValueOnce(new Error("disk full"))
+      .mockResolvedValue(undefined);
+
+    const queue = new PersistQueue(persist_fn, FAST_RETRIES);
+
+    queue.enqueue();
+    await queue.drain();
+
+    // Initial attempt + 2 retries + 1 success = 3 calls
+    // (first attempt fails, retry 1 fails, retry 2 succeeds)
+    expect(persist_fn).toHaveBeenCalledTimes(3);
+    expect(queue.failure_count).toBe(0);
+  });
+
+  it("logs CRITICAL after 3 consecutive total failures", async () => {
+    const error_spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // Always fails — 1 initial + 3 retries = 4 calls per enqueue, all fail.
+    const persist_fn = vi.fn().mockRejectedValue(new Error("disk full"));
+    const queue = new PersistQueue(persist_fn, FAST_RETRIES);
+
+    // Each enqueue will exhaust retries and increment consecutive_failures.
+    // We need 3 consecutive top-level failures (not retries) for CRITICAL.
+    queue.enqueue();
+    await queue.drain();
+    expect(queue.failure_count).toBe(1);
+
+    queue.enqueue();
+    await queue.drain();
+    expect(queue.failure_count).toBe(2);
+
+    queue.enqueue();
+    await queue.drain();
+    expect(queue.failure_count).toBe(3);
+
+    // The third failure should have logged CRITICAL
+    const critical_calls = error_spy.mock.calls.filter(
+      (args) => typeof args[0] === "string" && args[0].includes("CRITICAL"),
+    );
+    expect(critical_calls.length).toBe(1);
+    expect(critical_calls[0]![0]).toContain("3 consecutive persist failures");
+  });
+
+  it("resets consecutive failures on success", async () => {
+    const error_spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // First enqueue: all retries fail (4 calls).
+    // Second enqueue: succeeds on first try.
+    const persist_fn = vi.fn()
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockResolvedValue(undefined);
+
+    const queue = new PersistQueue(persist_fn, FAST_RETRIES);
+
+    queue.enqueue();
+    await queue.drain();
+    expect(queue.failure_count).toBe(1);
+
+    queue.enqueue();
+    await queue.drain();
+    expect(queue.failure_count).toBe(0);
+
+    error_spy.mockRestore();
+  });
+
+  it("drain resolves after pending writes complete", async () => {
+    let resolve_write: (() => void) | null = null;
+    const persist_fn = vi.fn().mockImplementation(
+      () => new Promise<void>((resolve) => { resolve_write = resolve; }),
+    );
+
+    const queue = new PersistQueue(persist_fn);
+
+    queue.enqueue();
+
+    let drained = false;
+    const drain_promise = queue.drain().then(() => { drained = true; });
+
+    // drain should not have resolved yet — write is in progress.
+    await tick();
+    expect(drained).toBe(false);
+
+    // Complete the write.
+    resolve_write!();
+    await drain_promise;
+
+    expect(drained).toBe(true);
+  });
+
+  it("drain resolves immediately when queue is empty", async () => {
+    const persist_fn = vi.fn().mockResolvedValue(undefined);
+    const queue = new PersistQueue(persist_fn);
+
+    // No enqueue — drain should resolve immediately.
+    await queue.drain();
+
+    expect(persist_fn).not.toHaveBeenCalled();
+  });
+
+  it("drain waits for coalesced write too", async () => {
+    let resolve_write: (() => void) | null = null;
+    const persist_fn = vi.fn().mockImplementation(
+      () => new Promise<void>((resolve) => { resolve_write = resolve; }),
+    );
+
+    const queue = new PersistQueue(persist_fn);
+
+    queue.enqueue();
+    queue.enqueue(); // coalesced
+
+    let drained = false;
+    const drain_promise = queue.drain().then(() => { drained = true; });
+
+    // Complete the first write — coalesced write should start.
+    resolve_write!();
+    await tick();
+    expect(drained).toBe(false);
+    expect(persist_fn).toHaveBeenCalledTimes(2);
+
+    // Complete the coalesced write.
+    resolve_write!();
+    await drain_promise;
+    expect(drained).toBe(true);
+  });
+});
+
+/** Yield to the microtask queue so pending promises resolve. */
+function tick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}

--- a/packages/daemon/src/features.ts
+++ b/packages/daemon/src/features.ts
@@ -18,6 +18,7 @@ import type { SessionResult } from "./session.js";
 import * as actions from "./actions.js";
 import { save_features, load_features, append_session_log } from "./persistence.js";
 import { extract_session_learnings } from "./hooks.js";
+import { PersistQueue } from "./persist-queue.js";
 
 // ── Phase configuration ──
 
@@ -143,6 +144,8 @@ export class FeatureManager extends EventEmitter {
   /** Optional pool reference — set via set_pool() after construction. */
   private pool: BotPool | null = null;
 
+  private persist_queue: PersistQueue;
+
   constructor(
     private registry: EntityRegistry,
     private queue: TaskQueue,
@@ -150,8 +153,15 @@ export class FeatureManager extends EventEmitter {
   ) {
     super();
 
+    this.persist_queue = new PersistQueue(() => this.persist());
+
     // When the queue drains (a task completes), retry features blocked due to queue-full
     this.queue.on("drain", () => this.retry_queue_blocked());
+  }
+
+  /** Drain the persist queue. Call during graceful shutdown. */
+  drain_persist(): Promise<void> {
+    return this.persist_queue.drain();
   }
 
   /**
@@ -313,7 +323,7 @@ export class FeatureManager extends EventEmitter {
     );
 
     // Persist after entry actions so worktreePath / discordWorkRoom are captured
-    void this.persist();
+    this.persist_queue.enqueue();
 
     this.emit("feature:created", feature);
     return feature;
@@ -333,7 +343,7 @@ export class FeatureManager extends EventEmitter {
 
     feature.approved = true;
     feature.updatedAt = new Date().toISOString();
-    void this.persist();
+    this.persist_queue.enqueue();
 
     console.log(`[features] Phase "${feature.phase}" approved for ${feature_id}`);
     this.emit("feature:approved", feature);
@@ -414,7 +424,7 @@ export class FeatureManager extends EventEmitter {
       }
     }
 
-    void this.persist();
+    this.persist_queue.enqueue();
     this.emit("feature:advanced", feature, old_phase);
 
     // When a feature reaches done, check if any blocked features can be unblocked
@@ -453,7 +463,7 @@ export class FeatureManager extends EventEmitter {
     feature.agentDone = true;
     feature.sessionId = null;
     feature.updatedAt = new Date().toISOString();
-    void this.persist();
+    this.persist_queue.enqueue();
 
     console.log(
       `[features] Agent completed for ${feature_id} (phase: ${feature.phase})`,
@@ -504,7 +514,7 @@ export class FeatureManager extends EventEmitter {
       console.error(`[features] Review completed for ${feature.id} but no PR number -- blocking`);
       feature.blocked = true;
       feature.blockedReason = "Review completed but no PR number to check";
-      void this.persist();
+      this.persist_queue.enqueue();
       return;
     }
 
@@ -546,7 +556,7 @@ export class FeatureManager extends EventEmitter {
         console.log(`[features] Reviewer completed for ${feature.id} without posting a decision -- blocking`);
         feature.blocked = true;
         feature.blockedReason = "Reviewer session completed without posting a review decision";
-        void this.persist();
+        this.persist_queue.enqueue();
         this.emit("feature:blocked", feature, feature.blockedReason);
         break;
     }
@@ -565,7 +575,7 @@ export class FeatureManager extends EventEmitter {
     feature.blockedReason = error;
     feature.sessionId = null;
     feature.updatedAt = new Date().toISOString();
-    void this.persist();
+    this.persist_queue.enqueue();
 
     console.error(`[features] Session failed for ${feature_id}: ${error}`);
     this.emit("feature:blocked", feature, error);
@@ -579,7 +589,7 @@ export class FeatureManager extends EventEmitter {
     feature.blocked = false;
     feature.blockedReason = null;
     feature.updatedAt = new Date().toISOString();
-    void this.persist();
+    this.persist_queue.enqueue();
     return feature;
   }
 
@@ -621,7 +631,7 @@ export class FeatureManager extends EventEmitter {
       this.emit("feature:unblocked", feature);
     }
 
-    void this.persist();
+    this.persist_queue.enqueue();
   }
 
   /**
@@ -648,7 +658,7 @@ export class FeatureManager extends EventEmitter {
 
       // spawn_phase_agent will re-block if the queue is still full
       void this.spawn_phase_agent(feature, phase_config);
-      void this.persist();
+      this.persist_queue.enqueue();
     }
   }
 
@@ -676,7 +686,7 @@ export class FeatureManager extends EventEmitter {
 
       // spawn_phase_agent will re-block if pool is still full
       void this.spawn_phase_agent(feature, phase_config);
-      void this.persist();
+      this.persist_queue.enqueue();
     }
   }
 
@@ -724,7 +734,7 @@ export class FeatureManager extends EventEmitter {
 
     if (feature.phase !== "build") {
       // Not in build phase — just clean up, don't try to advance
-      void this.persist();
+      this.persist_queue.enqueue();
       return;
     }
 
@@ -743,7 +753,7 @@ export class FeatureManager extends EventEmitter {
         // PR exists — advance to review
         feature.prNumber = pr_number;
         console.log(`[features] Builder exited with PR #${String(pr_number)} for ${feature.id} -- advancing to review`);
-        void this.persist();
+        this.persist_queue.enqueue();
 
         try {
           await this.advance_feature(feature.id, "review");
@@ -765,7 +775,7 @@ export class FeatureManager extends EventEmitter {
       entity,
       { also_alerts: true },
     );
-    void this.persist();
+    this.persist_queue.enqueue();
   }
 
   /**
@@ -871,7 +881,7 @@ export class FeatureManager extends EventEmitter {
         feature.blocked = true;
         feature.blockedReason = "Queue full -- will retry when capacity frees up";
         feature.updatedAt = new Date().toISOString();
-        void this.persist();
+        this.persist_queue.enqueue();
 
         console.log(`[features] Queue full -- ${feature.id} blocked, will retry on drain`);
         this.emit("feature:blocked", feature, feature.blockedReason);
@@ -939,7 +949,7 @@ export class FeatureManager extends EventEmitter {
       feature.blocked = true;
       feature.blockedReason = "No pool bots available -- will retry when one is freed";
       feature.updatedAt = new Date().toISOString();
-      void this.persist();
+      this.persist_queue.enqueue();
 
       console.log(`[features] No pool bots available -- ${feature.id} blocked, will retry on release`);
       this.emit("feature:blocked", feature, feature.blockedReason);
@@ -989,7 +999,7 @@ export class FeatureManager extends EventEmitter {
       );
     }
 
-    void this.persist();
+    this.persist_queue.enqueue();
   }
 
   /**

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -270,6 +270,9 @@ async function main(): Promise<void> {
     // from the CLI side before unloading the service.
     pool.stop_health_monitor();
 
+    // Drain the feature persist queue so pending state writes complete before exit
+    await feature_manager.drain_persist();
+
     // Stop Commander
     await commander.stop();
 

--- a/packages/daemon/src/persist-queue.ts
+++ b/packages/daemon/src/persist-queue.ts
@@ -1,0 +1,141 @@
+/**
+ * Queue-based persistence with retry and deduplication.
+ *
+ * Mutations remain non-blocking — callers call enqueue() and move on.
+ * The queue processes one write at a time, deduplicating if multiple
+ * mutations stack up before the first write completes (since we always
+ * persist the full current state, not individual mutations).
+ */
+
+/** Default exponential backoff delays for retries (ms). */
+const DEFAULT_RETRY_DELAYS: readonly number[] = [100, 400, 1600];
+
+export interface PersistQueueOptions {
+  /** Override retry backoff delays (ms). Defaults to [100, 400, 1600]. */
+  retry_delays?: readonly number[];
+}
+
+export class PersistQueue {
+  private writing = false;
+  private pending = false;
+  private consecutive_failures = 0;
+  private retry_delays: readonly number[];
+
+  /**
+   * Resolvers for drain() callers waiting on the queue to finish.
+   * Collected while writes are in progress, resolved when the queue empties.
+   */
+  private drain_resolvers: Array<() => void> = [];
+
+  constructor(
+    private persist_fn: () => Promise<void>,
+    opts?: PersistQueueOptions,
+  ) {
+    this.retry_delays = opts?.retry_delays ?? DEFAULT_RETRY_DELAYS;
+  }
+
+  /**
+   * Schedule a persist. Returns immediately — the write happens asynchronously.
+   * If a write is already in progress, the request is coalesced into a single
+   * follow-up write (since we persist full state, not deltas).
+   */
+  enqueue(): void {
+    if (this.writing) {
+      // A write is in progress — mark that we need another one after it finishes.
+      this.pending = true;
+      return;
+    }
+
+    void this.process();
+  }
+
+  /**
+   * Wait for all pending writes to complete. Resolves immediately if the
+   * queue is idle. Use during graceful shutdown to ensure no data is lost.
+   */
+  drain(): Promise<void> {
+    if (!this.writing && !this.pending) {
+      return Promise.resolve();
+    }
+
+    return new Promise<void>((resolve) => {
+      this.drain_resolvers.push(resolve);
+    });
+  }
+
+  /** Number of consecutive persist failures (for monitoring). */
+  get failure_count(): number {
+    return this.consecutive_failures;
+  }
+
+  // ── Internal ──
+
+  private async process(): Promise<void> {
+    this.writing = true;
+    this.pending = false;
+
+    try {
+      await this.write_with_retry();
+      this.consecutive_failures = 0;
+    } catch {
+      // Retries exhausted — already logged in write_with_retry.
+      // consecutive_failures is incremented there.
+    }
+
+    this.writing = false;
+
+    // If enqueue() was called while we were writing, process the coalesced write.
+    if (this.pending) {
+      void this.process();
+      return;
+    }
+
+    // Queue is empty — resolve any drain() waiters.
+    this.flush_drain_resolvers();
+  }
+
+  private async write_with_retry(): Promise<void> {
+    const max_retries = this.retry_delays.length;
+
+    for (let attempt = 0; attempt <= max_retries; attempt++) {
+      try {
+        await this.persist_fn();
+        return;
+      } catch (err) {
+        if (attempt < max_retries) {
+          const delay = this.retry_delays[attempt]!;
+          await sleep(delay);
+        } else {
+          // All retries exhausted.
+          this.consecutive_failures++;
+          const msg = err instanceof Error ? err.message : String(err);
+
+          if (this.consecutive_failures >= 3) {
+            console.error(
+              `[persist-queue] CRITICAL: ${String(this.consecutive_failures)} consecutive persist failures. ` +
+                `Latest: ${msg}`,
+            );
+          } else {
+            console.error(
+              `[persist-queue] Persist failed after ${String(max_retries)} retries: ${msg}`,
+            );
+          }
+
+          throw err;
+        }
+      }
+    }
+  }
+
+  private flush_drain_resolvers(): void {
+    const resolvers = this.drain_resolvers;
+    this.drain_resolvers = [];
+    for (const resolve of resolvers) {
+      resolve();
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Summary

- Add `PersistQueue` utility (`persist-queue.ts`) that replaces all 17 `void this.persist()` fire-and-forget calls in `features.ts` with a queued, retry-capable persistence mechanism
- Writes are non-blocking (callers call `enqueue()` and move on), deduplicated (multiple mutations while a write is in progress collapse into one follow-up write), and retried with exponential backoff (100ms, 400ms, 1600ms) before logging a CRITICAL warning after 3 consecutive failures
- Wire `drain_persist()` into the daemon shutdown handler so pending writes complete before exit

## Test plan

- [x] `enqueue()` triggers a persist call
- [x] Multiple rapid enqueues collapse into fewer writes (deduplication)
- [x] Retry on failure (mock persist_fn that fails then succeeds)
- [x] CRITICAL warning after 3 consecutive failures
- [x] Consecutive failure counter resets on success
- [x] `drain()` resolves after pending writes complete
- [x] `drain()` resolves immediately when queue is empty
- [x] `drain()` waits for coalesced writes too
- [ ] Verify `pr-cron.ts` was intentionally left unchanged (its `persist_review_completion` does more than pure state persistence)

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)