### PR TITLE
fix: deduplicate pool channel claims on initialize

### DIFF
--- a/packages/daemon/src/__tests__/pool-persistence.test.ts
+++ b/packages/daemon/src/__tests__/pool-persistence.test.ts
@@ -697,4 +697,62 @@ describe("BotPool persistence", () => {
       expect(bot3.channel_id).toBeNull();
     });
   });
+
+  describe("channel deduplication on initialize", () => {
+    // Use high pool IDs (50+) to avoid collisions with real tmux sessions on the host
+    it("frees duplicate parked bots claiming the same channel", async () => {
+      const config = make_config();
+
+      for (const id of [50, 51, 52]) {
+        const dir = join(temp_dir, "channels", `pool-${String(id)}`);
+        await mkdir(dir, { recursive: true });
+        await writeFile(join(dir, ".env"), `DISCORD_BOT_TOKEN=fake-token-${String(id)}`);
+      }
+
+      // Persist state: pool-50 and pool-51 both claim the same channel (from a prior race)
+      await save_pool_state([
+        make_persisted_bot({ id: 50, state: "parked", channel_id: "ch-duped", entity_id: "e1", archetype: "planner" }),
+        make_persisted_bot({ id: 51, state: "parked", channel_id: "ch-duped", entity_id: "e1", archetype: "planner" }),
+      ], config);
+
+      const pool = new TestBotPool(config);
+      await pool.initialize();
+
+      const bots = pool.get_bots();
+
+      // Pool-50 (lower ID, seen first) keeps the channel
+      const bot0 = bots.find(b => b.id === 50)!;
+      expect(bot0.state).toBe("parked");
+      expect(bot0.channel_id).toBe("ch-duped");
+
+      // Pool-51 (duplicate) is freed
+      const bot1 = bots.find(b => b.id === 51)!;
+      expect(bot1.state).toBe("free");
+      expect(bot1.channel_id).toBeNull();
+    });
+
+    it("keeps non-duplicate bots on different channels", async () => {
+      const config = make_config();
+
+      for (const id of [50, 51]) {
+        const dir = join(temp_dir, "channels", `pool-${String(id)}`);
+        await mkdir(dir, { recursive: true });
+        await writeFile(join(dir, ".env"), `DISCORD_BOT_TOKEN=fake-token-${String(id)}`);
+      }
+
+      await save_pool_state([
+        make_persisted_bot({ id: 50, state: "parked", channel_id: "ch-a", entity_id: "e1", archetype: "planner" }),
+        make_persisted_bot({ id: 51, state: "parked", channel_id: "ch-b", entity_id: "e1", archetype: "builder" }),
+      ], config);
+
+      const pool = new TestBotPool(config);
+      await pool.initialize();
+
+      const bots = pool.get_bots();
+      expect(bots.find(b => b.id === 50)!.state).toBe("parked");
+      expect(bots.find(b => b.id === 50)!.channel_id).toBe("ch-a");
+      expect(bots.find(b => b.id === 51)!.state).toBe("parked");
+      expect(bots.find(b => b.id === 51)!.channel_id).toBe("ch-b");
+    });
+  });
 });

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -248,7 +248,31 @@ export class BotPool extends EventEmitter {
       console.log(`[pool] Restored ${String(restored)} bot assignment(s) from persisted state`);
     }
 
-    // Persist cleaned state (stale entries removed, current snapshot)
+    // Deduplicate: if multiple bots claim the same channel (from a prior race condition),
+    // keep only the first (lowest pool-id) and free the rest. This prevents stale
+    // persisted state from causing duplicate assignments on restart.
+    const seen_channels = new Set<string>();
+    for (const bot of this.bots) {
+      if (bot.state === "free" || !bot.channel_id) continue;
+      if (seen_channels.has(bot.channel_id)) {
+        console.log(
+          `[pool] Dedup: pool-${String(bot.id)} has duplicate claim on channel ${bot.channel_id} — freeing`,
+        );
+        bot.state = "free";
+        bot.channel_id = null;
+        bot.entity_id = null;
+        bot.archetype = null;
+        bot.channel_type = null;
+        bot.session_id = null;
+        bot.last_active = null;
+        // Clear the stale access.json so the bot doesn't listen on the old channel
+        await this.write_access_json(bot.state_dir, null);
+      } else {
+        seen_channels.add(bot.channel_id);
+      }
+    }
+
+    // Persist cleaned state (stale entries removed, duplicates resolved, current snapshot)
     await this.persist();
 
     console.log(
@@ -459,7 +483,10 @@ export class BotPool extends EventEmitter {
   private async park_bot(bot: PoolBot): Promise<void> {
     this.kill_tmux(bot.tmux_session);
     bot.state = "parked";
-    // session_id, channel_id, entity_id, archetype preserved for resume
+    // session_id, channel_id, entity_id, archetype preserved for resume in memory.
+    // Clear access.json on disk so no stale channel config survives if the bot's
+    // tmux session is somehow restarted outside the normal assign() path.
+    await this.write_access_json(bot.state_dir, null);
     await this.persist();
     console.log(
       `[pool] Parked pool-${String(bot.id)} ` +


### PR DESCRIPTION
## Summary
- **Channel dedup in `initialize()`**: When restoring persisted state, if multiple bots claim the same channel (from a prior race condition like the one fixed in #52), only the first (lowest pool-id) is kept — the rest are freed and their access.json is cleared.
- **Clear access.json on `park_bot()`**: Parked bots no longer retain stale channel configs on disk. When a parked bot is reclaimed via `assign()`, a fresh access.json is written anyway.
- **Immediate cleanup**: Pool-1's stale access.json (which still had the lobster-farm #general channel from the prior double-assignment) has been manually cleared.

## Context
PR #52 fixed the concurrent `assign()` race that caused two bots to be assigned to the same channel. This PR hardens the restart path — if stale duplicate entries already exist in `pool-state.json` from before the race fix, `initialize()` now resolves them instead of restoring both as parked.

## Test plan
- [x] New test: duplicate parked bots claiming same channel → first kept, second freed
- [x] New test: non-duplicate bots on different channels → both kept
- [x] All 277 daemon tests pass (275 existing + 2 new)

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)