### PR TITLE
feat: proactive bot resume on daemon startup

### DIFF
--- a/packages/daemon/src/__tests__/pool-persistence.test.ts
+++ b/packages/daemon/src/__tests__/pool-persistence.test.ts
@@ -57,6 +57,10 @@ class TestBotPool extends BotPool {
     return (this as unknown as { bots: PoolBot[] }).bots;
   }
 
+  get_resume_candidates(): PersistedPoolBot[] {
+    return (this as unknown as { resume_candidates: PersistedPoolBot[] }).resume_candidates;
+  }
+
   set_bot_idle(bot_id: number, idle: boolean): void {
     this.idle_overrides.set(bot_id, idle);
   }
@@ -815,6 +819,308 @@ describe("BotPool persistence", () => {
       // Free bot: access.json also cleared
       const access61 = JSON.parse(await readFile(join(temp_dir, "channels", "pool-61", "access.json"), "utf-8")) as Record<string, unknown>;
       expect(access61.groups).toEqual({});
+    });
+  });
+
+  describe("proactive resume on startup", () => {
+    /** Helper: seed pool-state.json, create pool-N dirs, and initialize a fresh pool. */
+    async function setup_resume_pool(
+      persisted: PersistedPoolBot[],
+      bot_ids: number[],
+      registry_entities?: EntityConfig[],
+    ): Promise<TestBotPool> {
+      const cfg = make_config();
+      await save_pool_state(persisted, cfg);
+
+      for (const id of bot_ids) {
+        const dir = join(temp_dir, "channels", `pool-${String(id)}`);
+        await mkdir(dir, { recursive: true });
+        await writeFile(join(dir, ".env"), `DISCORD_BOT_TOKEN=fake-token-${String(id)}`, "utf-8");
+      }
+
+      const p = new TestBotPool(cfg);
+      vi.spyOn(p as unknown as Record<string, unknown>, "is_tmux_alive" as never)
+        .mockReturnValue(false);
+      vi.spyOn(p as unknown as Record<string, unknown>, "kill_tmux" as never)
+        .mockImplementation(() => {});
+      vi.spyOn(p as unknown as Record<string, unknown>, "write_access_json" as never)
+        .mockResolvedValue(undefined);
+      vi.spyOn(p as unknown as Record<string, unknown>, "set_bot_nickname" as never)
+        .mockResolvedValue(undefined);
+      vi.spyOn(p as unknown as Record<string, unknown>, "start_tmux" as never)
+        .mockResolvedValue(undefined);
+
+      const reg = registry_entities
+        ? make_registry(registry_entities)
+        : undefined;
+
+      await p.initialize(reg);
+      return p;
+    }
+
+    it("resumes bot saved as 'assigned' with session_id", async () => {
+      const p = await setup_resume_pool(
+        [
+          make_persisted_bot({
+            id: 1,
+            state: "assigned",
+            channel_id: "ch-1",
+            entity_id: "test-entity",
+            archetype: "builder",
+            session_id: "sess-abc",
+          }),
+        ],
+        [1],
+        [make_entity_config("test-entity", ["ch-1"])],
+      );
+
+      // Should have one resume candidate
+      expect(p.get_resume_candidates()).toHaveLength(1);
+
+      // Track bot:resumed events
+      const events: Array<{ bot_id: number; channel_id: string; entity_id: string }> = [];
+      p.on("bot:resumed", (evt: { bot_id: number; channel_id: string; entity_id: string }) => events.push(evt));
+
+      await p.resume_parked_bots();
+
+      // Bot should now be assigned
+      const bots = p.get_bots();
+      const bot = bots.find(b => b.id === 1)!;
+      expect(bot.state).toBe("assigned");
+      expect(bot.channel_id).toBe("ch-1");
+      expect(bot.entity_id).toBe("test-entity");
+
+      // start_tmux called with --resume session_id
+      const start_tmux_spy = p["start_tmux" as keyof typeof p] as unknown as { mock: { calls: unknown[][] } };
+      const call = start_tmux_spy.mock.calls[0]!;
+      expect(call[4]).toBe("sess-abc"); // resume_session_id argument
+
+      // Event emitted
+      expect(events).toHaveLength(1);
+      expect(events[0]!.bot_id).toBe(1);
+      expect(events[0]!.channel_id).toBe("ch-1");
+
+      // Candidates cleared
+      expect(p.get_resume_candidates()).toHaveLength(0);
+    });
+
+    it("does NOT resume bot saved as 'parked'", async () => {
+      const p = await setup_resume_pool(
+        [
+          make_persisted_bot({
+            id: 1,
+            state: "parked",
+            channel_id: "ch-1",
+            entity_id: "test-entity",
+            archetype: "builder",
+            session_id: "sess-old",
+          }),
+        ],
+        [1],
+        [make_entity_config("test-entity", ["ch-1"])],
+      );
+
+      // No resume candidates — bot was already parked before shutdown
+      expect(p.get_resume_candidates()).toHaveLength(0);
+
+      const events: unknown[] = [];
+      p.on("bot:resumed", (evt: unknown) => events.push(evt));
+
+      await p.resume_parked_bots();
+
+      // Bot stays parked
+      const bots = p.get_bots();
+      expect(bots[0]!.state).toBe("parked");
+
+      // No events
+      expect(events).toHaveLength(0);
+    });
+
+    it("does NOT resume bot saved as 'assigned' with null session_id", async () => {
+      const p = await setup_resume_pool(
+        [
+          make_persisted_bot({
+            id: 1,
+            state: "assigned",
+            channel_id: "ch-1",
+            entity_id: "test-entity",
+            archetype: "builder",
+            session_id: null,
+          }),
+        ],
+        [1],
+        [make_entity_config("test-entity", ["ch-1"])],
+      );
+
+      // No resume candidates — can't --resume without a session_id
+      expect(p.get_resume_candidates()).toHaveLength(0);
+
+      await p.resume_parked_bots();
+
+      // Bot stays parked (not proactively resumed)
+      const bots = p.get_bots();
+      expect(bots[0]!.state).toBe("parked");
+    });
+
+    it("resumes multiple candidates", async () => {
+      const p = await setup_resume_pool(
+        [
+          make_persisted_bot({
+            id: 1,
+            state: "assigned",
+            channel_id: "ch-1",
+            entity_id: "entity-a",
+            archetype: "builder",
+            session_id: "sess-1",
+          }),
+          make_persisted_bot({
+            id: 2,
+            state: "assigned",
+            channel_id: "ch-2",
+            entity_id: "entity-b",
+            archetype: "planner",
+            session_id: "sess-2",
+          }),
+        ],
+        [1, 2],
+        [
+          make_entity_config("entity-a", ["ch-1"]),
+          make_entity_config("entity-b", ["ch-2"]),
+        ],
+      );
+
+      expect(p.get_resume_candidates()).toHaveLength(2);
+
+      const events: Array<{ bot_id: number; channel_id: string }> = [];
+      p.on("bot:resumed", (evt: { bot_id: number; channel_id: string }) => events.push(evt));
+
+      await p.resume_parked_bots();
+
+      // Both bots should be assigned
+      const bots = p.get_bots();
+      expect(bots.find(b => b.id === 1)!.state).toBe("assigned");
+      expect(bots.find(b => b.id === 2)!.state).toBe("assigned");
+
+      // Two events emitted
+      expect(events).toHaveLength(2);
+      expect(events.map(e => e.bot_id).sort()).toEqual([1, 2]);
+    });
+
+    it("after resume, persist() reflects correct assigned state", async () => {
+      const cfg = make_config();
+      const p = await setup_resume_pool(
+        [
+          make_persisted_bot({
+            id: 1,
+            state: "assigned",
+            channel_id: "ch-1",
+            entity_id: "test-entity",
+            archetype: "builder",
+            session_id: "sess-abc",
+          }),
+        ],
+        [1],
+        [make_entity_config("test-entity", ["ch-1"])],
+      );
+
+      await p.resume_parked_bots();
+
+      // Re-read persisted state from disk
+      const saved = await load_pool_state(cfg);
+      const bot_entry = saved.find(b => b.id === 1);
+      expect(bot_entry).toBeDefined();
+      expect(bot_entry!.state).toBe("assigned");
+      expect(bot_entry!.channel_id).toBe("ch-1");
+      expect(bot_entry!.session_id).toBe("sess-abc");
+    });
+
+    it("bot:resumed event fires with correct metadata", async () => {
+      const p = await setup_resume_pool(
+        [
+          make_persisted_bot({
+            id: 3,
+            state: "assigned",
+            channel_id: "ch-work",
+            entity_id: "ent-x",
+            archetype: "designer",
+            session_id: "sess-design",
+            channel_type: "work_room",
+          }),
+        ],
+        [3],
+        [make_entity_config("ent-x", ["ch-work"])],
+      );
+
+      const events: Array<{ bot_id: number; channel_id: string; entity_id: string }> = [];
+      p.on("bot:resumed", (evt: { bot_id: number; channel_id: string; entity_id: string }) => events.push(evt));
+
+      await p.resume_parked_bots();
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        bot_id: 3,
+        channel_id: "ch-work",
+        entity_id: "ent-x",
+      });
+    });
+
+    it("resume_candidates cleared after resume completes", async () => {
+      const p = await setup_resume_pool(
+        [
+          make_persisted_bot({
+            id: 1,
+            state: "assigned",
+            channel_id: "ch-1",
+            entity_id: "test-entity",
+            archetype: "builder",
+            session_id: "sess-abc",
+          }),
+        ],
+        [1],
+        [make_entity_config("test-entity", ["ch-1"])],
+      );
+
+      expect(p.get_resume_candidates()).toHaveLength(1);
+
+      await p.resume_parked_bots();
+
+      expect(p.get_resume_candidates()).toHaveLength(0);
+
+      // Calling again is a no-op
+      const events: unknown[] = [];
+      p.on("bot:resumed", (evt: unknown) => events.push(evt));
+      await p.resume_parked_bots();
+      expect(events).toHaveLength(0);
+    });
+
+    it("existing assign-on-message flow still works for non-resumed parked bots", async () => {
+      const p = await setup_resume_pool(
+        [
+          make_persisted_bot({
+            id: 1,
+            state: "parked",
+            channel_id: "ch-1",
+            entity_id: "test-entity",
+            archetype: "planner",
+            session_id: "sess-old",
+          }),
+        ],
+        [1],
+        [make_entity_config("test-entity", ["ch-1"])],
+      );
+
+      // Not a resume candidate
+      expect(p.get_resume_candidates()).toHaveLength(0);
+
+      // Simulate a message arriving — assign() should reclaim the parked bot
+      const assignment = await p.assign("ch-1", "test-entity", "planner", undefined, "general");
+      expect(assignment).not.toBeNull();
+      expect(assignment!.bot_id).toBe(1);
+      expect(assignment!.session_id).toBe("sess-old");
+
+      // Bot is now assigned
+      const bots = p.get_bots();
+      expect(bots[0]!.state).toBe("assigned");
     });
   });
 });

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -189,6 +189,19 @@ async function main(): Promise<void> {
     await reset_idle_work_room_topics(registry);
   }
 
+  // Proactively resume bots that were assigned before shutdown.
+  // Must happen after Discord connects so we can send "back online" notifications.
+  // Listen for bot:resumed events and notify each channel via the daemon bot.
+  pool.on("bot:resumed", ({ channel_id }: { channel_id: string }) => {
+    if (discord_connected) {
+      void discord.send(channel_id, "Session restored after daemon restart.");
+    }
+  });
+
+  if (discord_connected) {
+    await pool.resume_parked_bots();
+  }
+
   // Initialize Commander (persistent Claude Code session with Discord channel)
   const commander = new CommanderProcess(config);
   if (await commander.has_token()) {

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -112,6 +112,9 @@ export class BotPool extends EventEmitter {
   private releasing_channels = new Set<string>();
   private bot_user_ids = new Map<number, string>();
   private nickname_handler: NicknameHandler | null = null;
+  /** Bots that were actively assigned before shutdown and should be proactively resumed.
+   * Populated during initialize(), consumed by resume_parked_bots(). */
+  private resume_candidates: PersistedPoolBot[] = [];
 
   constructor(config: LobsterFarmConfig) {
     super();
@@ -206,6 +209,7 @@ export class BotPool extends EventEmitter {
     // Restore persisted assignments from last run
     const saved = await load_pool_state(this.config);
     let restored = 0;
+    this.resume_candidates = [];
 
     for (const entry of saved) {
       const bot = this.bots.find(b => b.id === entry.id);
@@ -239,6 +243,13 @@ export class BotPool extends EventEmitter {
         bot.channel_type = entry.channel_type;
         bot.session_id = entry.session_id;
         bot.last_active = entry.last_active ? new Date(entry.last_active) : null;
+
+        // If this bot was actively assigned (not already parked) before shutdown
+        // and has a session_id, it's a candidate for proactive resume.
+        // Bots saved as "parked" were already idle — don't resume those.
+        if (entry.state === "assigned" && entry.session_id) {
+          this.resume_candidates.push(entry);
+        }
       }
 
       restored++;
@@ -295,6 +306,69 @@ export class BotPool extends EventEmitter {
       `${String(this.bots.filter(b => b.state === "parked").length)} parked, ` +
       `${String(this.bots.filter(b => b.state === "assigned").length)} assigned)`,
     );
+  }
+
+  /**
+   * Proactively resume bots that were actively assigned before daemon shutdown.
+   * Call AFTER Discord is connected so notifications can be sent.
+   *
+   * For each resume candidate: write access.json, set nickname, start tmux
+   * with --resume, update state to assigned, emit bot:resumed.
+   * Clears resume_candidates when done (or on skip) to prevent stale state.
+   */
+  async resume_parked_bots(): Promise<void> {
+    if (this.resume_candidates.length === 0) return;
+
+    console.log(
+      `[pool] Proactively resuming ${String(this.resume_candidates.length)} bot(s) ` +
+      `that were assigned before shutdown`,
+    );
+
+    let resumed = 0;
+    for (const candidate of this.resume_candidates) {
+      const bot = this.bots.find(
+        b => b.id === candidate.id && b.state === "parked" && b.channel_id === candidate.channel_id,
+      );
+      if (!bot) continue;
+
+      try {
+        // Write access.json so the Discord plugin listens on this channel
+        await this.write_access_json(bot.state_dir, candidate.channel_id);
+
+        // Set Discord nickname to match the archetype
+        await this.set_bot_nickname(bot, candidate.archetype);
+
+        // Start tmux with --resume to restore the previous session
+        const working_dir = entity_dir(this.config.paths, candidate.entity_id);
+        await this.start_tmux(bot, candidate.archetype, candidate.entity_id, working_dir, candidate.session_id!);
+
+        // Update bot state to assigned
+        bot.state = "assigned";
+        bot.last_active = new Date();
+
+        resumed++;
+
+        this.emit("bot:resumed", {
+          bot_id: bot.id,
+          channel_id: bot.channel_id,
+          entity_id: bot.entity_id,
+        });
+      } catch (err) {
+        console.error(
+          `[pool] Failed to resume pool-${String(bot.id)}: ${String(err)}`,
+        );
+        // Leave the bot parked — it can still be resumed on next message
+      }
+    }
+
+    // Clear candidates regardless of success — prevents stale resumes
+    // if the daemon stays running through another restart cycle
+    this.resume_candidates = [];
+
+    if (resumed > 0) {
+      await this.persist();
+      console.log(`[pool] Proactively resumed ${String(resumed)} bot(s)`);
+    }
   }
 
   /** Assign a pool bot to a channel with a specific archetype. */


### PR DESCRIPTION
## Summary

- After daemon restart, bots that were actively assigned (saved as `"assigned"` with a `session_id` in pool-state.json) are now proactively resumed via `--resume {session_id}` instead of waiting for the user to message the channel
- Each resumed channel receives a `"Session restored after daemon restart."` notification sent via the daemon bot (not the pool bot)
- Bots saved as `"parked"` or `"assigned"` without a `session_id` remain parked and resume on next message as before

## Implementation

**`pool.ts`:**
- New `resume_candidates` field on BotPool, populated during `initialize()` when a bot's saved state was `"assigned"` but tmux is dead and `session_id` is present
- New `resume_parked_bots()` method iterates candidates, runs the assign flow (write access.json, set nickname, start_tmux with --resume, update state), emits `bot:resumed` event
- Candidates cleared after resume completes to prevent stale state

**`index.ts`:**
- `bot:resumed` event listener sends notification via daemon bot
- `pool.resume_parked_bots()` called after Discord connects; skipped entirely if Discord is not connected

## Test plan

- [x] Bot saved as `"assigned"` with session_id -> resumed on startup, tmux started with `--resume`
- [x] Bot saved as `"parked"` -> NOT resumed, stays parked
- [x] Bot saved as `"assigned"` with null session_id -> NOT resumed, stays parked
- [x] Multiple resume candidates -> all resumed
- [x] After resume, `pool.persist()` reflects correct assigned state
- [x] `bot:resumed` event fires with correct metadata
- [x] `resume_candidates` cleared after resume completes (no stale candidates)
- [x] Existing assign-on-message flow still works for non-resumed parked bots

All 295 tests pass (8 new tests added to pool-persistence.test.ts).

Closes #56

Generated with [Claude Code](https://claude.com/claude-code)