### PR TITLE
feat: preserve session history across pool bot evictions

### DIFF
--- a/packages/daemon/src/__tests__/pool-persistence.test.ts
+++ b/packages/daemon/src/__tests__/pool-persistence.test.ts
@@ -144,47 +144,53 @@ describe("save_pool_state / load_pool_state", () => {
 
     await save_pool_state(bots, config);
 
-    // Verify the file is valid JSON
+    // Verify the file is valid JSON with new format
     const raw = await readFile(join(temp_dir, "state", "pool-state.json"), "utf-8");
-    const parsed = JSON.parse(raw) as unknown;
-    expect(Array.isArray(parsed)).toBe(true);
-    expect(parsed).toHaveLength(2);
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    expect(parsed).toHaveProperty("bots");
+    expect(parsed).toHaveProperty("session_history");
+    expect(Array.isArray(parsed["bots"])).toBe(true);
+    expect(parsed["bots"]).toHaveLength(2);
 
     // Load it back
     const loaded = await load_pool_state(config);
-    expect(loaded).toHaveLength(2);
-    expect(loaded[0]!.id).toBe(1);
-    expect(loaded[0]!.state).toBe("assigned");
-    expect(loaded[0]!.session_id).toBe("sess-abc");
-    expect(loaded[1]!.id).toBe(3);
-    expect(loaded[1]!.state).toBe("parked");
-    expect(loaded[1]!.channel_type).toBe("work_room");
+    expect(loaded.bots).toHaveLength(2);
+    expect(loaded.bots[0]!.id).toBe(1);
+    expect(loaded.bots[0]!.state).toBe("assigned");
+    expect(loaded.bots[0]!.session_id).toBe("sess-abc");
+    expect(loaded.bots[1]!.id).toBe(3);
+    expect(loaded.bots[1]!.state).toBe("parked");
+    expect(loaded.bots[1]!.channel_type).toBe("work_room");
   });
 
-  it("returns empty array when file does not exist", async () => {
+  it("returns empty state when file does not exist", async () => {
     const config = make_config();
     const result = await load_pool_state(config);
-    expect(result).toEqual([]);
+    expect(result).toEqual({ bots: [], session_history: {} });
   });
 
-  it("returns empty array for malformed JSON", async () => {
+  it("returns empty state for malformed JSON", async () => {
     const config = make_config();
     const state_path = join(temp_dir, "state");
     await mkdir(state_path, { recursive: true });
     await writeFile(join(state_path, "pool-state.json"), "not valid json{{{", "utf-8");
 
     const result = await load_pool_state(config);
-    expect(result).toEqual([]);
+    expect(result).toEqual({ bots: [], session_history: {} });
   });
 
-  it("returns empty array when file contains a non-array JSON value", async () => {
+  it("backward compat: loads old-format plain array as bots-only", async () => {
     const config = make_config();
     const state_path = join(temp_dir, "state");
     await mkdir(state_path, { recursive: true });
-    await writeFile(join(state_path, "pool-state.json"), '{"not": "array"}', "utf-8");
+    // Old format: plain array of bots
+    const old_bots = [make_persisted_bot({ id: 1, session_id: "sess-old" })];
+    await writeFile(join(state_path, "pool-state.json"), JSON.stringify(old_bots), "utf-8");
 
     const result = await load_pool_state(config);
-    expect(result).toEqual([]);
+    expect(result.bots).toHaveLength(1);
+    expect(result.bots[0]!.session_id).toBe("sess-old");
+    expect(result.session_history).toEqual({});
   });
 
   it("creates state directory if missing", async () => {
@@ -194,7 +200,7 @@ describe("save_pool_state / load_pool_state", () => {
     await save_pool_state([make_persisted_bot({ id: 1 })], config);
 
     const loaded = await load_pool_state(config);
-    expect(loaded).toHaveLength(1);
+    expect(loaded.bots).toHaveLength(1);
   });
 });
 
@@ -245,7 +251,7 @@ describe("BotPool persistence", () => {
 
       const saved = await load_pool_state(config);
       // Bot 2 is still free — should NOT appear in persisted state
-      const ids = saved.map(b => b.id);
+      const ids = saved.bots.map(b => b.id);
       expect(ids).not.toContain(2); // free bot excluded
 
       // Bots 1 (now assigned), 3 (assigned), 4 (parked) should be persisted
@@ -254,7 +260,7 @@ describe("BotPool persistence", () => {
       expect(ids).toContain(4);
 
       // Verify no free bots leak through
-      for (const bot of saved) {
+      for (const bot of saved.bots) {
         expect(bot.state).not.toBe("free");
         expect(bot.channel_id).toBeTruthy();
         expect(bot.entity_id).toBeTruthy();
@@ -269,8 +275,8 @@ describe("BotPool persistence", () => {
 
       // Verify state was written to disk
       const saved = await load_pool_state(config);
-      expect(saved.length).toBeGreaterThanOrEqual(1);
-      const assigned = saved.find(b => b.channel_id === "ch-1");
+      expect(saved.bots.length).toBeGreaterThanOrEqual(1);
+      const assigned = saved.bots.find(b => b.channel_id === "ch-1");
       expect(assigned).toBeDefined();
       expect(assigned!.state).toBe("assigned");
       expect(assigned!.entity_id).toBe("e1");
@@ -293,7 +299,7 @@ describe("BotPool persistence", () => {
 
       const saved = await load_pool_state(config);
       // After release, bot should be free — not in persisted state
-      const released = saved.find(b => b.id === 1);
+      const released = saved.bots.find(b => b.id === 1);
       expect(released).toBeUndefined();
     });
 
@@ -329,7 +335,7 @@ describe("BotPool persistence", () => {
 
       const saved = await load_pool_state(config);
       // The bot should now be assigned to ch-new
-      const bot = saved.find(b => b.id === 1);
+      const bot = saved.bots.find(b => b.id === 1);
       expect(bot).toBeDefined();
       expect(bot!.channel_id).toBe("ch-new");
       expect(bot!.state).toBe("assigned");
@@ -558,9 +564,9 @@ describe("BotPool persistence", () => {
 
       // Re-read persisted state — should only contain the valid entry
       const cleaned = await load_pool_state(config);
-      expect(cleaned).toHaveLength(1);
-      expect(cleaned[0]!.id).toBe(1);
-      expect(cleaned[0]!.entity_id).toBe("test-entity");
+      expect(cleaned.bots).toHaveLength(1);
+      expect(cleaned.bots[0]!.id).toBe(1);
+      expect(cleaned.bots[0]!.entity_id).toBe("test-entity");
     });
   });
 
@@ -587,8 +593,8 @@ describe("BotPool persistence", () => {
 
       // Verify persisted state
       const saved = await load_pool_state(config);
-      expect(saved).toHaveLength(1);
-      expect(saved[0]!.session_id).toBe("sess-original-123");
+      expect(saved.bots).toHaveLength(1);
+      expect(saved.bots[0]!.session_id).toBe("sess-original-123");
 
       // Phase 2: Simulate daemon restart — create fresh pool, restore state
       const channels_dir = join(temp_dir, "channels", "pool-1");
@@ -1027,7 +1033,7 @@ describe("BotPool persistence", () => {
 
       // Re-read persisted state from disk
       const saved = await load_pool_state(cfg);
-      const bot_entry = saved.find(b => b.id === 1);
+      const bot_entry = saved.bots.find(b => b.id === 1);
       expect(bot_entry).toBeDefined();
       expect(bot_entry!.state).toBe("assigned");
       expect(bot_entry!.channel_id).toBe("ch-1");

--- a/packages/daemon/src/__tests__/session-history.test.ts
+++ b/packages/daemon/src/__tests__/session-history.test.ts
@@ -1,0 +1,452 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { join } from "node:path";
+import { mkdtemp, rm, readFile, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
+import type { LobsterFarmConfig, EntityConfig } from "@lobster-farm/shared";
+import { BotPool } from "../pool.js";
+import type { PoolBot } from "../pool.js";
+import {
+  save_pool_state,
+  load_pool_state,
+} from "../persistence.js";
+import type { PersistedPoolBot } from "../persistence.js";
+
+// ── Test helpers ──
+
+let temp_dir: string;
+
+function make_config(lobsterfarm_dir_override?: string): LobsterFarmConfig {
+  return LobsterFarmConfigSchema.parse({
+    user: { name: "Test" },
+    paths: {
+      lobsterfarm_dir: lobsterfarm_dir_override ?? temp_dir,
+    },
+  });
+}
+
+function make_persisted_bot(overrides: Partial<PersistedPoolBot> & { id: number }): PersistedPoolBot {
+  return {
+    state: "assigned",
+    channel_id: "ch-100",
+    entity_id: "test-entity",
+    archetype: "builder",
+    channel_type: null,
+    session_id: null,
+    last_active: null,
+    ...overrides,
+  };
+}
+
+function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
+  return {
+    state: "free",
+    channel_id: null,
+    entity_id: null,
+    archetype: null,
+    channel_type: null,
+    session_id: null,
+    tmux_session: `pool-${String(overrides.id)}`,
+    last_active: null,
+    state_dir: `/tmp/test-pool-${String(overrides.id)}`,
+    ...overrides,
+  };
+}
+
+function make_entity_config(
+  entity_id: string,
+  channel_ids: string[],
+): EntityConfig {
+  return {
+    entity: {
+      id: entity_id,
+      name: `Test ${entity_id}`,
+      description: "",
+      status: "active",
+      repos: [],
+      accounts: {},
+      channels: {
+        category_id: "",
+        list: channel_ids.map(id => ({
+          type: "general" as const,
+          id,
+        })),
+      },
+      memory: { path: "/tmp/memory", auto_extract: true },
+      secrets: { vault: "1password", vault_name: `entity-${entity_id}` },
+    },
+  };
+}
+
+/**
+ * Test-friendly BotPool subclass that stubs tmux/filesystem/persistence side effects.
+ */
+class TestBotPool extends BotPool {
+  private idle_overrides = new Map<number, boolean>();
+
+  inject_bots(bots: PoolBot[]): void {
+    (this as unknown as { bots: PoolBot[] }).bots = bots;
+  }
+
+  get_bots(): PoolBot[] {
+    return (this as unknown as { bots: PoolBot[] }).bots;
+  }
+
+  get_session_history(): Map<string, string> {
+    return (this as unknown as { session_history: Map<string, string> }).session_history;
+  }
+
+  set_bot_idle(bot_id: number, idle: boolean): void {
+    this.idle_overrides.set(bot_id, idle);
+  }
+
+  protected override is_bot_idle(bot: PoolBot): boolean {
+    return this.idle_overrides.get(bot.id) ?? true;
+  }
+}
+
+// ── Tests ──
+
+describe("session history preservation", () => {
+  let config: LobsterFarmConfig;
+  let pool: TestBotPool;
+
+  beforeEach(async () => {
+    temp_dir = await mkdtemp(join(tmpdir(), "session-history-test-"));
+    config = make_config();
+    pool = new TestBotPool(config);
+
+    // Stub out side effects
+    vi.spyOn(pool as unknown as Record<string, unknown>, "kill_tmux" as never)
+      .mockImplementation(() => {});
+    vi.spyOn(pool as unknown as Record<string, unknown>, "write_access_json" as never)
+      .mockResolvedValue(undefined);
+    vi.spyOn(pool as unknown as Record<string, unknown>, "set_bot_nickname" as never)
+      .mockResolvedValue(undefined);
+    vi.spyOn(pool as unknown as Record<string, unknown>, "start_tmux" as never)
+      .mockResolvedValue(undefined);
+    vi.spyOn(pool as unknown as Record<string, unknown>, "is_tmux_alive" as never)
+      .mockReturnValue(false);
+    vi.spyOn(pool as unknown as Record<string, unknown>, "park_bot" as never)
+      .mockImplementation(async (bot: PoolBot) => {
+        bot.state = "parked";
+      });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(temp_dir, { recursive: true, force: true });
+  });
+
+  describe("eviction stashes session history", () => {
+    it("stashes session_id when evicting a parked bot for a different channel", async () => {
+      pool.inject_bots([
+        make_bot({
+          id: 1,
+          state: "parked",
+          channel_id: "ch-old",
+          entity_id: "e1",
+          archetype: "planner",
+          session_id: "sess-old-abc",
+          channel_type: "general",
+          last_active: new Date(Date.now() - 3600_000),
+        }),
+      ]);
+
+      // Assign to a different channel -- evicts the parked bot
+      await pool.assign("ch-new", "e2", "builder", undefined, "general");
+
+      // Session history should have the evicted bot's old session
+      const history = pool.get_session_history();
+      expect(history.get("e1:ch-old")).toBe("sess-old-abc");
+    });
+
+    it("stashes session_id when evicting an idle assigned bot", async () => {
+      // Restore mocks for this test since we need real park_bot to be mocked
+      pool.inject_bots([
+        make_bot({
+          id: 1,
+          state: "assigned",
+          channel_id: "ch-busy",
+          entity_id: "e1",
+          archetype: "builder",
+          session_id: "sess-busy-123",
+          channel_type: "work_room",
+          last_active: new Date(Date.now() - 3600_000), // 1 hour ago = idle
+        }),
+      ]);
+
+      pool.set_bot_idle(1, true); // Mark as idle at prompt
+
+      await pool.assign("ch-new", "e2", "planner", undefined, "general");
+
+      const history = pool.get_session_history();
+      expect(history.get("e1:ch-busy")).toBe("sess-busy-123");
+    });
+
+    it("stashes session_id when evicting a waiting_for_human bot", async () => {
+      pool.inject_bots([
+        make_bot({
+          id: 1,
+          state: "assigned",
+          channel_id: "ch-waiting",
+          entity_id: "e1",
+          archetype: "designer",
+          session_id: "sess-waiting-456",
+          channel_type: "general",
+          last_active: new Date(Date.now() - 600_000), // 10 min ago = waiting_for_human
+        }),
+      ]);
+
+      pool.set_bot_idle(1, true);
+
+      await pool.assign("ch-new", "e2", "planner", undefined, "general");
+
+      const history = pool.get_session_history();
+      expect(history.get("e1:ch-waiting")).toBe("sess-waiting-456");
+    });
+
+    it("does NOT stash when a parked bot reclaims its own channel", async () => {
+      pool.inject_bots([
+        make_bot({
+          id: 1,
+          state: "parked",
+          channel_id: "ch-same",
+          entity_id: "e1",
+          archetype: "planner",
+          session_id: "sess-same",
+          channel_type: "general",
+        }),
+      ]);
+
+      // Assign to the SAME channel -- this is a reclaim, not an eviction
+      await pool.assign("ch-same", "e1", "planner", undefined, "general");
+
+      const history = pool.get_session_history();
+      expect(history.size).toBe(0);
+    });
+
+    it("does NOT stash for free bots (no prior channel)", async () => {
+      pool.inject_bots([make_bot({ id: 1, state: "free" })]);
+
+      await pool.assign("ch-new", "e1", "builder", undefined, "general");
+
+      const history = pool.get_session_history();
+      expect(history.size).toBe(0);
+    });
+  });
+
+  describe("session history is consumed on reassignment", () => {
+    it("uses history entry as resume_session_id when channel gets a new bot", async () => {
+      pool.inject_bots([
+        make_bot({ id: 1, state: "free" }),
+        make_bot({ id: 2, state: "free" }),
+      ]);
+
+      // Manually seed session history (as if an eviction happened earlier)
+      pool.get_session_history().set("e1:ch-returning", "sess-history-789");
+
+      // Assign bot to the channel with history
+      const result = await pool.assign("ch-returning", "e1", "builder", undefined, "general");
+      expect(result).not.toBeNull();
+
+      // The session should use the history entry
+      expect(result!.session_id).toBe("sess-history-789");
+
+      // History entry should be consumed
+      const history = pool.get_session_history();
+      expect(history.has("e1:ch-returning")).toBe(false);
+    });
+
+    it("explicit resume_session_id takes precedence over history", async () => {
+      pool.inject_bots([make_bot({ id: 1, state: "free" })]);
+
+      pool.get_session_history().set("e1:ch-1", "sess-from-history");
+
+      const result = await pool.assign("ch-1", "e1", "builder", "sess-explicit", "general");
+      expect(result).not.toBeNull();
+      expect(result!.session_id).toBe("sess-explicit");
+
+      // History entry still consumed on successful assignment
+      expect(pool.get_session_history().has("e1:ch-1")).toBe(false);
+    });
+
+    it("parked bot's session_id takes precedence over history", async () => {
+      pool.inject_bots([
+        make_bot({
+          id: 1,
+          state: "parked",
+          channel_id: "ch-1",
+          entity_id: "e1",
+          archetype: "builder",
+          session_id: "sess-parked",
+          channel_type: "general",
+        }),
+      ]);
+
+      // Seed history for the same channel (stale entry)
+      pool.get_session_history().set("e1:ch-1", "sess-stale-history");
+
+      const result = await pool.assign("ch-1", "e1", "builder", undefined, "general");
+      expect(result).not.toBeNull();
+      // Parked bot's session wins
+      expect(result!.session_id).toBe("sess-parked");
+
+      // History entry consumed
+      expect(pool.get_session_history().has("e1:ch-1")).toBe(false);
+    });
+  });
+
+  describe("session history survives daemon restart (persistence)", () => {
+    it("persists and restores session_history through pool-state.json", async () => {
+      pool.inject_bots([
+        make_bot({
+          id: 1,
+          state: "parked",
+          channel_id: "ch-old",
+          entity_id: "e1",
+          archetype: "planner",
+          session_id: "sess-evicted",
+          channel_type: "general",
+          last_active: new Date(Date.now() - 3600_000),
+        }),
+      ]);
+
+      // Evict bot 1 by assigning to different channel -- stashes history
+      await pool.assign("ch-new", "e2", "builder", undefined, "general");
+
+      // Verify session history was stashed
+      expect(pool.get_session_history().get("e1:ch-old")).toBe("sess-evicted");
+
+      // Read the persisted file
+      const state = await load_pool_state(config);
+      expect(state.session_history["e1:ch-old"]).toBe("sess-evicted");
+
+      // Simulate daemon restart: create fresh pool, seed pool-bot directories
+      const channels_dir = join(temp_dir, "channels", "pool-1");
+      await mkdir(channels_dir, { recursive: true });
+      await writeFile(join(channels_dir, ".env"), "DISCORD_BOT_TOKEN=fake-token", "utf-8");
+
+      const fresh_pool = new TestBotPool(config);
+      vi.spyOn(fresh_pool as unknown as Record<string, unknown>, "is_tmux_alive" as never)
+        .mockReturnValue(false);
+      vi.spyOn(fresh_pool as unknown as Record<string, unknown>, "kill_tmux" as never)
+        .mockImplementation(() => {});
+      vi.spyOn(fresh_pool as unknown as Record<string, unknown>, "write_access_json" as never)
+        .mockResolvedValue(undefined);
+
+      const registry = {
+        get: (id: string) => id === "e1" ? make_entity_config("e1", ["ch-old", "ch-new"]) :
+          id === "e2" ? make_entity_config("e2", ["ch-new"]) : undefined,
+        get_all: () => [],
+        get_active: () => [],
+        count: () => 2,
+      } as unknown as import("../registry.js").EntityRegistry;
+
+      await fresh_pool.initialize(registry);
+
+      // Session history should be restored from disk
+      expect(fresh_pool.get_session_history().get("e1:ch-old")).toBe("sess-evicted");
+    });
+  });
+
+  describe("backward compatibility: old pool-state.json format", () => {
+    it("loads plain array format as bots-only with empty session_history", async () => {
+      const state_path = join(temp_dir, "state");
+      await mkdir(state_path, { recursive: true });
+
+      // Write old-format file: plain array of bots
+      const old_format = [
+        make_persisted_bot({ id: 1, session_id: "sess-old-format" }),
+      ];
+      await writeFile(join(state_path, "pool-state.json"), JSON.stringify(old_format), "utf-8");
+
+      const result = await load_pool_state(config);
+      expect(result.bots).toHaveLength(1);
+      expect(result.bots[0]!.session_id).toBe("sess-old-format");
+      expect(result.session_history).toEqual({});
+    });
+
+    it("loads new format with session_history correctly", async () => {
+      const state_path = join(temp_dir, "state");
+      await mkdir(state_path, { recursive: true });
+
+      const new_format = {
+        bots: [make_persisted_bot({ id: 1, session_id: "sess-new" })],
+        session_history: { "e1:ch-1": "sess-abc" },
+      };
+      await writeFile(join(state_path, "pool-state.json"), JSON.stringify(new_format), "utf-8");
+
+      const result = await load_pool_state(config);
+      expect(result.bots).toHaveLength(1);
+      expect(result.session_history["e1:ch-1"]).toBe("sess-abc");
+    });
+  });
+
+  describe("clear_session_history (used by !reset and feature completion)", () => {
+    it("clears the history entry for a specific channel", () => {
+      pool.get_session_history().set("e1:ch-1", "sess-a");
+      pool.get_session_history().set("e1:ch-2", "sess-b");
+
+      pool.clear_session_history("e1", "ch-1");
+
+      expect(pool.get_session_history().has("e1:ch-1")).toBe(false);
+      // Other entries unaffected
+      expect(pool.get_session_history().get("e1:ch-2")).toBe("sess-b");
+    });
+
+    it("is a no-op when no history exists for the channel", () => {
+      // Should not throw
+      pool.clear_session_history("e1", "ch-nonexistent");
+      expect(pool.get_session_history().size).toBe(0);
+    });
+  });
+
+  describe("end-to-end: evict -> reassign with history", () => {
+    it("full cycle: assign -> evict -> reassign resumes old session", async () => {
+      pool.inject_bots([
+        make_bot({ id: 1, state: "free" }),
+      ]);
+
+      // Step 1: Assign bot 1 to channel A
+      const first = await pool.assign("ch-A", "e1", "builder", "sess-first", "work_room");
+      expect(first).not.toBeNull();
+      expect(first!.session_id).toBe("sess-first");
+
+      // Step 2: Bot finishes working, becomes parked (simulated)
+      const bot1 = pool.get_bots().find(b => b.id === 1)!;
+      bot1.state = "parked";
+
+      // Step 3: Channel B needs a bot -- evicts bot 1 from channel A
+      const second = await pool.assign("ch-B", "e2", "planner", undefined, "general");
+      expect(second).not.toBeNull();
+      expect(second!.bot_id).toBe(1);
+
+      // Session history should have channel A's session
+      expect(pool.get_session_history().get("e1:ch-A")).toBe("sess-first");
+
+      // Step 4: Bot finishes on channel B, becomes parked again
+      bot1.state = "parked";
+      bot1.channel_id = "ch-B";
+      bot1.entity_id = "e2";
+
+      // Step 5: Channel A needs a bot again -- should use session history
+      // Need to clear the bot's current state first (eviction from ch-B)
+      const third = await pool.assign("ch-A", "e1", "builder", undefined, "work_room");
+      expect(third).not.toBeNull();
+      // Should resume with the original session from channel A
+      expect(third!.session_id).toBe("sess-first");
+
+      // History entry consumed
+      expect(pool.get_session_history().has("e1:ch-A")).toBe(false);
+
+      // Verify start_tmux was called with is_resume=true for the last assignment
+      const start_tmux_spy = pool["start_tmux" as keyof typeof pool] as unknown as { mock: { calls: unknown[][] } };
+      const last_call = start_tmux_spy.mock.calls[start_tmux_spy.mock.calls.length - 1]!;
+      // session_id arg (index 4) should be the history session
+      expect(last_call[4]).toBe("sess-first");
+      // is_resume arg (index 5) should be true
+      expect(last_call[5]).toBe(true);
+    });
+  });
+});

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -581,6 +581,8 @@ export class DiscordBot extends EventEmitter {
     // Intercept !reset — release current bot, next real message triggers fresh assignment
     if (message.content.trim().toLowerCase() === "!reset") {
       if (this._pool) {
+        // Clear session history so the next assignment starts fresh
+        this._pool.clear_session_history(entry.entity_id, message.channelId);
         await this._pool.release(message.channelId);
         await this.reply(message, "Session reset. Send a message to start fresh.");
       }

--- a/packages/daemon/src/features.ts
+++ b/packages/daemon/src/features.ts
@@ -1232,6 +1232,9 @@ export class FeatureManager extends EventEmitter {
       // Always release pool bot, even if merge fails — otherwise the slot is permanently occupied.
       // pool.release() kills the tmux session, so do this after any work room messaging is done.
       if (this.pool && work_room) {
+        // Clear session history for the work room — feature is done, no context to preserve
+        this.pool.clear_session_history(feature.entity, work_room);
+
         const assignment = this.pool.get_assignment(work_room);
         if (assignment) {
           await this.pool.release(work_room);

--- a/packages/daemon/src/persistence.ts
+++ b/packages/daemon/src/persistence.ts
@@ -99,28 +99,60 @@ export interface PersistedPoolBot {
   last_active: string | null;  // ISO timestamp
 }
 
-/** Save pool bot state to disk. Only assigned/parked bots should be included. */
+/** Persisted pool state: bots + session history for cross-eviction resume. */
+export interface PersistedPoolState {
+  bots: PersistedPoolBot[];
+  /** Maps "{entity_id}:{channel_id}" → session_id. Preserved across evictions
+   * so a channel can resume its old session when a bot is reassigned to it. */
+  session_history: Record<string, string>;
+}
+
+/** Save pool state (bots + session history) to disk. */
 export async function save_pool_state(
   bots: PersistedPoolBot[],
   config: LobsterFarmConfig,
+  session_history?: Record<string, string>,
 ): Promise<void> {
   const path = pool_state_path(config);
   await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, JSON.stringify(bots, null, 2), "utf-8");
+  const state: PersistedPoolState = {
+    bots,
+    session_history: session_history ?? {},
+  };
+  await writeFile(path, JSON.stringify(state, null, 2), "utf-8");
 }
 
-/** Load pool bot state from disk. Returns empty array if file doesn't exist or is malformed. */
+/**
+ * Load pool state from disk.
+ * Backward-compatible: if the file contains a plain array (old format),
+ * treats it as bots-only with empty session history.
+ */
 export async function load_pool_state(
   config: LobsterFarmConfig,
-): Promise<PersistedPoolBot[]> {
+): Promise<PersistedPoolState> {
   const path = pool_state_path(config);
   try {
     const content = await readFile(path, "utf-8");
     const data: unknown = JSON.parse(content);
-    if (!Array.isArray(data)) return [];
-    return data as PersistedPoolBot[];
+
+    // Old format: plain array of bots
+    if (Array.isArray(data)) {
+      return { bots: data as PersistedPoolBot[], session_history: {} };
+    }
+
+    // New format: { bots, session_history }
+    if (typeof data === "object" && data !== null && "bots" in data) {
+      const obj = data as Record<string, unknown>;
+      const bots = Array.isArray(obj["bots"]) ? (obj["bots"] as PersistedPoolBot[]) : [];
+      const history = (typeof obj["session_history"] === "object" && obj["session_history"] !== null && !Array.isArray(obj["session_history"]))
+        ? (obj["session_history"] as Record<string, string>)
+        : {};
+      return { bots, session_history: history };
+    }
+
+    return { bots: [], session_history: {} };
   } catch {
-    return [];
+    return { bots: [], session_history: {} };
   }
 }
 

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -116,6 +116,9 @@ export class BotPool extends EventEmitter {
   /** Bots that were actively assigned before shutdown and should be proactively resumed.
    * Populated during initialize(), consumed by resume_parked_bots(). */
   private resume_candidates: PersistedPoolBot[] = [];
+  /** Maps "{entity_id}:{channel_id}" → session_id. Preserves session context
+   * across evictions so a channel can resume its old session when reassigned. */
+  private session_history = new Map<string, string>();
 
   constructor(config: LobsterFarmConfig) {
     super();
@@ -208,11 +211,19 @@ export class BotPool extends EventEmitter {
     }
 
     // Restore persisted assignments from last run
-    const saved = await load_pool_state(this.config);
+    const saved_state = await load_pool_state(this.config);
     let restored = 0;
     this.resume_candidates = [];
 
-    for (const entry of saved) {
+    // Restore session history from persisted state
+    for (const [key, session_id] of Object.entries(saved_state.session_history)) {
+      this.session_history.set(key, session_id);
+    }
+    if (this.session_history.size > 0) {
+      console.log(`[pool] Restored ${String(this.session_history.size)} session history entries`);
+    }
+
+    for (const entry of saved_state.bots) {
       const bot = this.bots.find(b => b.id === entry.id);
       if (!bot) continue; // Bot directory removed since last run
 
@@ -425,6 +436,21 @@ export class BotPool extends EventEmitter {
         );
       }
 
+      // Check session_history for a previously evicted session on this channel.
+      // Only used if no explicit resume_session_id was provided and no parked bot
+      // was found (parked bots carry their own session_id).
+      if (!resume_session_id) {
+        const history_key = `${entity_id}:${channel_id}`;
+        const history_session = this.session_history.get(history_key);
+        if (history_session) {
+          resume_session_id = history_session;
+          console.log(
+            `[pool] Found session history for channel ${channel_id}: ` +
+            `${resume_session_id.slice(0, 8)}`,
+          );
+        }
+      }
+
       // Find a free bot if we don't have a returning one
       if (!bot) {
         bot = this.bots.find(b => b.state === "free");
@@ -489,6 +515,17 @@ export class BotPool extends EventEmitter {
         return null;
       }
 
+      // Stash session history for the evicted bot's channel before overwriting.
+      // Only stash if the bot is being reassigned away from a different channel
+      // (i.e., not a returning parked bot reclaiming its own channel, and not a free bot).
+      if (bot.channel_id && bot.entity_id && bot.session_id && bot.channel_id !== channel_id) {
+        const evict_key = `${bot.entity_id}:${bot.channel_id}`;
+        this.session_history.set(evict_key, bot.session_id);
+        console.log(
+          `[pool] Stashed session history for ${evict_key}: ${bot.session_id.slice(0, 8)}`,
+        );
+      }
+
       // Kill any existing tmux session
       this.kill_tmux(bot.tmux_session);
 
@@ -513,6 +550,13 @@ export class BotPool extends EventEmitter {
       bot.channel_type = channel_type ?? null;
       bot.session_id = session_id;
       bot.last_active = new Date();
+
+      // Consume session history entry now that it's been used
+      const assign_key = `${entity_id}:${channel_id}`;
+      if (this.session_history.has(assign_key)) {
+        this.session_history.delete(assign_key);
+        console.log(`[pool] Consumed session history for ${assign_key}`);
+      }
 
       await this.persist();
 
@@ -590,6 +634,14 @@ export class BotPool extends EventEmitter {
   /** Get the assignment for a channel. */
   get_assignment(channel_id: string): PoolBot | undefined {
     return this.bots.find(b => b.channel_id === channel_id && b.state === "assigned");
+  }
+
+  /** Clear session history for a specific channel. Used by !reset and feature completion. */
+  clear_session_history(entity_id: string, channel_id: string): void {
+    const key = `${entity_id}:${channel_id}`;
+    if (this.session_history.delete(key)) {
+      console.log(`[pool] Cleared session history for ${key}`);
+    }
   }
 
   /** Get pool status. */
@@ -786,8 +838,14 @@ export class BotPool extends EventEmitter {
         last_active: b.last_active?.toISOString() ?? null,
       }));
 
+    // Convert session_history Map to a plain object for serialization
+    const history_obj: Record<string, string> = {};
+    for (const [key, value] of this.session_history) {
+      history_obj[key] = value;
+    }
+
     try {
-      await save_pool_state(to_save, this.config);
+      await save_pool_state(to_save, this.config, history_obj);
     } catch (err) {
       // Non-fatal: log and continue. Next mutation will retry the write.
       console.error(`[pool] Failed to persist state: ${String(err)}`);


### PR DESCRIPTION
## Summary

- **Session history preservation**: When a pool bot is evicted from a channel, the channel's `session_id` is stashed in a `session_history` map (`{entity_id}:{channel_id}` -> `session_id`). When that channel later gets a bot again (even a different bot), the old session is automatically resumed via `--resume`.
- **Persistence**: `pool-state.json` migrated from plain array to `{ bots, session_history }` format with backward compatibility -- old format files load correctly as bots-only with empty history.
- **Cleanup hooks**: Session history is cleared on `!reset` (user wants a fresh start) and on feature completion/ship (context is no longer relevant).

### Changes

| File | What |
|------|------|
| `persistence.ts` | New `PersistedPoolState` type, updated `save_pool_state`/`load_pool_state` for `{ bots, session_history }` format with backward compat |
| `pool.ts` | `session_history` Map, stash on eviction (tiers 2-4), lookup + consume on assign, `clear_session_history()` public method, persist history |
| `discord.ts` | Clear session history on `!reset` before releasing bot |
| `features.ts` | Clear session history for work room on feature ship/completion |
| `pool-persistence.test.ts` | Updated 14 existing assertions for new `PersistedPoolState` return type, added backward compat test |
| `session-history.test.ts` | 14 new tests covering all scenarios |

## Test plan

- [x] Session history is stashed on eviction (parked, idle assigned, waiting_for_human)
- [x] Session history is NOT stashed when a parked bot reclaims its own channel
- [x] Session history is NOT stashed for free bots
- [x] Session history is consumed on reassignment (bot resumes with old session_id)
- [x] Explicit resume_session_id takes precedence over history
- [x] Parked bot's session_id takes precedence over history
- [x] Session history survives daemon restart (persisted to disk, restored on init)
- [x] Backward compatibility: old pool-state.json (plain array) loads correctly
- [x] New format with session_history loads correctly
- [x] `clear_session_history()` clears specific channel, leaves others
- [x] End-to-end: assign -> evict -> reassign resumes old session
- [x] All 309 tests pass (295 existing + 14 new)

Closes #62

Generated with [Claude Code](https://claude.com/claude-code)