### PR TITLE
fix: check pool state when assigning work rooms to features

### DIFF
--- a/packages/daemon/src/__tests__/work-rooms.test.ts
+++ b/packages/daemon/src/__tests__/work-rooms.test.ts
@@ -98,6 +98,22 @@ function make_mock_feature_manager(features: FeatureState[] = []) {
   };
 }
 
+// ── Mock Bot Pool ──
+
+/**
+ * Create a mock pool where `assigned_channels` maps channel IDs to a pool bot stub.
+ * Channels not in the map return undefined from get_assignment().
+ */
+function make_mock_pool(assigned_channels: Record<string, { id: number; archetype: string }> = {}) {
+  return {
+    get_assignment: vi.fn((channel_id: string) => {
+      const entry = assigned_channels[channel_id];
+      if (!entry) return undefined;
+      return { id: entry.id, state: "assigned", channel_id, archetype: entry.archetype };
+    }),
+  };
+}
+
 // ── Tests ──
 
 describe("Work Room Assignment", () => {
@@ -107,6 +123,8 @@ describe("Work Room Assignment", () => {
     discord = make_mock_discord();
     // @ts-expect-error — mock does not implement full DiscordBot interface
     actions.set_discord_bot(discord);
+    // Reset pool to null so tests without pool awareness are unaffected
+    actions.set_pool(null);
   });
 
   describe("assign_work_room", () => {
@@ -269,6 +287,92 @@ describe("Work Room Assignment", () => {
       const room_id = await actions.assign_work_room(feature, entity);
 
       expect(room_id).toBeNull();
+    });
+
+    it("skips rooms with active pool bot assignments", async () => {
+      const feature = make_feature({ id: "alpha-42" });
+      const entity = make_entity_config(make_static_work_rooms());
+      // @ts-expect-error — mock feature manager
+      actions.set_feature_manager(make_mock_feature_manager([]));
+      // Pool has a bot assigned to wr-1 (e.g., manual planner session)
+      // @ts-expect-error — mock pool
+      actions.set_pool(make_mock_pool({ "wr-1": { id: 0, archetype: "planner" } }));
+
+      const room_id = await actions.assign_work_room(feature, entity);
+
+      expect(room_id).toBe("wr-2");
+    });
+
+    it("skips rooms occupied by both features and pool assignments", async () => {
+      const feature = make_feature({ id: "alpha-42" });
+      const existing_feature = make_feature({
+        id: "alpha-10",
+        discordWorkRoom: "wr-1",
+        phase: "build",
+      });
+      const entity = make_entity_config(make_static_work_rooms());
+      // @ts-expect-error — mock feature manager
+      actions.set_feature_manager(make_mock_feature_manager([existing_feature]));
+      // Pool has a bot in wr-2 (manual session), feature occupies wr-1
+      // @ts-expect-error — mock pool
+      actions.set_pool(make_mock_pool({ "wr-2": { id: 1, archetype: "planner" } }));
+
+      const room_id = await actions.assign_work_room(feature, entity);
+
+      expect(room_id).toBe("wr-3");
+    });
+
+    it("creates dynamic room when all static rooms are pool-assigned", async () => {
+      const feature = make_feature({ id: "alpha-42" });
+      const entity = make_entity_config(make_static_work_rooms());
+      // @ts-expect-error — mock feature manager
+      actions.set_feature_manager(make_mock_feature_manager([]));
+      // All three rooms have pool bots
+      // @ts-expect-error — mock pool
+      actions.set_pool(make_mock_pool({
+        "wr-1": { id: 0, archetype: "planner" },
+        "wr-2": { id: 1, archetype: "builder" },
+        "wr-3": { id: 2, archetype: "planner" },
+      }));
+
+      const room_id = await actions.assign_work_room(feature, entity);
+
+      expect(room_id).toBe("dynamic-wr-4");
+      expect(discord.create_channel).toHaveBeenCalledWith(
+        "cat-123",
+        "work-room-4",
+        "Overflow for alpha-42",
+      );
+    });
+
+    it("does not check non-work-room channels for pool assignments", async () => {
+      const feature = make_feature({ id: "alpha-42" });
+      const entity = make_entity_config(make_static_work_rooms());
+      // @ts-expect-error — mock feature manager
+      actions.set_feature_manager(make_mock_feature_manager([]));
+      // Pool has a bot in the general channel — should not affect work room assignment
+      const pool = make_mock_pool({ "gen-1": { id: 0, archetype: "planner" } });
+      // @ts-expect-error — mock pool
+      actions.set_pool(pool);
+
+      const room_id = await actions.assign_work_room(feature, entity);
+
+      // Should still get wr-1 (general channel pool assignment is irrelevant)
+      expect(room_id).toBe("wr-1");
+      // get_assignment should only have been called for work_room channels
+      expect(pool.get_assignment).not.toHaveBeenCalledWith("gen-1");
+    });
+
+    it("does not block rooms when pool is null", async () => {
+      const feature = make_feature({ id: "alpha-42" });
+      const entity = make_entity_config(make_static_work_rooms());
+      // @ts-expect-error — mock feature manager
+      actions.set_feature_manager(make_mock_feature_manager([]));
+      actions.set_pool(null);
+
+      const room_id = await actions.assign_work_room(feature, entity);
+
+      expect(room_id).toBe("wr-1");
     });
   });
 

--- a/packages/daemon/src/actions.ts
+++ b/packages/daemon/src/actions.ts
@@ -5,6 +5,7 @@ import type { FeatureState, EntityConfig, ChannelType, ArchetypeRole, ChannelMap
 import { expand_home, entity_config_path, write_yaml } from "@lobster-farm/shared";
 import type { DiscordBot } from "./discord.js";
 import type { FeatureManager } from "./features.js";
+import type { BotPool } from "./pool.js";
 import type { EntityRegistry } from "./registry.js";
 
 const exec = promisify(execFile);
@@ -178,12 +179,19 @@ let _discord: DiscordBot | null = null;
 /** Global feature manager reference, set by the daemon on startup. */
 let _features: FeatureManager | null = null;
 
+/** Global bot pool reference, set by the daemon on startup. */
+let _pool: BotPool | null = null;
+
 export function set_discord_bot(bot: DiscordBot | null): void {
   _discord = bot;
 }
 
 export function set_feature_manager(fm: FeatureManager | null): void {
   _features = fm;
+}
+
+export function set_pool(pool: BotPool | null): void {
+  _pool = pool;
 }
 
 /** Send a notification to an entity's Discord channel (or log if not connected). */
@@ -272,6 +280,19 @@ export async function assign_work_room(
   const occupied = new Set(
     active.map(f => f.discordWorkRoom).filter((id): id is string => Boolean(id)),
   );
+
+  // Also mark rooms with active pool assignments as occupied.
+  // This prevents feature deployments from overwriting manual pool sessions
+  // (e.g., an interactive planner assigned via POST /pool/assign).
+  if (_pool) {
+    for (const room of work_rooms) {
+      const assignment = _pool.get_assignment(room.id);
+      if (assignment) {
+        occupied.add(room.id);
+      }
+    }
+  }
+
   const free_room = work_rooms.find((r: ChannelMapping) => !occupied.has(r.id));
 
   let channel_id: string | null = null;

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -6,7 +6,7 @@ import type { ActiveSession, SessionResult } from "./session.js";
 import { TaskQueue } from "./queue.js";
 import { FeatureManager } from "./features.js";
 import { DiscordBot, resolve_bot_token } from "./discord.js";
-import { set_discord_bot, set_feature_manager, reset_idle_work_room_topics } from "./actions.js";
+import { set_discord_bot, set_feature_manager, set_pool, reset_idle_work_room_topics } from "./actions.js";
 import { start_server } from "./server.js";
 import { write_pid, remove_pid } from "./pid.js";
 import { CommanderProcess } from "./commander-process.js";
@@ -156,6 +156,9 @@ async function main(): Promise<void> {
 
   // Wire pool to feature manager for interactive builder sessions
   feature_manager.set_pool(pool);
+
+  // Wire pool to actions module so assign_work_room() checks pool state
+  set_pool(pool);
 
   // Start health monitor for detecting dead tmux sessions
   pool.start_health_monitor();


### PR DESCRIPTION
## Summary

- `assign_work_room()` in `actions.ts` now checks `BotPool.get_assignment()` for each work room channel before marking it as free
- Prevents feature deployments from overwriting manual pool sessions (e.g., interactive planner assigned via `POST /pool/assign`)
- Follows the existing `_discord`/`_features` module-level ref pattern: new `_pool` ref + `set_pool()` setter, wired in `index.ts` alongside the other setters

## Test plan

- [x] New test: pool-assigned room is skipped, next free room is selected
- [x] New test: mixed feature + pool occupancy correctly combines both sources
- [x] New test: all rooms pool-assigned triggers dynamic room creation
- [x] New test: non-work-room pool assignments are ignored (only work_room channels checked)
- [x] New test: null pool does not block any rooms (backward compatible)
- [x] All 313 existing tests pass (no regressions)

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)