### PR TITLE
feat: optional tool integrations multi-select in lf init wizard

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -8,6 +8,7 @@ import {
   type PathConfig,
 } from "@lobster-farm/shared";
 import { detect_machine, check_sudo, check_onepassword, check_claude_code, check_bun, check_tmux, check_github_cli } from "./init/detect.js";
+import { setup_tool_integrations } from "./init/tools.js";
 import {
   prompt_user_name,
   prompt_agent_names,
@@ -54,7 +55,19 @@ export const init_command = new Command("init")
   .option("--prefix <dir>", "Write output to <dir>/.claude/ and <dir>/.lobsterfarm/ instead of ~/")
   .option("--name <name>", "User name (skips interactive prompt)")
   .option("--non-interactive", "Use defaults for all prompts (requires --name)")
-  .action(async (options: { prefix?: string; name?: string; nonInteractive?: boolean }) => {
+  .option("--tools <list>", "Comma-separated list of tools to install (tailscale,docker,vercel,supabase,sentry)")
+  .option("--tailscale-authkey <key>", "Tailscale auth key for non-interactive setup")
+  .option("--sentry-token <token>", "Sentry auth token")
+  .option("--supabase-token <token>", "Supabase access token")
+  .action(async (options: {
+    prefix?: string;
+    name?: string;
+    nonInteractive?: boolean;
+    tools?: string;
+    tailscaleAuthkey?: string;
+    sentryToken?: string;
+    supabaseToken?: string;
+  }) => {
     const prefix = options.prefix;
     const non_interactive = options.nonInteractive ?? false;
     const path_overrides: Partial<PathConfig> | undefined = prefix
@@ -427,7 +440,10 @@ export const init_command = new Command("init")
       }
     }
 
-    // ── Step 8-10: Prompts (skipped in non-interactive mode) ──
+    // ── Step 11: Tool Integrations ──
+    const tools_config = await setup_tool_integrations(spin, non_interactive, options);
+
+    // ── Prompts (skipped in non-interactive mode) ──
     // Check if Discord tokens already exist
     let has_existing_discord_token = false;
     try {
@@ -499,6 +515,10 @@ export const init_command = new Command("init")
 
     if (discord_setup) {
       config_input["discord"] = { server_id: discord_setup.server_id };
+    }
+
+    if (tools_config && Object.keys(tools_config).length > 0) {
+      config_input["tools"] = tools_config;
     }
 
     const config: LobsterFarmConfig = LobsterFarmConfigSchema.parse(config_input);
@@ -632,6 +652,26 @@ export const init_command = new Command("init")
 
     if (github.username) {
       summary_lines.push(`GitHub:     ${github.username}`);
+    }
+
+    // Tool integration statuses
+    if (tools_config?.tailscale?.installed) {
+      const ts = tools_config.tailscale;
+      summary_lines.push(`Tailscale:  connected as ${ts.hostname ?? "unknown"} (${ts.ip ?? "unknown"})`);
+    }
+    if (tools_config?.docker?.installed) {
+      summary_lines.push(`Docker:     ${tools_config.docker.runtime ?? "colima"} ready`);
+    }
+    if (tools_config?.vercel?.installed) {
+      const v = tools_config.vercel;
+      summary_lines.push(`Vercel:     authenticated as ${v.username ?? "unknown"}`);
+    }
+    if (tools_config?.supabase?.installed) {
+      summary_lines.push(`Supabase:   authenticated`);
+    }
+    if (tools_config?.sentry?.installed) {
+      const s = tools_config.sentry;
+      summary_lines.push(`Sentry:     authenticated${s.org ? ` (org: ${s.org})` : ""}`);
     }
 
     p.note(summary_lines.join("\n"), "Setup Complete");

--- a/packages/cli/src/commands/init/detect.ts
+++ b/packages/cli/src/commands/init/detect.ts
@@ -142,3 +142,221 @@ export async function check_onepassword(): Promise<OnePasswordCheckResult> {
 
   return { cli_installed, token_configured, status };
 }
+
+// ── Optional Tool Detection ──
+
+export interface TailscaleCheckResult {
+  installed: boolean;
+  running: boolean;
+  authenticated: boolean;
+  hostname: string | null;
+  ip: string | null;
+  gui_app_detected: boolean;
+  gui_extension_running: boolean;
+  status: string;
+}
+
+/** Check Tailscale installation, daemon status, and GUI conflicts. */
+export async function check_tailscale(): Promise<TailscaleCheckResult> {
+  const result: TailscaleCheckResult = {
+    installed: false,
+    running: false,
+    authenticated: false,
+    hostname: null,
+    ip: null,
+    gui_app_detected: false,
+    gui_extension_running: false,
+    status: "not installed",
+  };
+
+  const { exitCode: which_exit } = await exec_command("which tailscale 2>/dev/null");
+  if (which_exit !== 0) return result;
+  result.installed = true;
+
+  // Check for GUI app conflict
+  const { exitCode: app_exit } = await exec_command("ls /Applications/Tailscale.app 2>/dev/null");
+  result.gui_app_detected = app_exit === 0;
+
+  // Check for system extension running
+  const { exitCode: ext_exit, stdout: ext_out } = await exec_command(
+    "ps aux 2>/dev/null | grep io.tailscale.ipn.macsys.network-extension | grep -v grep",
+  );
+  result.gui_extension_running = ext_exit === 0 && ext_out.trim().length > 0;
+
+  // Check daemon status and auth
+  const { exitCode: status_exit, stdout: status_out } = await exec_command("tailscale status --json 2>/dev/null");
+  if (status_exit !== 0) {
+    result.status = "installed, daemon not running";
+    return result;
+  }
+
+  result.running = true;
+
+  try {
+    const status_json = JSON.parse(status_out);
+    const self = status_json.Self;
+    if (self) {
+      result.authenticated = true;
+      result.hostname = self.HostName ?? self.DNSName?.split(".")[0] ?? null;
+      const addrs: string[] = self.TailscaleIPs ?? [];
+      // Prefer IPv4
+      result.ip = addrs.find((a: string) => !a.includes(":")) ?? addrs[0] ?? null;
+      result.status = `connected as ${result.hostname} (${result.ip})`;
+    } else {
+      result.status = "installed, not authenticated";
+    }
+  } catch {
+    result.status = "installed, running (status parse failed)";
+  }
+
+  return result;
+}
+
+export interface DockerCheckResult {
+  docker_installed: boolean;
+  colima_installed: boolean;
+  colima_running: boolean;
+  docker_desktop_detected: boolean;
+  docker_version: string | null;
+  colima_version: string | null;
+  status: string;
+}
+
+/** Check Docker/Colima installation and running state. */
+export async function check_docker(): Promise<DockerCheckResult> {
+  const result: DockerCheckResult = {
+    docker_installed: false,
+    colima_installed: false,
+    colima_running: false,
+    docker_desktop_detected: false,
+    docker_version: null,
+    colima_version: null,
+    status: "not installed",
+  };
+
+  const { exitCode: docker_exit, stdout: docker_ver } = await exec_command("docker --version 2>/dev/null");
+  result.docker_installed = docker_exit === 0;
+  if (docker_exit === 0) {
+    const match = docker_ver.match(/Docker version ([\d.]+)/);
+    result.docker_version = match?.[1] ?? null;
+  }
+
+  const { exitCode: colima_exit, stdout: colima_ver } = await exec_command("colima version 2>/dev/null");
+  result.colima_installed = colima_exit === 0;
+  if (colima_exit === 0) {
+    const match = colima_ver.match(/colima version ([\d.]+)/);
+    result.colima_version = match?.[1] ?? null;
+  }
+
+  // Check for Docker Desktop conflict
+  const { exitCode: desktop_exit } = await exec_command("ls /Applications/Docker.app 2>/dev/null");
+  result.docker_desktop_detected = desktop_exit === 0;
+
+  // Check if Colima is running
+  if (result.colima_installed) {
+    const { exitCode: running_exit } = await exec_command("colima status 2>/dev/null");
+    result.colima_running = running_exit === 0;
+  }
+
+  // Build status string
+  const parts: string[] = [];
+  if (result.colima_installed) parts.push(`Colima v${result.colima_version ?? "?"}`);
+  if (result.docker_installed) parts.push(`Docker v${result.docker_version ?? "?"}`);
+  if (parts.length === 0) {
+    result.status = "not installed";
+  } else if (result.colima_running) {
+    result.status = `${parts.join(", ")} (running)`;
+  } else {
+    result.status = `${parts.join(", ")} (stopped)`;
+  }
+
+  return result;
+}
+
+export interface VercelCheckResult {
+  installed: boolean;
+  authenticated: boolean;
+  username: string | null;
+  status: string;
+}
+
+/** Check Vercel CLI installation and auth state. */
+export async function check_vercel(): Promise<VercelCheckResult> {
+  const { exitCode: which_exit } = await exec_command("which vercel 2>/dev/null");
+  if (which_exit !== 0) {
+    return { installed: false, authenticated: false, username: null, status: "not installed" };
+  }
+
+  const { exitCode: whoami_exit, stdout: whoami_out } = await exec_command("vercel whoami 2>/dev/null");
+  if (whoami_exit === 0 && whoami_out.trim()) {
+    const username = whoami_out.trim();
+    return { installed: true, authenticated: true, username, status: `authenticated as ${username}` };
+  }
+
+  return { installed: true, authenticated: false, username: null, status: "installed, not authenticated" };
+}
+
+export interface SupabaseCheckResult {
+  installed: boolean;
+  authenticated: boolean;
+  version: string | null;
+  status: string;
+}
+
+/** Check Supabase CLI installation and auth state. */
+export async function check_supabase(): Promise<SupabaseCheckResult> {
+  const { exitCode: which_exit, stdout: ver_out } = await exec_command("supabase --version 2>/dev/null");
+  if (which_exit !== 0) {
+    return { installed: false, authenticated: false, version: null, status: "not installed" };
+  }
+
+  const version = ver_out.trim() || null;
+
+  // `supabase projects list` requires auth — exit code reveals auth state
+  const { exitCode: auth_exit } = await exec_command("supabase projects list 2>/dev/null");
+  if (auth_exit === 0) {
+    return {
+      installed: true,
+      authenticated: true,
+      version,
+      status: `v${version}, authenticated`,
+    };
+  }
+
+  return {
+    installed: true,
+    authenticated: false,
+    version,
+    status: `v${version}, not authenticated`,
+  };
+}
+
+export interface SentryCheckResult {
+  installed: boolean;
+  authenticated: boolean;
+  org: string | null;
+  status: string;
+}
+
+/** Check Sentry CLI installation and auth state. */
+export async function check_sentry(): Promise<SentryCheckResult> {
+  const { exitCode: which_exit } = await exec_command("which sentry-cli 2>/dev/null");
+  if (which_exit !== 0) {
+    return { installed: false, authenticated: false, org: null, status: "not installed" };
+  }
+
+  const { exitCode: info_exit, stdout: info_out } = await exec_command("sentry-cli info 2>/dev/null");
+  if (info_exit === 0) {
+    // Parse org from sentry-cli info output (line like "Default Organization: ultim8")
+    const org_match = info_out.match(/Default Organization:\s*(.+)/i);
+    const org = org_match?.[1]?.trim() ?? null;
+    return {
+      installed: true,
+      authenticated: true,
+      org,
+      status: org ? `authenticated (org: ${org})` : "authenticated",
+    };
+  }
+
+  return { installed: true, authenticated: false, org: null, status: "installed, not authenticated" };
+}

--- a/packages/cli/src/commands/init/tools.ts
+++ b/packages/cli/src/commands/init/tools.ts
@@ -1,0 +1,638 @@
+import * as p from "@clack/prompts";
+import { spawnSync } from "node:child_process";
+import { writeFile, readFile, mkdir } from "node:fs/promises";
+import { exec_command } from "../../lib/process.js";
+import {
+  check_tailscale, check_docker, check_vercel, check_supabase, check_sentry,
+  type TailscaleCheckResult, type DockerCheckResult, type VercelCheckResult,
+  type SupabaseCheckResult, type SentryCheckResult,
+} from "./detect.js";
+
+// Tool names used as keys throughout the module.
+const TOOL_NAMES = ["tailscale", "docker", "vercel", "supabase", "sentry"] as const;
+type ToolName = (typeof TOOL_NAMES)[number];
+
+/** Config shape written to config.yaml — mirrors the schema in config.ts. */
+export interface ToolsConfig {
+  tailscale?: { installed: boolean; hostname?: string; ip?: string };
+  docker?: { installed: boolean; runtime?: "colima" | "docker-desktop" | "other" };
+  vercel?: { installed: boolean; username?: string };
+  supabase?: { installed: boolean };
+  sentry?: { installed: boolean; org?: string };
+}
+
+interface ToolDetectionResults {
+  tailscale: TailscaleCheckResult;
+  docker: DockerCheckResult;
+  vercel: VercelCheckResult;
+  supabase: SupabaseCheckResult;
+  sentry: SentryCheckResult;
+}
+
+interface ToolOption {
+  value: ToolName;
+  label: string;
+  hint: string;
+}
+
+interface ToolSetupOptions {
+  tools?: string;
+  tailscaleAuthkey?: string;
+  sentryToken?: string;
+  supabaseToken?: string;
+}
+
+// ── Detection ──
+
+/** Run all 5 tool detections in parallel. */
+async function detect_all_tools(): Promise<ToolDetectionResults> {
+  const [tailscale, docker, vercel, supabase, sentry] = await Promise.all([
+    check_tailscale(),
+    check_docker(),
+    check_vercel(),
+    check_supabase(),
+    check_sentry(),
+  ]);
+  return { tailscale, docker, vercel, supabase, sentry };
+}
+
+/** Build the multiselect option list from detection results. */
+function build_tool_options(detection: ToolDetectionResults): ToolOption[] {
+  return [
+    {
+      value: "tailscale",
+      label: "Tailscale",
+      hint: `mesh VPN for remote SSH + dev server access [${detection.tailscale.status}]`,
+    },
+    {
+      value: "docker",
+      label: "Docker",
+      hint: `container runtime via Colima [${detection.docker.status}]`,
+    },
+    {
+      value: "vercel",
+      label: "Vercel",
+      hint: `frontend deployment platform [${detection.vercel.status}]`,
+    },
+    {
+      value: "supabase",
+      label: "Supabase",
+      hint: `database & auth backend [${detection.supabase.status}]`,
+    },
+    {
+      value: "sentry",
+      label: "Sentry",
+      hint: `error monitoring [${detection.sentry.status}]`,
+    },
+  ];
+}
+
+/** Determine which tools should be pre-selected (checked) by default. */
+function default_selections(detection: ToolDetectionResults): ToolName[] {
+  const selected: ToolName[] = [];
+
+  // Not-installed or not-authenticated tools are checked by default.
+  // Already fully configured tools are unchecked (user can still re-enable).
+  if (!detection.tailscale.installed || !detection.tailscale.authenticated) selected.push("tailscale");
+  if (!detection.docker.docker_installed || !detection.docker.colima_installed) selected.push("docker");
+  if (!detection.vercel.installed || !detection.vercel.authenticated) selected.push("vercel");
+  if (!detection.supabase.installed || !detection.supabase.authenticated) selected.push("supabase");
+  if (!detection.sentry.installed || !detection.sentry.authenticated) selected.push("sentry");
+
+  return selected;
+}
+
+// ── Individual tool setup flows ──
+
+async function setup_tailscale(
+  spin: ReturnType<typeof p.spinner>,
+  detection: TailscaleCheckResult,
+  non_interactive: boolean,
+  authkey?: string,
+): Promise<ToolsConfig["tailscale"]> {
+  p.log.step("Setting up Tailscale");
+
+  // GUI conflict check
+  if (detection.gui_app_detected && !non_interactive) {
+    p.log.warning(
+      "Tailscale.app (GUI) detected. The App Store version conflicts with the CLI daemon\n" +
+      "and doesn't support Tailscale SSH.\n" +
+      "Please quit and uninstall Tailscale.app via Finder, then press Enter to continue.",
+    );
+    const proceed = await p.confirm({ message: "Tailscale.app removed?" });
+    if (p.isCancel(proceed)) { p.cancel("Setup cancelled."); process.exit(0); }
+
+    // Re-check
+    const recheck = await check_tailscale();
+    if (recheck.gui_app_detected) {
+      p.log.warning("Tailscale.app still detected. Skipping Tailscale setup.");
+      return undefined;
+    }
+  }
+
+  // Install via brew if needed
+  if (!detection.installed) {
+    spin.start("Installing Tailscale...");
+    const install = await exec_command("brew install tailscale");
+    if (install.exitCode !== 0) {
+      spin.stop("Tailscale installation failed");
+      p.log.warning("Install manually: brew install tailscale");
+      return undefined;
+    }
+    spin.stop("Tailscale installed");
+  }
+
+  // Create LaunchDaemon (requires sudo)
+  const plist_path = "/Library/LaunchDaemons/com.tailscale.tailscaled.plist";
+  const plist_content = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.tailscale.tailscaled</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/opt/homebrew/opt/tailscale/bin/tailscaled</string>
+    <string>--state=/var/lib/tailscale/tailscaled.state</string>
+    <string>--socket=/var/run/tailscaled.socket</string>
+    <string>--port=0</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/usr/sbin:/usr/bin:/sbin:/bin:/opt/homebrew/bin</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>/var/log/tailscaled.log</string>
+  <key>StandardErrorPath</key>
+  <string>/var/log/tailscaled.log</string>
+</dict>
+</plist>`;
+
+  spin.start("Configuring Tailscale daemon...");
+
+  // Create state directory and write plist
+  const mkdir_result = spawnSync("sudo", ["mkdir", "-p", "/var/lib/tailscale"], { stdio: "inherit" });
+  if (mkdir_result.status !== 0) {
+    spin.stop("Failed to create /var/lib/tailscale");
+    p.log.warning("Tailscale daemon setup requires sudo access.");
+    return undefined;
+  }
+
+  // Write the plist via sudo tee
+  const write_plist = spawnSync("sudo", ["tee", plist_path], {
+    input: plist_content,
+    stdio: ["pipe", "pipe", "inherit"],
+  });
+  if (write_plist.status !== 0) {
+    spin.stop("Failed to write LaunchDaemon plist");
+    return undefined;
+  }
+
+  // Load the daemon
+  const load_result = spawnSync("sudo", ["launchctl", "load", plist_path], { stdio: "inherit" });
+  if (load_result.status !== 0) {
+    // May already be loaded — try unload + load
+    spawnSync("sudo", ["launchctl", "unload", plist_path], { stdio: "inherit" });
+    const retry = spawnSync("sudo", ["launchctl", "load", plist_path], { stdio: "inherit" });
+    if (retry.status !== 0) {
+      spin.stop("Failed to load Tailscale daemon");
+      return undefined;
+    }
+  }
+  spin.stop("Tailscale daemon configured");
+
+  // Authenticate
+  if (authkey) {
+    // Non-interactive: use auth key
+    spin.start("Authenticating Tailscale...");
+    const auth = await exec_command(`tailscale up --ssh --authkey=${authkey}`);
+    if (auth.exitCode !== 0) {
+      spin.stop("Tailscale auth failed");
+      p.log.warning("Check your auth key and try again.");
+      return undefined;
+    }
+    spin.stop("Tailscale authenticated");
+  } else if (!detection.authenticated) {
+    // Interactive: browser auth — spawnSync with inherited stdio so the URL is visible
+    p.log.info("Tailscale will open a browser for authentication...");
+    const auth = spawnSync("tailscale", ["up", "--ssh"], { stdio: "inherit" });
+    if (auth.status !== 0) {
+      p.log.warning("Tailscale authentication failed or was cancelled.");
+      return undefined;
+    }
+  }
+
+  // Verify
+  const verify = await check_tailscale();
+  if (verify.authenticated) {
+    p.log.success(`Tailscale connected as ${verify.hostname} (${verify.ip})`);
+    return { installed: true, hostname: verify.hostname ?? undefined, ip: verify.ip ?? undefined };
+  }
+
+  p.log.warning("Tailscale setup completed but verification failed.");
+  return { installed: true };
+}
+
+async function setup_docker(
+  spin: ReturnType<typeof p.spinner>,
+  detection: DockerCheckResult,
+  non_interactive: boolean,
+): Promise<ToolsConfig["docker"]> {
+  p.log.step("Setting up Docker");
+
+  // Docker Desktop conflict
+  if (detection.docker_desktop_detected && !non_interactive) {
+    p.log.warning(
+      "Docker Desktop detected. For headless operation, we'll use Colima instead.\n" +
+      "Please uninstall Docker Desktop via Finder, then press Enter to continue.",
+    );
+    const proceed = await p.confirm({ message: "Docker Desktop removed?" });
+    if (p.isCancel(proceed)) { p.cancel("Setup cancelled."); process.exit(0); }
+  }
+
+  // Install missing components
+  const to_install: string[] = [];
+  if (!detection.colima_installed) to_install.push("colima");
+  if (!detection.docker_installed) to_install.push("docker");
+
+  // Always check docker-compose
+  const { exitCode: compose_exit } = await exec_command("which docker-compose 2>/dev/null");
+  if (compose_exit !== 0) to_install.push("docker-compose");
+
+  if (to_install.length > 0) {
+    spin.start(`Installing ${to_install.join(", ")}...`);
+    const install = await exec_command(`brew install ${to_install.join(" ")}`);
+    if (install.exitCode !== 0) {
+      spin.stop("Docker installation failed");
+      p.log.warning(`Install manually: brew install ${to_install.join(" ")}`);
+      return undefined;
+    }
+    spin.stop(`Installed ${to_install.join(", ")}`);
+  }
+
+  // Configure docker-compose CLI plugin path
+  const home = process.env["HOME"] ?? "";
+  const docker_config_path = `${home}/.docker/config.json`;
+  try {
+    await mkdir(`${home}/.docker`, { recursive: true });
+    let docker_config: Record<string, unknown> = {};
+    try {
+      const existing = await readFile(docker_config_path, "utf-8");
+      docker_config = JSON.parse(existing);
+    } catch { /* file doesn't exist yet */ }
+
+    docker_config["cliPluginsExtraDirs"] = ["/opt/homebrew/lib/docker/cli-plugins"];
+    await writeFile(docker_config_path, JSON.stringify(docker_config, null, 2) + "\n");
+  } catch (err) {
+    p.log.warning(`Failed to configure docker-compose plugin: ${String(err)}`);
+  }
+
+  // Start Colima if not running
+  if (!detection.colima_running) {
+    spin.start("Starting Colima (--cpu 2 --memory 4 --disk 30)...");
+    const start = await exec_command("colima start --cpu 2 --memory 4 --disk 30");
+    if (start.exitCode !== 0) {
+      spin.stop("Colima start failed");
+      p.log.warning("Start manually: colima start --cpu 2 --memory 4 --disk 30");
+      // Continue anyway — colima might already be running via different config
+    } else {
+      spin.stop("Colima started");
+    }
+  }
+
+  // Auto-start on login
+  spin.start("Enabling Colima auto-start...");
+  await exec_command("brew services start colima");
+  spin.stop("Colima auto-start enabled");
+
+  // Verify with hello-world
+  spin.start("Verifying Docker...");
+  const verify = await exec_command("docker run --rm hello-world 2>&1");
+  if (verify.exitCode === 0) {
+    spin.stop("Docker verified");
+  } else {
+    spin.stop("Docker verification failed — container runtime may need a moment");
+    p.log.warning("Try: docker run --rm hello-world");
+  }
+
+  // Get version info for summary
+  const recheck = await check_docker();
+  p.log.success(`Docker ready (Colima v${recheck.colima_version ?? "?"}, Docker v${recheck.docker_version ?? "?"})`);
+
+  return { installed: true, runtime: "colima" };
+}
+
+async function setup_vercel(
+  spin: ReturnType<typeof p.spinner>,
+  detection: VercelCheckResult,
+  _non_interactive: boolean,
+): Promise<ToolsConfig["vercel"]> {
+  p.log.step("Setting up Vercel");
+
+  if (!detection.installed) {
+    spin.start("Installing Vercel CLI...");
+    const install = await exec_command("brew install vercel-cli");
+    if (install.exitCode !== 0) {
+      // Fallback: try npm
+      const npm_install = await exec_command("npm install -g vercel");
+      if (npm_install.exitCode !== 0) {
+        spin.stop("Vercel installation failed");
+        p.log.warning("Install manually: brew install vercel-cli");
+        return undefined;
+      }
+    }
+    spin.stop("Vercel CLI installed");
+  }
+
+  if (!detection.authenticated) {
+    // Device auth flow — needs inherited stdio for URL display
+    p.log.info("Vercel will open a browser for authentication...");
+    const auth = spawnSync("vercel", ["login"], { stdio: "inherit" });
+    if (auth.status !== 0) {
+      p.log.warning("Vercel authentication failed or was cancelled.");
+      return { installed: true };
+    }
+  }
+
+  // Verify
+  const verify = await check_vercel();
+  if (verify.authenticated) {
+    p.log.success(`Vercel authenticated as ${verify.username}`);
+    return { installed: true, username: verify.username ?? undefined };
+  }
+
+  p.log.warning("Vercel setup completed but verification failed.");
+  return { installed: true };
+}
+
+async function setup_supabase(
+  spin: ReturnType<typeof p.spinner>,
+  detection: SupabaseCheckResult,
+  non_interactive: boolean,
+  token?: string,
+): Promise<ToolsConfig["supabase"]> {
+  p.log.step("Setting up Supabase");
+
+  if (!detection.installed) {
+    spin.start("Installing Supabase CLI...");
+    const install = await exec_command("brew install supabase/tap/supabase");
+    if (install.exitCode !== 0) {
+      spin.stop("Supabase installation failed");
+      p.log.warning("Install manually: brew install supabase/tap/supabase");
+      return undefined;
+    }
+    spin.stop("Supabase CLI installed");
+  }
+
+  if (!detection.authenticated) {
+    if (token) {
+      // Non-interactive: use provided token
+      spin.start("Authenticating Supabase...");
+      const auth = await exec_command(`supabase login --token ${token}`);
+      if (auth.exitCode !== 0) {
+        spin.stop("Supabase auth failed");
+        return undefined;
+      }
+      spin.stop("Supabase authenticated");
+    } else if (!non_interactive) {
+      // Try interactive login first
+      p.log.info("Attempting Supabase login...");
+      const interactive_result = spawnSync("supabase", ["login"], { stdio: "inherit" });
+
+      if (interactive_result.status !== 0) {
+        // Fallback: prompt for token
+        p.note(
+          "Supabase requires a token for non-interactive auth.\n" +
+          "Generate one at: https://supabase.com/dashboard/account/tokens",
+          "Supabase Token",
+        );
+        const manual_token = await p.password({ message: "Paste your Supabase access token:" });
+        if (p.isCancel(manual_token)) { p.cancel("Setup cancelled."); process.exit(0); }
+
+        if (manual_token?.trim()) {
+          spin.start("Authenticating Supabase...");
+          const auth = await exec_command(`supabase login --token ${manual_token.trim()}`);
+          if (auth.exitCode !== 0) {
+            spin.stop("Supabase auth failed");
+            return { installed: true };
+          }
+          spin.stop("Supabase authenticated");
+        }
+      }
+    } else {
+      // Non-interactive without token — skip auth
+      p.log.warning("Supabase token required for non-interactive auth. Skipping.");
+      return { installed: true };
+    }
+  }
+
+  // Verify
+  const verify = await check_supabase();
+  if (verify.authenticated) {
+    p.log.success("Supabase authenticated");
+    return { installed: true };
+  }
+
+  return { installed: true };
+}
+
+async function setup_sentry(
+  spin: ReturnType<typeof p.spinner>,
+  detection: SentryCheckResult,
+  non_interactive: boolean,
+  token?: string,
+): Promise<ToolsConfig["sentry"]> {
+  p.log.step("Setting up Sentry");
+
+  if (!detection.installed) {
+    spin.start("Installing Sentry CLI...");
+    const install = await exec_command("brew install getsentry/tools/sentry-cli");
+    if (install.exitCode !== 0) {
+      spin.stop("Sentry CLI installation failed");
+      p.log.warning("Install manually: brew install getsentry/tools/sentry-cli");
+      return undefined;
+    }
+    spin.stop("Sentry CLI installed");
+  }
+
+  let auth_token = token;
+
+  if (!detection.authenticated && !auth_token) {
+    if (non_interactive) {
+      p.log.warning("Sentry token required for non-interactive auth. Skipping.");
+      return { installed: true };
+    }
+
+    p.note(
+      "Generate a Sentry auth token at:\n" +
+      "https://sentry.io/settings/account/api/auth-tokens/\n\n" +
+      "Scopes needed: project:read, project:write, org:read, event:read, event:write",
+      "Sentry Token",
+    );
+    const prompted_token = await p.password({ message: "Paste your Sentry auth token:" });
+    if (p.isCancel(prompted_token)) { p.cancel("Setup cancelled."); process.exit(0); }
+    auth_token = prompted_token?.trim() || undefined;
+  }
+
+  if (auth_token) {
+    // Write token to ~/.sentryclirc
+    const home = process.env["HOME"] ?? "";
+    const sentryclirc_path = `${home}/.sentryclirc`;
+
+    let org: string | undefined;
+
+    // Write token first so sentry-cli can authenticate
+    const initial_content = `[auth]\ntoken = ${auth_token}\n`;
+    await writeFile(sentryclirc_path, initial_content, { mode: 0o600 });
+
+    // Try to get org
+    if (!non_interactive) {
+      spin.start("Fetching Sentry organizations...");
+      const orgs_result = await exec_command("sentry-cli organizations list 2>/dev/null");
+      spin.stop("Organizations fetched");
+
+      if (orgs_result.exitCode === 0 && orgs_result.stdout.trim()) {
+        // Parse org list — each line has org slug
+        const lines = orgs_result.stdout.trim().split("\n").filter((l) => l.trim() && !l.startsWith("-"));
+        // Filter header lines — org lines typically don't start with "Name" or have dashes
+        const org_slugs = lines
+          .map((l) => l.trim().split(/\s+/)[0])
+          .filter((s): s is string => Boolean(s) && s !== "Name" && s !== "Slug" && !s?.startsWith("|"));
+
+        if (org_slugs.length === 1) {
+          org = org_slugs[0];
+        } else if (org_slugs.length > 1) {
+          const selected = await p.select({
+            message: "Select default Sentry organization:",
+            options: org_slugs.map((s) => ({ value: s, label: s })),
+          });
+          if (p.isCancel(selected)) { p.cancel("Setup cancelled."); process.exit(0); }
+          org = selected;
+        }
+      }
+    }
+
+    // Write final config with org
+    let rc_content = "";
+    if (org) {
+      rc_content += `[defaults]\norg = ${org}\n\n`;
+    }
+    rc_content += `[auth]\ntoken = ${auth_token}\n`;
+    await writeFile(sentryclirc_path, rc_content, { mode: 0o600 });
+  }
+
+  // Verify
+  const verify = await check_sentry();
+  if (verify.authenticated) {
+    p.log.success(`Sentry authenticated${verify.org ? ` (org: ${verify.org})` : ""}`);
+    return { installed: true, org: verify.org ?? undefined };
+  }
+
+  return { installed: true };
+}
+
+// ── Main entry point ──
+
+/**
+ * Run the tool integrations step of the init wizard.
+ *
+ * In interactive mode: detect all tools, show multiselect, run setup flows.
+ * In non-interactive mode with --tools: install only listed tools.
+ * In non-interactive mode without --tools: skip entirely.
+ */
+export async function setup_tool_integrations(
+  spin: ReturnType<typeof p.spinner>,
+  non_interactive: boolean,
+  options: ToolSetupOptions,
+): Promise<ToolsConfig | undefined> {
+  // Non-interactive without --tools: skip
+  if (non_interactive && !options.tools) {
+    return undefined;
+  }
+
+  // Detect all tools
+  spin.start("Detecting installed tools...");
+  const detection = await detect_all_tools();
+  spin.stop("Tool detection complete");
+
+  let selected_tools: ToolName[];
+
+  if (options.tools) {
+    // Parse --tools flag
+    selected_tools = options.tools.split(",").map((t) => t.trim()).filter(
+      (t): t is ToolName => TOOL_NAMES.includes(t as ToolName),
+    );
+    if (selected_tools.length === 0) {
+      p.log.warning(`No valid tools in --tools flag. Valid options: ${TOOL_NAMES.join(", ")}`);
+      return undefined;
+    }
+  } else {
+    // Interactive multiselect
+    const tool_options = build_tool_options(detection);
+    const initial_values = default_selections(detection);
+
+    const choices = await p.multiselect({
+      message: "Which optional tools would you like to set up?",
+      options: tool_options.map((opt) => ({
+        value: opt.value,
+        label: opt.label,
+        hint: opt.hint,
+      })),
+      initialValues: initial_values,
+      required: false,
+    });
+
+    if (p.isCancel(choices)) { p.cancel("Setup cancelled."); process.exit(0); }
+    selected_tools = (choices as ToolName[]) ?? [];
+  }
+
+  if (selected_tools.length === 0) {
+    p.log.info("No tools selected. Skipping tool setup.");
+    return undefined;
+  }
+
+  // Walk through each selected tool sequentially.
+  // Failures in one tool don't block others.
+  const tools_config: ToolsConfig = {};
+
+  for (const tool of selected_tools) {
+    try {
+      switch (tool) {
+        case "tailscale": {
+          const result = await setup_tailscale(spin, detection.tailscale, non_interactive, options.tailscaleAuthkey);
+          if (result) tools_config.tailscale = result;
+          break;
+        }
+        case "docker": {
+          const result = await setup_docker(spin, detection.docker, non_interactive);
+          if (result) tools_config.docker = result;
+          break;
+        }
+        case "vercel": {
+          const result = await setup_vercel(spin, detection.vercel, non_interactive);
+          if (result) tools_config.vercel = result;
+          break;
+        }
+        case "supabase": {
+          const result = await setup_supabase(spin, detection.supabase, non_interactive, options.supabaseToken);
+          if (result) tools_config.supabase = result;
+          break;
+        }
+        case "sentry": {
+          const result = await setup_sentry(spin, detection.sentry, non_interactive, options.sentryToken);
+          if (result) tools_config.sentry = result;
+          break;
+        }
+      }
+    } catch (err) {
+      p.log.warning(`${tool} setup failed: ${String(err)}`);
+    }
+  }
+
+  return Object.keys(tools_config).length > 0 ? tools_config : undefined;
+}

--- a/packages/shared/src/schemas/config.ts
+++ b/packages/shared/src/schemas/config.ts
@@ -62,6 +62,29 @@ export const LobsterFarmConfigSchema = z.object({
     operator: AgentNameSchema.default({ name: "Ray" }),
     commander: AgentNameSchema.default({ name: "Pat" }),
   }).default({}),
+
+  tools: z.object({
+    tailscale: z.object({
+      installed: z.boolean().default(false),
+      hostname: z.string().optional(),
+      ip: z.string().optional(),
+    }).optional(),
+    docker: z.object({
+      installed: z.boolean().default(false),
+      runtime: z.enum(["colima", "docker-desktop", "other"]).optional(),
+    }).optional(),
+    vercel: z.object({
+      installed: z.boolean().default(false),
+      username: z.string().optional(),
+    }).optional(),
+    supabase: z.object({
+      installed: z.boolean().default(false),
+    }).optional(),
+    sentry: z.object({
+      installed: z.boolean().default(false),
+      org: z.string().optional(),
+    }).optional(),
+  }).optional(),
 });
 
 export type LobsterFarmConfig = z.infer<typeof LobsterFarmConfigSchema>;


### PR DESCRIPTION
## Summary

- Adds a `p.multiselect()` step to `lf init` for 5 optional tools: Tailscale, Docker/Colima, Vercel, Supabase, and Sentry
- Each tool gets a detection function (install state, auth state, GUI conflict checks) and a sequential setup flow (brew install + native auth)
- Config schema extended with `tools` section; summary output shows installed tool statuses
- Non-interactive mode supported via `--tools`, `--tailscale-authkey`, `--sentry-token`, `--supabase-token` flags

### Files changed

- `packages/cli/src/commands/init/detect.ts` — 5 new detection functions with rich status
- `packages/cli/src/commands/init/tools.ts` — new module: multiselect UI, setup flows, error isolation
- `packages/cli/src/commands/init.ts` — wiring, CLI flags, summary output
- `packages/shared/src/schemas/config.ts` — `tools` section in LobsterFarmConfigSchema

### Key implementation details

- Tailscale: custom LaunchDaemon (not brew services), `tailscale up --ssh` with stdio:inherit
- Docker: Colima + docker + docker-compose, CLI plugin config, `colima start`
- Vercel: `vercel login` device auth with stdio:inherit
- Supabase: interactive login with password prompt fallback
- Sentry: `getsentry/tools/sentry-cli`, token prompt, `~/.sentryclirc`, org selection
- Failures in one tool don't block others (try/catch per tool)

## Test plan

- [ ] Multi-select appears after Full Disk Access, before Discord
- [ ] Already-installed tools show correct status in selection UI
- [ ] Already-configured tools are unchecked by default
- [ ] Declining all tools skips cleanly
- [ ] Each tool installs + authenticates independently
- [ ] Tailscale: GUI conflict warning appears when Tailscale.app present
- [ ] Tailscale: LaunchDaemon created with correct PATH and socket
- [ ] Docker: Colima starts, docker-compose plugin configured
- [ ] Docker Desktop conflict warning appears when Docker.app present
- [ ] Vercel: device auth flow completes
- [ ] Supabase: token auth flow completes (non-TTY fallback)
- [ ] Sentry: token prompt + org selection works
- [ ] Config contains `tools` section with correct data
- [ ] Summary shows all installed tools with status
- [ ] `--non-interactive --tools tailscale,docker --tailscale-authkey <key>` works
- [ ] `--non-interactive` without `--tools` skips tool step entirely
- [ ] Partial failures don't block other tools
- [ ] Shared package tests pass (54/54)

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)