### PR TITLE
fix: include PR title in alert notifications

### DIFF
--- a/packages/daemon/src/features.ts
+++ b/packages/daemon/src/features.ts
@@ -546,7 +546,7 @@ export class FeatureManager extends EventEmitter {
         // Notify alerts about the bounce
         await actions.notify_feature(
           feature,
-          `Review bounced ${feature.id} back to build -- changes requested on PR #${String(feature.prNumber)}`,
+          `PR #${String(feature.prNumber)}: ${feature.title} — changes requested, bouncing back to build`,
           entity,
           { also_alerts: true },
         );

--- a/packages/daemon/src/pr-cron.ts
+++ b/packages/daemon/src/pr-cron.ts
@@ -311,7 +311,7 @@ export class PRReviewCron {
       await this.spawn_external_pr_fixer(entity_id, repo_path, pr);
       await this.notify_alerts(
         entity_id,
-        `External PR #${String(pr.number)} needs changes — spawning builder to fix`,
+        `External PR #${String(pr.number)}: ${pr.title} — needs changes, spawning builder to fix`,
       );
     } else if (review_state === "approved") {
       // Check if the reviewer already merged (they're instructed to merge on approval)
@@ -319,13 +319,13 @@ export class PRReviewCron {
       if (is_merged) {
         await this.notify_alerts(
           entity_id,
-          `External PR #${String(pr.number)} approved and merged`,
+          `External PR #${String(pr.number)}: ${pr.title} — approved and merged to main`,
         );
       } else {
         // Not yet merged — escalate to human
         await this.notify_alerts(
           entity_id,
-          `External PR #${String(pr.number)} approved — awaiting human merge approval`,
+          `External PR #${String(pr.number)}: ${pr.title} — approved, awaiting human merge`,
         );
       }
     } else {


### PR DESCRIPTION
## Summary

- PR review and merge notifications in `#alerts` now include the PR title alongside the number (e.g. `PR #73: fix lazy session resume -- approved and merged to main` instead of just `PR #73 approved and merged`)
- Updated 4 notification messages across `pr-cron.ts` (3 external PR alerts) and `features.ts` (1 review bounce alert)
- No new data fetching needed -- PR titles were already available from existing GitHub API calls

## Test plan

- [x] All 419 existing tests pass (54 shared + 21 cli + 344 daemon)
- [ ] Trigger a PR review notification -- verify title is included
- [ ] Merge a PR -- verify merge notification includes title
- [ ] Long PR titles -- verify no truncation issues

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)