### PR TITLE
fix: re-review PRs when commits are pushed after feedback

### DIFF
--- a/packages/daemon/src/__tests__/pr-cron.test.ts
+++ b/packages/daemon/src/__tests__/pr-cron.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
+import type { LobsterFarmConfig } from "@lobster-farm/shared";
+import { PRReviewCron } from "../pr-cron.js";
+
+// ── Helpers ──
+
+function make_config(): LobsterFarmConfig {
+  return LobsterFarmConfigSchema.parse({
+    user: { name: "Test" },
+  });
+}
+
+/** ISO timestamps for test scenarios. Spaced apart to be clearly outside the 60s buffer. */
+const T = {
+  review:       "2026-03-27T10:00:00Z",
+  commit_old:   "2026-03-27T09:00:00Z",  // 1h before review
+  commit_new:   "2026-03-27T11:00:00Z",  // 1h after review
+  commit_close: "2026-03-27T10:00:30Z",  // 30s after review (within 60s buffer)
+};
+
+/** Shape matching the private PRFeedbackData interface. */
+interface FeedbackData {
+  reviews: Array<{ submittedAt: string; author: { login: string }; state: string }>;
+  comments: Array<{ createdAt: string; author: { login: string } }>;
+  commits: Array<{ committedDate: string }>;
+}
+
+/** Build a PRFeedbackData object for test scenarios. */
+function make_pr_data(opts: {
+  reviews?: Array<{ submittedAt: string; login?: string; state?: string }>;
+  comments?: Array<{ createdAt: string; login?: string }>;
+  commits?: Array<{ committedDate: string }>;
+}): FeedbackData {
+  return {
+    reviews: (opts.reviews ?? []).map(r => ({
+      submittedAt: r.submittedAt,
+      author: { login: r.login ?? "reviewer-bot" },
+      state: r.state ?? "COMMENTED",
+    })),
+    comments: (opts.comments ?? []).map(c => ({
+      createdAt: c.createdAt,
+      author: { login: c.login ?? "reviewer-bot" },
+    })),
+    commits: (opts.commits ?? []).map(c => ({
+      committedDate: c.committedDate,
+    })),
+  };
+}
+
+/**
+ * Test-friendly subclass that overrides the protected fetch_pr_feedback method
+ * to return canned data instead of calling `gh` CLI. This follows the same
+ * pattern as TestBotPool overriding is_bot_idle.
+ */
+class TestPRReviewCron extends PRReviewCron {
+  private feedback_responses = new Map<number, FeedbackData | null>();
+
+  constructor() {
+    const config = make_config();
+    super(
+      { get_active: () => [] } as never,
+      { spawn: vi.fn(), on: vi.fn(), removeListener: vi.fn() } as never,
+      config,
+      null,
+      null,
+    );
+  }
+
+  /** Set the feedback data to return for a specific PR number. */
+  set_feedback(pr_number: number, data: FeedbackData | null): void {
+    this.feedback_responses.set(pr_number, data);
+  }
+
+  /** Override to return canned data instead of calling gh CLI. */
+  protected override async fetch_pr_feedback(
+    _repo_path: string,
+    pr_number: number,
+  ): Promise<FeedbackData | null> {
+    const response = this.feedback_responses.get(pr_number);
+    // If no response set, return null (simulates gh CLI error)
+    if (response === undefined) return null;
+    return response;
+  }
+
+  /**
+   * Expose the private should_skip_pr for direct testing.
+   * Uses bracket notation to call the private method.
+   */
+  async test_should_skip_pr(pr_number: number): Promise<boolean> {
+    type SkipFn = (repo_path: string, pr_number: number) => Promise<boolean>;
+    const fn = (this as unknown as { should_skip_pr: SkipFn }).should_skip_pr.bind(this);
+    return fn("/test/repo", pr_number);
+  }
+}
+
+// ── Tests ──
+
+describe("PRReviewCron.should_skip_pr", () => {
+  let cron: TestPRReviewCron;
+  let log_spy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    cron = new TestPRReviewCron();
+    log_spy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    log_spy.mockRestore();
+  });
+
+  it("does not skip PR with no reviews or comments (never reviewed)", async () => {
+    cron.set_feedback(42, make_pr_data({
+      reviews: [],
+      comments: [],
+      commits: [{ committedDate: T.commit_new }],
+    }));
+
+    const skip = await cron.test_should_skip_pr(42);
+    expect(skip).toBe(false);
+  });
+
+  it("skips PR with review and no new commits", async () => {
+    cron.set_feedback(42, make_pr_data({
+      reviews: [{ submittedAt: T.review }],
+      comments: [],
+      commits: [{ committedDate: T.commit_old }],
+    }));
+
+    const skip = await cron.test_should_skip_pr(42);
+    expect(skip).toBe(true);
+  });
+
+  it("does not skip PR with review followed by new commits", async () => {
+    cron.set_feedback(42, make_pr_data({
+      reviews: [{ submittedAt: T.review }],
+      comments: [],
+      commits: [
+        { committedDate: T.commit_old },
+        { committedDate: T.commit_new },
+      ],
+    }));
+
+    const skip = await cron.test_should_skip_pr(42);
+    expect(skip).toBe(false);
+  });
+
+  it("skips when commit is within the 60s timestamp buffer", async () => {
+    cron.set_feedback(42, make_pr_data({
+      reviews: [{ submittedAt: T.review }],
+      comments: [],
+      commits: [{ committedDate: T.commit_close }],
+    }));
+
+    const skip = await cron.test_should_skip_pr(42);
+    expect(skip).toBe(true);
+  });
+
+  it("does not skip when commit is just past the 60s buffer", async () => {
+    // 61s after review — just past the buffer
+    const commit_past_buffer = "2026-03-27T10:01:01Z";
+    cron.set_feedback(42, make_pr_data({
+      reviews: [{ submittedAt: T.review }],
+      comments: [],
+      commits: [{ committedDate: commit_past_buffer }],
+    }));
+
+    const skip = await cron.test_should_skip_pr(42);
+    expect(skip).toBe(false);
+  });
+
+  it("uses comment timestamps when no formal reviews exist", async () => {
+    cron.set_feedback(42, make_pr_data({
+      reviews: [],
+      comments: [{ createdAt: T.review }],
+      commits: [{ committedDate: T.commit_old }],
+    }));
+
+    const skip = await cron.test_should_skip_pr(42);
+    expect(skip).toBe(true);
+  });
+
+  it("compares against the LATEST feedback across reviews and comments", async () => {
+    const early_review = "2026-03-27T08:00:00Z";
+    const late_comment = "2026-03-27T12:00:00Z";
+    const mid_commit = "2026-03-27T11:00:00Z";
+
+    cron.set_feedback(42, make_pr_data({
+      reviews: [{ submittedAt: early_review }],
+      comments: [{ createdAt: late_comment }],
+      commits: [{ committedDate: mid_commit }],
+    }));
+
+    // Latest feedback (comment at 12:00) is after latest commit (11:00) — skip
+    const skip = await cron.test_should_skip_pr(42);
+    expect(skip).toBe(true);
+  });
+
+  it("handles multiple review rounds — compares against latest", async () => {
+    cron.set_feedback(42, make_pr_data({
+      // Round 1: review + comment, then fix
+      // Round 2: re-review + comment, then another fix
+      reviews: [
+        { submittedAt: "2026-03-27T08:00:00Z" },
+        { submittedAt: "2026-03-27T10:00:00Z" },
+      ],
+      comments: [
+        { createdAt: "2026-03-27T08:30:00Z" },
+        { createdAt: "2026-03-27T10:30:00Z" },
+      ],
+      commits: [
+        { committedDate: "2026-03-27T07:00:00Z" },
+        { committedDate: "2026-03-27T09:00:00Z" },
+        { committedDate: "2026-03-27T11:30:00Z" }, // newest, after all feedback
+      ],
+    }));
+
+    const skip = await cron.test_should_skip_pr(42);
+    expect(skip).toBe(false); // newest commit is after latest feedback (10:30)
+  });
+
+  it("does not skip on gh CLI error (fail-open)", async () => {
+    // No feedback set — simulates gh error (returns null)
+    const skip = await cron.test_should_skip_pr(99);
+    expect(skip).toBe(false);
+  });
+
+  it("does not skip when explicitly set to null (gh error)", async () => {
+    cron.set_feedback(42, null);
+
+    const skip = await cron.test_should_skip_pr(42);
+    expect(skip).toBe(false);
+  });
+
+  it("does not skip when commits array is empty", async () => {
+    cron.set_feedback(42, make_pr_data({
+      reviews: [{ submittedAt: T.review }],
+      comments: [],
+      commits: [],
+    }));
+
+    const skip = await cron.test_should_skip_pr(42);
+    expect(skip).toBe(false);
+  });
+
+  it("logs re-review reason when commits are newer", async () => {
+    cron.set_feedback(42, make_pr_data({
+      reviews: [{ submittedAt: T.review }],
+      comments: [],
+      commits: [{ committedDate: T.commit_new }],
+    }));
+
+    await cron.test_should_skip_pr(42);
+
+    const log_messages = log_spy.mock.calls.map(c => c[0]) as string[];
+    expect(log_messages.some(m =>
+      typeof m === "string" && m.includes("PR #42") && m.includes("needs re-review"),
+    )).toBe(true);
+  });
+
+  it("logs skip reason when already reviewed", async () => {
+    cron.set_feedback(42, make_pr_data({
+      reviews: [{ submittedAt: T.review }],
+      comments: [],
+      commits: [{ committedDate: T.commit_old }],
+    }));
+
+    await cron.test_should_skip_pr(42);
+
+    const log_messages = log_spy.mock.calls.map(c => c[0]) as string[];
+    expect(log_messages.some(m =>
+      typeof m === "string" && m.includes("PR #42") && m.includes("already reviewed"),
+    )).toBe(true);
+  });
+});

--- a/packages/daemon/src/pr-cron.ts
+++ b/packages/daemon/src/pr-cron.ts
@@ -30,9 +30,35 @@ interface ActiveReview {
   last_checked: Date;
 }
 
+// ── GitHub API response shapes (subset of what gh pr view --json returns) ──
+
+interface GHReview {
+  submittedAt: string;
+  author: { login: string };
+  state: string;
+}
+
+interface GHComment {
+  createdAt: string;
+  author: { login: string };
+}
+
+interface GHCommit {
+  committedDate: string;
+}
+
+interface PRFeedbackData {
+  reviews: GHReview[];
+  comments: GHComment[];
+  commits: GHCommit[];
+}
+
 // ── PR Cron ──
 
 const DEFAULT_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+/** Buffer in ms to avoid re-reviewing when commit and review timestamps are very close. */
+const TIMESTAMP_BUFFER_MS = 60_000; // 60 seconds
 
 export class PRReviewCron {
   private timer: ReturnType<typeof setInterval> | null = null;
@@ -164,10 +190,9 @@ export class PRReviewCron {
 
       console.log(`[pr-cron] Found open PR #${String(pr.number)} in ${entity_id}: "${pr.title}"`);
 
-      // Check if PR already has a review
-      const has_review = await this.pr_has_review(repo_path, pr.number);
-      if (has_review) {
-        console.log(`[pr-cron] PR #${String(pr.number)} already reviewed, skipping`);
+      // Check if PR needs (re-)review by comparing commit vs feedback timestamps
+      const skip = await this.should_skip_pr(repo_path, pr.number);
+      if (skip) {
         continue;
       }
 
@@ -176,18 +201,80 @@ export class PRReviewCron {
     }
   }
 
-  /** Check if a PR already has a review (formal reviews OR comments). */
-  private async pr_has_review(repo_path: string, pr_number: number): Promise<boolean> {
+  /**
+   * Decide whether to skip a PR based on commit vs review/comment timestamps.
+   *
+   * - No feedback at all: don't skip (never reviewed)
+   * - Latest commit is newer than latest feedback + buffer: don't skip (needs re-review)
+   * - Latest feedback is at or after latest commit: skip (already reviewed)
+   */
+  private async should_skip_pr(repo_path: string, pr_number: number): Promise<boolean> {
+    const data = await this.fetch_pr_feedback(repo_path, pr_number);
+    if (!data) {
+      // Can't fetch PR data — don't skip, let the reviewer attempt proceed
+      return false;
+    }
+
+    // Extract feedback timestamps from reviews and comments.
+    // Note: we don't filter by author here. In this codebase all reviews come from
+    // the same GitHub account (ultim88888888). If CI bots start posting comments,
+    // add author filtering (e.g., skip authors with [bot] suffix or known CI logins).
+    const feedback_timestamps: number[] = [];
+
+    for (const review of data.reviews) {
+      if (review.submittedAt) {
+        feedback_timestamps.push(new Date(review.submittedAt).getTime());
+      }
+    }
+    for (const comment of data.comments) {
+      if (comment.createdAt) {
+        feedback_timestamps.push(new Date(comment.createdAt).getTime());
+      }
+    }
+
+    // No feedback at all — never reviewed
+    if (feedback_timestamps.length === 0) {
+      return false;
+    }
+
+    const latest_feedback = Math.max(...feedback_timestamps);
+
+    // Get latest commit timestamp — commits are returned in chronological order
+    const commits = data.commits;
+    if (commits.length === 0) {
+      // No commits somehow — don't skip, something is off
+      return false;
+    }
+
+    const last_commit = commits[commits.length - 1]!;
+    const latest_commit_ts = new Date(last_commit.committedDate).getTime();
+
+    // Re-review if commits are newer than feedback (with buffer for timestamp rounding)
+    if (latest_commit_ts > latest_feedback + TIMESTAMP_BUFFER_MS) {
+      console.log(
+        `[pr-cron] PR #${String(pr_number)} has commits newer than latest feedback — needs re-review`,
+      );
+      return false;
+    }
+
+    console.log(`[pr-cron] PR #${String(pr_number)} already reviewed, skipping`);
+    return true;
+  }
+
+  /** Fetch reviews, comments, and commits for a PR via gh CLI. Returns null on error. */
+  protected async fetch_pr_feedback(
+    repo_path: string,
+    pr_number: number,
+  ): Promise<PRFeedbackData | null> {
     try {
       const { stdout } = await exec("gh", [
         "pr", "view", String(pr_number),
-        "--json", "reviews,comments",
-        "--jq", "(.reviews | length) + (.comments | length)",
+        "--json", "reviews,comments,commits",
       ], { cwd: repo_path, timeout: 15_000 });
 
-      return parseInt(stdout.trim(), 10) > 0;
+      return JSON.parse(stdout) as PRFeedbackData;
     } catch {
-      return false;
+      return null;
     }
   }
 


### PR DESCRIPTION
## Summary

- Replaced the binary `pr_has_review()` check with timestamp-aware `should_skip_pr()` that compares latest commit vs latest review/comment timestamps
- PRs with commits newer than the most recent feedback (with 60s buffer) are re-reviewed instead of skipped
- Extracted `fetch_pr_feedback()` as a protected method for clean test overriding (follows existing `TestBotPool.is_bot_idle` pattern)

## Test plan

- [x] PR with review but no new commits -- skipped (existing behavior preserved)
- [x] PR with review + new commits -- re-reviewed
- [x] PR with no reviews -- reviewed (existing behavior preserved)
- [x] PR with multiple review rounds -- compares against latest review
- [x] Commit within 60s buffer of review -- skipped (timestamp rounding protection)
- [x] Commit just past 60s buffer -- re-reviewed
- [x] gh CLI error -- fail-open (don't skip)
- [x] Empty commits array -- fail-open
- [x] Comment-only feedback (no formal reviews) -- uses comment timestamps
- [x] Mixed reviews + comments -- uses latest across both
- [x] Logging for re-review and skip decisions
- [x] All 357 tests pass (344 existing + 13 new)

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)