### PR TITLE
feat: auto-fix loop -- reviewer feedback triggers builder automatically

### DIFF
--- a/packages/daemon/src/__tests__/auto-fix-loop.test.ts
+++ b/packages/daemon/src/__tests__/auto-fix-loop.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it, vi } from "vitest";
+
+// ── Mock child_process ──
+// vi.hoisted() ensures the mock ref is available when vi.mock factory runs
+// (vi.mock is hoisted above all imports by vitest).
+//
+// Node's real execFile has a [util.promisify.custom] symbol that makes
+// promisify(execFile) return {stdout, stderr}. Our mock needs the same
+// so that `const { stdout } = await exec_async(...)` works correctly.
+
+const { execFile_mock } = vi.hoisted(() => {
+  const mock = vi.fn();
+
+  // Attach the custom promisify symbol so promisify(mock) returns {stdout, stderr}
+  // The symbol is the well-known Symbol.for("nodejs.util.promisify.custom")
+  const CUSTOM = Symbol.for("nodejs.util.promisify.custom");
+  Object.defineProperty(mock, CUSTOM, {
+    value: (...args: unknown[]) => {
+      return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+        mock(...args, (err: Error | null, stdout: string, stderr: string) => {
+          if (err) reject(err);
+          else resolve({ stdout, stderr });
+        });
+      });
+    },
+    configurable: true,
+  });
+
+  return { execFile_mock: mock };
+});
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    execFile: execFile_mock,
+  };
+});
+
+import {
+  build_review_fix_prompt,
+  fetch_review_comments,
+  check_merge_conflicts,
+} from "../features.js";
+
+/**
+ * Configure execFile mock to return specific stdout/error for sequential calls.
+ * promisify(execFile) calls execFile(cmd, args, opts, callback) — the callback
+ * is always the last argument.
+ */
+function mock_gh_responses(responses: Array<{ stdout?: string; error?: Error }>): void {
+  let call_idx = 0;
+  execFile_mock.mockImplementation((...args: unknown[]) => {
+    const resp = responses[Math.min(call_idx, responses.length - 1)]!;
+    call_idx++;
+
+    // promisify adds callback as the last argument
+    const callback = args[args.length - 1] as
+      (err: Error | null, stdout: string, stderr: string) => void;
+
+    if (typeof callback === "function") {
+      if (resp.error) {
+        callback(resp.error, "", "");
+      } else {
+        callback(null, resp.stdout ?? "", "");
+      }
+    }
+    return { pid: 1 };
+  });
+}
+
+// ── build_review_fix_prompt (pure function) ──
+
+describe("build_review_fix_prompt", () => {
+  it("includes review comments when provided", () => {
+    const prompt = build_review_fix_prompt(42, "Add caching", "Fix the TTL logic in cache.ts");
+    expect(prompt).toContain("PR #42");
+    expect(prompt).toContain("Add caching");
+    expect(prompt).toContain("## Reviewer Feedback");
+    expect(prompt).toContain("Fix the TTL logic in cache.ts");
+    expect(prompt).toContain("## Instructions");
+    expect(prompt).toContain("Do NOT change anything the reviewer didn't flag");
+  });
+
+  it("omits reviewer feedback section when no comments", () => {
+    const prompt = build_review_fix_prompt(42, "Add caching");
+    expect(prompt).toContain("PR #42");
+    expect(prompt).not.toContain("## Reviewer Feedback");
+    expect(prompt).toContain("## Instructions");
+  });
+
+  it("omits reviewer feedback section when comments are undefined", () => {
+    const prompt = build_review_fix_prompt(42, "Add caching", undefined);
+    expect(prompt).not.toContain("## Reviewer Feedback");
+  });
+
+  it("includes all required instruction steps", () => {
+    const prompt = build_review_fix_prompt(1, "Title", "feedback");
+    expect(prompt).toContain("Read the reviewer's feedback carefully");
+    expect(prompt).toContain("Fix each issue mentioned");
+    expect(prompt).toContain("Run the test suite");
+    expect(prompt).toContain("Commit and push");
+    expect(prompt).toContain("Keep changes minimal and targeted");
+  });
+});
+
+// ── fetch_review_comments ──
+
+describe("fetch_review_comments", () => {
+  it("returns the latest CHANGES_REQUESTED review body", async () => {
+    mock_gh_responses([{ stdout: "Please fix the null check on line 42\n" }]);
+    const result = await fetch_review_comments(10, "/tmp/repo");
+    expect(result).toBe("Please fix the null check on line 42");
+  });
+
+  it("falls back to last review body when CHANGES_REQUESTED filter returns empty", async () => {
+    mock_gh_responses([
+      { stdout: "" },  // first call: CHANGES_REQUESTED filter returns empty
+      { stdout: "General review body\n" },  // second call: last review fallback
+    ]);
+    const result = await fetch_review_comments(10, "/tmp/repo");
+    expect(result).toBe("General review body");
+  });
+
+  it("returns fallback message when all gh calls fail", async () => {
+    mock_gh_responses([
+      { error: new Error("gh not found") },
+      { error: new Error("gh not found") },
+    ]);
+    const result = await fetch_review_comments(10, "/tmp/repo");
+    expect(result).toContain("Could not fetch review comments");
+    expect(result).toContain("gh pr view 10");
+  });
+
+  it("returns empty-body fallback when both calls return empty", async () => {
+    mock_gh_responses([
+      { stdout: "" },
+      { stdout: "" },
+    ]);
+    const result = await fetch_review_comments(10, "/tmp/repo");
+    expect(result).toContain("No review body found");
+  });
+});
+
+// ── check_merge_conflicts ──
+
+describe("check_merge_conflicts", () => {
+  it("returns true when PR is CONFLICTING", async () => {
+    mock_gh_responses([{ stdout: "CONFLICTING\n" }]);
+    const result = await check_merge_conflicts(10, "/tmp/repo");
+    expect(result).toBe(true);
+  });
+
+  it("returns false when PR is MERGEABLE", async () => {
+    mock_gh_responses([{ stdout: "MERGEABLE\n" }]);
+    const result = await check_merge_conflicts(10, "/tmp/repo");
+    expect(result).toBe(false);
+  });
+
+  it("returns false when PR is UNKNOWN", async () => {
+    mock_gh_responses([{ stdout: "UNKNOWN\n" }]);
+    const result = await check_merge_conflicts(10, "/tmp/repo");
+    expect(result).toBe(false);
+  });
+
+  it("returns false on error (conservative -- don't block on uncertainty)", async () => {
+    mock_gh_responses([{ error: new Error("network error") }]);
+    const result = await check_merge_conflicts(10, "/tmp/repo");
+    expect(result).toBe(false);
+  });
+});
+
+// ── reviewBounceCount schema field ──
+
+describe("reviewBounceCount schema field", () => {
+  it("defaults to 0 when not provided", async () => {
+    const { FeatureStateSchema } = await import("@lobster-farm/shared");
+    const feature = FeatureStateSchema.parse({
+      id: "test-1",
+      entity: "test",
+      githubIssue: 1,
+      title: "Test",
+      phase: "plan",
+      branch: "feature/1-test",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    expect(feature.reviewBounceCount).toBe(0);
+  });
+
+  it("preserves an explicit bounce count", async () => {
+    const { FeatureStateSchema } = await import("@lobster-farm/shared");
+    const feature = FeatureStateSchema.parse({
+      id: "test-2",
+      entity: "test",
+      githubIssue: 2,
+      title: "Test",
+      phase: "review",
+      branch: "feature/2-test",
+      reviewBounceCount: 3,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    expect(feature.reviewBounceCount).toBe(3);
+  });
+});
+
+// ── ESCALATE marker detection ──
+
+describe("ESCALATE marker detection", () => {
+  it("detects ESCALATE in review comments (uppercase)", () => {
+    const comments = "This PR has security issues.\n\nESCALATE: needs human review of the auth flow.";
+    expect(comments.toUpperCase().includes("ESCALATE")).toBe(true);
+  });
+
+  it("does not trigger on normal review comments", () => {
+    const comments = "Please fix the null check on line 42.";
+    expect(comments.toUpperCase().includes("ESCALATE")).toBe(false);
+  });
+
+  it("detects escalate in lowercase (case-insensitive check)", () => {
+    const comments = "I think we need to escalate this to a senior.";
+    expect(comments.toUpperCase().includes("ESCALATE")).toBe(true);
+  });
+
+  it("detects ESCALATE in mixed case", () => {
+    const comments = "Escalate: auth issue needs human eyes.";
+    expect(comments.toUpperCase().includes("ESCALATE")).toBe(true);
+  });
+});

--- a/packages/daemon/src/features.ts
+++ b/packages/daemon/src/features.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
-import { execFileSync } from "node:child_process";
+import { execFileSync, execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { writeFile as writeFileAsync, unlink } from "node:fs/promises";
 import type {
   FeatureState,
@@ -19,6 +20,14 @@ import * as actions from "./actions.js";
 import { save_features, load_features, append_session_log } from "./persistence.js";
 import { extract_session_learnings } from "./hooks.js";
 import { PersistQueue } from "./persist-queue.js";
+
+const exec_async = promisify(execFile);
+
+/** Maximum number of review->build bounces before escalating to a human. */
+const MAX_REVIEW_BOUNCES = 3;
+
+/** Marker in review comments that forces immediate escalation. */
+const ESCALATE_MARKER = "ESCALATE";
 
 // ── Phase configuration ──
 
@@ -143,6 +152,10 @@ export class FeatureManager extends EventEmitter {
 
   /** Optional pool reference — set via set_pool() after construction. */
   private pool: BotPool | null = null;
+
+  /** Transient cache of review comments from the most recent bounce.
+   * Keyed by feature ID, consumed when the builder is spawned. */
+  private last_review_comments = new Map<string, string>();
 
   private persist_queue: PersistQueue;
 
@@ -295,6 +308,7 @@ export class FeatureManager extends EventEmitter {
       labels: opts.labels ?? [],
       poolBotId: null,
       prNumber: null,
+      reviewBounceCount: 0,
       agentDone: false,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
@@ -506,7 +520,17 @@ export class FeatureManager extends EventEmitter {
     }
   }
 
-  /** Detect review outcome and route: approved -> ship, changes_requested -> build bounce, pending -> blocked. */
+  /**
+   * Detect review outcome and route:
+   *   approved -> ship
+   *   changes_requested -> build bounce (with safety rails)
+   *   pending -> blocked
+   *
+   * Safety rails on changes_requested:
+   *   - Increment reviewBounceCount; escalate if > MAX_REVIEW_BOUNCES
+   *   - Check review comments for ESCALATE marker
+   *   - Check PR for merge conflicts
+   */
   private async handle_review_outcome(feature: FeatureState): Promise<void> {
     const entity = this.registry.get(feature.entity);
 
@@ -527,6 +551,8 @@ export class FeatureManager extends EventEmitter {
     switch (outcome) {
       case "approved":
         console.log(`[features] PR #${String(feature.prNumber)} approved -- advancing ${feature.id} to ship`);
+        // Reset bounce count on approval (clean slate if feature is ever re-reviewed)
+        feature.reviewBounceCount = 0;
         try {
           await this.advance_feature(feature.id, "ship");
         } catch (err) {
@@ -535,22 +561,87 @@ export class FeatureManager extends EventEmitter {
         }
         break;
 
-      case "changes_requested":
-        console.log(`[features] PR #${String(feature.prNumber)} changes requested -- bouncing ${feature.id} back to build`);
+      case "changes_requested": {
+        feature.reviewBounceCount += 1;
+        this.persist_queue.enqueue();
+
+        const bounce = feature.reviewBounceCount;
+        const pr = String(feature.prNumber);
+        console.log(
+          `[features] PR #${pr} changes requested -- bounce ${String(bounce)}/${String(MAX_REVIEW_BOUNCES)} for ${feature.id}`,
+        );
+
+        // Fetch the latest review comments so we can check for ESCALATE and pass to builder
+        const review_comments = await fetch_review_comments(feature.prNumber, repo_path);
+
+        // Safety rail: reviewer flagged ESCALATE
+        if (review_comments.toUpperCase().includes(ESCALATE_MARKER)) {
+          console.log(`[features] Review contains ${ESCALATE_MARKER} marker -- escalating ${feature.id}`);
+          feature.blocked = true;
+          feature.blockedReason = `Reviewer flagged ${ESCALATE_MARKER} on PR #${pr}. Human review needed.`;
+          this.persist_queue.enqueue();
+          this.emit("feature:blocked", feature, feature.blockedReason);
+          await actions.notify_feature(
+            feature,
+            `PR #${pr}: ${feature.title} -- reviewer flagged ${ESCALATE_MARKER}. Human review needed.`,
+            entity,
+            { also_alerts: true },
+          );
+          return;
+        }
+
+        // Safety rail: max bounce count exceeded
+        if (bounce > MAX_REVIEW_BOUNCES) {
+          console.log(`[features] Review loop exceeded ${String(MAX_REVIEW_BOUNCES)} bounces -- escalating ${feature.id}`);
+          feature.blocked = true;
+          feature.blockedReason = `Review loop exceeded ${String(MAX_REVIEW_BOUNCES)} attempts for #${String(feature.githubIssue)}. Human review needed.`;
+          this.persist_queue.enqueue();
+          this.emit("feature:blocked", feature, feature.blockedReason);
+          await actions.notify_feature(
+            feature,
+            `PR #${pr}: ${feature.title} -- review loop exceeded ${String(MAX_REVIEW_BOUNCES)} attempts. Human review needed.`,
+            entity,
+            { also_alerts: true },
+          );
+          return;
+        }
+
+        // Safety rail: merge conflicts
+        const has_conflicts = await check_merge_conflicts(feature.prNumber, repo_path);
+        if (has_conflicts) {
+          console.log(`[features] PR #${pr} has merge conflicts -- escalating ${feature.id}`);
+          feature.blocked = true;
+          feature.blockedReason = `PR #${pr} has merge conflicts. Human intervention needed.`;
+          this.persist_queue.enqueue();
+          this.emit("feature:blocked", feature, feature.blockedReason);
+          await actions.notify_feature(
+            feature,
+            `PR #${pr}: ${feature.title} -- merge conflicts detected. Human intervention needed.`,
+            entity,
+            { also_alerts: true },
+          );
+          return;
+        }
+
+        // All safety rails passed -- bounce back to build with review feedback
+        // Store review comments so bridge methods can pick them up
+        this.last_review_comments.set(feature.id, review_comments);
+
         try {
           await this.advance_feature(feature.id, "build");
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           console.error(`[features] Failed to bounce ${feature.id} to build: ${msg}`);
         }
-        // Notify alerts about the bounce
+
         await actions.notify_feature(
           feature,
-          `PR #${String(feature.prNumber)}: ${feature.title} — changes requested, bouncing back to build`,
+          `PR #${pr}: ${feature.title} -- changes requested (bounce ${String(bounce)}/${String(MAX_REVIEW_BOUNCES)}), dispatching builder`,
           entity,
           { also_alerts: true },
         );
         break;
+      }
 
       case "pending":
         console.log(`[features] Reviewer completed for ${feature.id} without posting a decision -- blocking`);
@@ -852,13 +943,22 @@ export class FeatureManager extends EventEmitter {
     const entity = this.registry.get(feature.entity);
     if (!entity) return;
 
-    const prompt = resolve_prompt(phase_config.prompt_template, feature);
     const worktree_path = feature.worktreePath ?? expand_home_safe(entity.entity.repos[0]?.path ?? ".");
 
     // Resume builder session on review->build bounce using the dedicated lastBuilderSessionId.
     // This is intentionally narrow — only builder bounce gets resume. All other transitions get fresh sessions.
     const is_builder_bounce = phase_config.archetype === "builder" && Boolean(feature.lastBuilderSessionId);
     const resume_id = is_builder_bounce ? (feature.lastBuilderSessionId ?? undefined) : undefined;
+
+    // On review->build bounce, use the review feedback as the prompt instead of the generic build template
+    let prompt: string;
+    const cached_comments = this.last_review_comments.get(feature.id);
+    if (is_builder_bounce && feature.prNumber && cached_comments) {
+      this.last_review_comments.delete(feature.id);
+      prompt = build_review_fix_prompt(feature.prNumber, feature.title, cached_comments);
+    } else {
+      prompt = resolve_prompt(phase_config.prompt_template, feature);
+    }
 
     let task_id: string;
     try {
@@ -1075,6 +1175,8 @@ export class FeatureManager extends EventEmitter {
   /**
    * Bridge review feedback to a pool bot via tmux send-keys.
    * Used for review->build bounce — tells the builder what to fix.
+   * Includes the actual review comments when available so the builder
+   * has full context without needing to fetch from GitHub.
    */
   private async bridge_review_feedback_to_tmux(
     tmux_session: string,
@@ -1083,12 +1185,12 @@ export class FeatureManager extends EventEmitter {
     const pr_number = feature.prNumber;
     if (!pr_number) return;
 
+    // Consume cached review comments if available
+    const cached_comments = this.last_review_comments.get(feature.id);
+    this.last_review_comments.delete(feature.id);
+
     const feedback_path = `/tmp/lf-review-feedback-${feature.id}.txt`;
-    const feedback = (
-      `The reviewer requested changes on PR #${String(pr_number)}.\n` +
-      `Read the review comments with \`gh pr view ${String(pr_number)} --json reviews\` and make the fixes.\n` +
-      `When done, commit, push, and post in this channel that the fixes are ready.`
-    );
+    const feedback = build_review_fix_prompt(pr_number, feature.title, cached_comments);
 
     try {
       await writeFileAsync(feedback_path, feedback, "utf-8");
@@ -1310,4 +1412,94 @@ function expand_home_safe(p: string): string {
     return p.replace("~", process.env["HOME"] ?? "/root");
   }
   return p;
+}
+
+// ── Review feedback helpers ──
+
+/**
+ * Fetch the most recent review comments from a PR.
+ * Returns the concatenated review body text, or a fallback message if fetching fails.
+ */
+export async function fetch_review_comments(
+  pr_number: number,
+  repo_path: string,
+): Promise<string> {
+  try {
+    const { stdout } = await exec_async("gh", [
+      "pr", "view", String(pr_number),
+      "--json", "reviews",
+      "--jq", ".reviews | map(select(.state == \"CHANGES_REQUESTED\")) | last | .body // empty",
+    ], { cwd: repo_path, timeout: 15_000 });
+    const body = stdout.trim();
+    if (body) return body;
+  } catch {
+    // Fall through to fallback
+  }
+
+  // Fallback: try to get any review body
+  try {
+    const { stdout } = await exec_async("gh", [
+      "pr", "view", String(pr_number),
+      "--json", "reviews",
+      "--jq", ".reviews | last | .body // empty",
+    ], { cwd: repo_path, timeout: 15_000 });
+    return stdout.trim() || `(No review body found. Run \`gh pr view ${String(pr_number)} --json reviews\` to inspect.)`;
+  } catch {
+    return `(Could not fetch review comments. Run \`gh pr view ${String(pr_number)} --json reviews\` to inspect.)`;
+  }
+}
+
+/**
+ * Check if a PR has merge conflicts by inspecting its mergeable state.
+ */
+export async function check_merge_conflicts(
+  pr_number: number,
+  repo_path: string,
+): Promise<boolean> {
+  try {
+    const { stdout } = await exec_async("gh", [
+      "pr", "view", String(pr_number),
+      "--json", "mergeable",
+      "--jq", ".mergeable",
+    ], { cwd: repo_path, timeout: 15_000 });
+
+    // GitHub returns "CONFLICTING", "MERGEABLE", or "UNKNOWN"
+    return stdout.trim().toUpperCase() === "CONFLICTING";
+  } catch {
+    // If we can't determine, err on the side of not blocking
+    return false;
+  }
+}
+
+/**
+ * Build the prompt given to a builder when fixing reviewer feedback.
+ * Used by both the pool (tmux bridge) and queue (headless) paths.
+ */
+export function build_review_fix_prompt(
+  pr_number: number,
+  title: string,
+  review_comments?: string,
+): string {
+  const pr = String(pr_number);
+  const lines = [
+    `The reviewer requested changes on PR #${pr}: ${title}`,
+    ``,
+  ];
+
+  if (review_comments) {
+    lines.push(`## Reviewer Feedback`, ``, review_comments, ``);
+  }
+
+  lines.push(
+    `## Instructions`,
+    ``,
+    `1. Read the reviewer's feedback carefully`,
+    `2. Fix each issue mentioned`,
+    `3. Run the test suite to verify your changes`,
+    `4. Commit and push`,
+    ``,
+    `Do NOT change anything the reviewer didn't flag. Keep changes minimal and targeted.`,
+  );
+
+  return lines.join("\n");
 }

--- a/packages/daemon/src/pr-cron.ts
+++ b/packages/daemon/src/pr-cron.ts
@@ -6,6 +6,7 @@ import type { EntityRegistry } from "./registry.js";
 import type { ClaudeSessionManager } from "./session.js";
 import type { DiscordBot } from "./discord.js";
 import type { FeatureManager } from "./features.js";
+import { fetch_review_comments, build_review_fix_prompt } from "./features.js";
 import { detect_review_outcome } from "./actions.js";
 import { load_pr_reviews, save_pr_reviews } from "./persistence.js";
 import type { PRReviewState } from "./persistence.js";
@@ -343,17 +344,19 @@ export class PRReviewCron {
     repo_path: string,
     pr: OpenPR,
   ): Promise<void> {
+    // Fetch the actual review comments to give the builder full context
+    const review_comments = await fetch_review_comments(pr.number, repo_path);
+
     const prompt = [
       `An external PR needs fixes based on reviewer feedback.`,
       `PR #${String(pr.number)}: "${pr.title}" on branch ${pr.headRefName}`,
       `Repository: ${repo_path}`,
       ``,
-      `Steps:`,
-      `1. Check out the PR branch: git checkout ${pr.headRefName}`,
-      `2. Read the reviewer's comments: gh pr view ${String(pr.number)} --json reviews --jq '.reviews[].body'`,
-      `3. Make targeted fixes to address ONLY what the reviewer flagged — do not refactor beyond that`,
-      `4. Commit and push your changes to the PR branch`,
-      `5. Do NOT merge the PR`,
+      `First, check out the PR branch: git checkout ${pr.headRefName}`,
+      ``,
+      build_review_fix_prompt(pr.number, pr.title, review_comments),
+      ``,
+      `Do NOT merge the PR.`,
     ].join("\n");
 
     console.log(`[pr-cron] Spawning builder to fix external PR #${String(pr.number)} in ${entity_id}`);

--- a/packages/shared/src/schemas/feature.ts
+++ b/packages/shared/src/schemas/feature.ts
@@ -25,6 +25,7 @@ export const FeatureStateSchema = z.object({
   labels: z.array(z.string()).default([]),
   poolBotId: z.number().int().nullable().default(null),
   prNumber: z.number().int().nullable().default(null),
+  reviewBounceCount: z.number().default(0),
   agentDone: z.boolean().default(false),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),


### PR DESCRIPTION
## Summary

- When the reviewer requests changes on a PR, the daemon automatically dispatches a builder with the review comments as context -- closing the plan/build/review/ship loop without human intervention
- Adds a `reviewBounceCount` safety rail (max 3 bounces before escalating to #alerts)
- Detects `ESCALATE` marker in review comments for immediate human escalation
- Checks for merge conflicts before dispatching builder (escalates if conflicting)
- External PRs (not from feature lifecycle) also get review comments passed to the builder

## Files changed

| File | Change |
|------|--------|
| `packages/shared/src/schemas/feature.ts` | Add `reviewBounceCount` field (default 0) |
| `packages/daemon/src/features.ts` | Rewrite `handle_review_outcome` with bounce counter, ESCALATE detection, conflict check; add `fetch_review_comments`, `check_merge_conflicts`, `build_review_fix_prompt` helpers; pass review text to builder via pool/queue paths |
| `packages/daemon/src/pr-cron.ts` | External PR fixer now fetches and includes actual review comments |
| `packages/daemon/src/__tests__/auto-fix-loop.test.ts` | 18 tests covering prompt generation, comment fetching, conflict detection, schema defaults, ESCALATE marker |

## Test plan

- [x] `build_review_fix_prompt` generates correct prompt with/without comments
- [x] `fetch_review_comments` returns review body, falls back gracefully on error
- [x] `check_merge_conflicts` detects CONFLICTING/MERGEABLE/UNKNOWN/error states
- [x] `reviewBounceCount` defaults to 0, preserves explicit values via schema
- [x] ESCALATE marker detection is case-insensitive
- [x] All 437 existing tests still pass


Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)