### PR TITLE
fix: persist pool state on shutdown + validate snowflake IDs in channel map

### DIFF
--- a/packages/daemon/src/__tests__/fix-resume-persist.test.ts
+++ b/packages/daemon/src/__tests__/fix-resume-persist.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
+import type { LobsterFarmConfig } from "@lobster-farm/shared";
+import { BotPool } from "../pool.js";
+import type { PoolBot } from "../pool.js";
+
+function make_config(): LobsterFarmConfig {
+  return LobsterFarmConfigSchema.parse({
+    user: { name: "Test" },
+  });
+}
+
+/**
+ * Test-friendly subclass that exposes internals and stubs side effects.
+ * Tracks persist() and kill_tmux() calls for assertion.
+ */
+class TestBotPool extends BotPool {
+  persist_calls = 0;
+  kill_tmux_calls: string[] = [];
+  private persist_order: string[] = [];
+  private kill_order: string[] = [];
+
+  inject_bots(bots: PoolBot[]): void {
+    (this as unknown as { bots: PoolBot[] }).bots = bots;
+  }
+
+  get_bots(): PoolBot[] {
+    return (this as unknown as { bots: PoolBot[] }).bots;
+  }
+
+  /** Returns the ordered list of operations (persist/kill) for sequence assertions. */
+  get_operation_order(): string[] {
+    return [...this.persist_order, ...this.kill_order].length > 0
+      ? this.interleaved_order
+      : [];
+  }
+
+  private interleaved_order: string[] = [];
+
+  /** Override persist to track calls without filesystem access. */
+  protected override async check_assigned_health(): Promise<void> {
+    // Call the real implementation through the parent — the drain guard is what we're testing
+    return super.check_assigned_health();
+  }
+
+  set_draining(value: boolean): void {
+    (this as unknown as { _draining: boolean })._draining = value;
+  }
+
+  protected override is_bot_idle(/* _bot: PoolBot */): boolean {
+    return true;
+  }
+}
+
+function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
+  return {
+    state: "free",
+    channel_id: null,
+    entity_id: null,
+    archetype: null,
+    channel_type: null,
+    session_id: null,
+    tmux_session: `pool-${String(overrides.id)}`,
+    last_active: null,
+    assigned_at: null,
+    state_dir: `/tmp/test-pool-${String(overrides.id)}`,
+    ...overrides,
+  };
+}
+
+describe("shutdown() persists state before killing tmux", () => {
+  let config: LobsterFarmConfig;
+  let pool: TestBotPool;
+
+  beforeEach(() => {
+    config = make_config();
+    pool = new TestBotPool(config);
+  });
+
+  it("calls persist() before killing any tmux sessions", async () => {
+    const operation_order: string[] = [];
+
+    // Spy on persist (private) — track order
+    vi.spyOn(pool as unknown as Record<string, unknown>, "persist" as never)
+      .mockImplementation(async () => {
+        operation_order.push("persist");
+      });
+
+    // Spy on kill_tmux (private) — track order
+    vi.spyOn(pool as unknown as Record<string, unknown>, "kill_tmux" as never)
+      .mockImplementation((session: string) => {
+        operation_order.push(`kill:${session}`);
+      });
+
+    pool.inject_bots([
+      make_bot({ id: 0, state: "assigned", channel_id: "ch-1", entity_id: "e1", archetype: "builder" }),
+      make_bot({ id: 1, state: "assigned", channel_id: "ch-2", entity_id: "e1", archetype: "planner" }),
+      make_bot({ id: 2, state: "free" }),
+    ]);
+
+    await pool.shutdown();
+
+    // persist must come first, before any kill
+    expect(operation_order[0]).toBe("persist");
+    expect(operation_order).toContain("kill:pool-0");
+    expect(operation_order).toContain("kill:pool-1");
+
+    // Verify persist happened exactly once and before all kills
+    const persist_index = operation_order.indexOf("persist");
+    const first_kill_index = operation_order.findIndex(op => op.startsWith("kill:"));
+    expect(persist_index).toBeLessThan(first_kill_index);
+  });
+
+  it("does not kill free bots during shutdown", async () => {
+    const killed: string[] = [];
+
+    vi.spyOn(pool as unknown as Record<string, unknown>, "persist" as never)
+      .mockResolvedValue(undefined);
+    vi.spyOn(pool as unknown as Record<string, unknown>, "kill_tmux" as never)
+      .mockImplementation((session: string) => {
+        killed.push(session);
+      });
+
+    pool.inject_bots([
+      make_bot({ id: 0, state: "free" }),
+      make_bot({ id: 1, state: "assigned", channel_id: "ch-1", entity_id: "e1", archetype: "builder" }),
+      make_bot({ id: 2, state: "parked", channel_id: "ch-2", entity_id: "e1", archetype: "planner" }),
+    ]);
+
+    await pool.shutdown();
+
+    // Only the assigned bot gets killed
+    expect(killed).toEqual(["pool-1"]);
+  });
+});
+
+describe("check_assigned_health() drain guard", () => {
+  let config: LobsterFarmConfig;
+  let pool: TestBotPool;
+
+  beforeEach(() => {
+    config = make_config();
+    pool = new TestBotPool(config);
+
+    // Stub side effects
+    vi.spyOn(pool as unknown as Record<string, unknown>, "kill_tmux" as never)
+      .mockImplementation(() => {});
+    vi.spyOn(pool as unknown as Record<string, unknown>, "is_tmux_alive" as never)
+      .mockReturnValue(false);
+    vi.spyOn(pool as unknown as Record<string, unknown>, "persist" as never)
+      .mockResolvedValue(undefined);
+  });
+
+  it("returns early without modifying state when draining", async () => {
+    pool.inject_bots([
+      make_bot({
+        id: 0,
+        state: "assigned",
+        channel_id: "ch-1",
+        entity_id: "e1",
+        archetype: "builder",
+        session_id: "sess-1",
+      }),
+    ]);
+
+    // Enter drain mode
+    pool.set_draining(true);
+
+    // Health check should be a no-op
+    await (pool as unknown as { check_assigned_health: () => Promise<void> }).check_assigned_health();
+
+    // Bot should still be assigned — drain guard prevented cleanup
+    const bots = pool.get_bots();
+    expect(bots[0]!.state).toBe("assigned");
+    expect(bots[0]!.channel_id).toBe("ch-1");
+    expect(bots[0]!.session_id).toBe("sess-1");
+  });
+
+  it("processes dead sessions when NOT draining", async () => {
+    const events: string[] = [];
+    pool.on("bot:session_ended", () => events.push("session_ended"));
+    pool.on("bot:released", () => events.push("released"));
+
+    pool.inject_bots([
+      make_bot({
+        id: 0,
+        state: "assigned",
+        channel_id: "ch-1",
+        entity_id: "e1",
+        archetype: "builder",
+        session_id: "sess-1",
+      }),
+    ]);
+
+    // is_tmux_alive returns false (mocked above) — session is dead
+    await (pool as unknown as { check_assigned_health: () => Promise<void> }).check_assigned_health();
+
+    // Bot should have been cleaned up
+    const bots = pool.get_bots();
+    expect(bots[0]!.state).toBe("free");
+    expect(bots[0]!.channel_id).toBeNull();
+    expect(events).toContain("session_ended");
+    expect(events).toContain("released");
+  });
+});

--- a/packages/daemon/src/__tests__/fix-snowflake-validation.test.ts
+++ b/packages/daemon/src/__tests__/fix-snowflake-validation.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "vitest";
+import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
+import type { LobsterFarmConfig, EntityConfig } from "@lobster-farm/shared";
+import { is_discord_snowflake, DiscordBot } from "../discord.js";
+import { EntityRegistry } from "../registry.js";
+
+// ── Test helpers ──
+
+function make_config(): LobsterFarmConfig {
+  return LobsterFarmConfigSchema.parse({
+    user: { name: "Test" },
+  });
+}
+
+function make_entity_config(
+  entity_id: string,
+  channels: Array<{ id: string; type: string; name?: string }>,
+): EntityConfig {
+  return {
+    entity: {
+      id: entity_id,
+      name: `Test ${entity_id}`,
+      description: "",
+      status: "active",
+      repos: [],
+      accounts: {},
+      channels: {
+        category_id: "",
+        list: channels.map(ch => ({
+          type: ch.type as "general" | "work_room" | "work_log" | "alerts",
+          id: ch.id,
+          name: ch.name ?? ch.type,
+        })),
+      },
+      memory: { path: "/tmp/memory", auto_extract: true },
+      secrets: { vault: "1password", vault_name: `entity-${entity_id}` },
+    },
+  };
+}
+
+function make_registry(entities: EntityConfig[]): EntityRegistry {
+  const map = new Map<string, EntityConfig>();
+  for (const e of entities) {
+    map.set(e.entity.id, e);
+  }
+  return {
+    get: (id: string) => map.get(id),
+    get_all: () => [...map.values()],
+    get_active: () => [...map.values()].filter(e => e.entity.status === "active"),
+    count: () => map.size,
+  } as unknown as EntityRegistry;
+}
+
+/**
+ * Test-friendly subclass that exposes build_channel_map() internals
+ * without requiring a real Discord connection.
+ */
+class TestDiscordBot extends DiscordBot {
+  get_channel_map(): Map<string, unknown> {
+    return (this as unknown as { channel_map: Map<string, unknown> }).channel_map;
+  }
+
+  get_entity_channels(): Map<string, Map<string, string>> {
+    return (this as unknown as { entity_channels: Map<string, Map<string, string>> }).entity_channels;
+  }
+}
+
+// ── is_discord_snowflake ──
+
+describe("is_discord_snowflake", () => {
+  it("accepts valid 18-digit snowflake IDs", () => {
+    expect(is_discord_snowflake("1486494404784160849")).toBe(true);
+  });
+
+  it("accepts 17-digit snowflake IDs", () => {
+    expect(is_discord_snowflake("12345678901234567")).toBe(true);
+  });
+
+  it("accepts 20-digit snowflake IDs", () => {
+    expect(is_discord_snowflake("12345678901234567890")).toBe(true);
+  });
+
+  it("rejects placeholder IDs like 'gen-1'", () => {
+    expect(is_discord_snowflake("gen-1")).toBe(false);
+  });
+
+  it("rejects placeholder IDs like 'wr-1'", () => {
+    expect(is_discord_snowflake("wr-1")).toBe(false);
+  });
+
+  it("rejects placeholder IDs like 'cat-123'", () => {
+    expect(is_discord_snowflake("cat-123")).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(is_discord_snowflake("")).toBe(false);
+  });
+
+  it("rejects IDs shorter than 17 digits", () => {
+    expect(is_discord_snowflake("1234567890123456")).toBe(false);
+  });
+
+  it("rejects IDs longer than 20 digits", () => {
+    expect(is_discord_snowflake("123456789012345678901")).toBe(false);
+  });
+
+  it("rejects IDs with non-digit characters", () => {
+    expect(is_discord_snowflake("1234567890123456a")).toBe(false);
+  });
+});
+
+// ── build_channel_map snowflake filtering ──
+
+describe("build_channel_map skips non-snowflake IDs", () => {
+  it("only maps channels with valid snowflake IDs", () => {
+    const config = make_config();
+    const entity = make_entity_config("test-entity", [
+      { id: "1486494404784160849", type: "general", name: "general" },
+      { id: "gen-1", type: "general", name: "general-placeholder" },
+      { id: "1486494404784160850", type: "work_room", name: "work-room-1" },
+      { id: "wr-1", type: "work_room", name: "work-room-placeholder" },
+    ]);
+
+    const registry = make_registry([entity]);
+    const bot = new TestDiscordBot(config, registry);
+
+    bot.build_channel_map();
+
+    const channel_map = bot.get_channel_map();
+
+    // Only the two valid snowflake IDs should be in the map
+    expect(channel_map.size).toBe(2);
+    expect(channel_map.has("1486494404784160849")).toBe(true);
+    expect(channel_map.has("1486494404784160850")).toBe(true);
+    expect(channel_map.has("gen-1")).toBe(false);
+    expect(channel_map.has("wr-1")).toBe(false);
+  });
+
+  it("entity_channels map only contains valid snowflake IDs", () => {
+    const config = make_config();
+    const entity = make_entity_config("test-entity", [
+      { id: "gen-1", type: "general", name: "general-placeholder" },
+      { id: "1486494404784160849", type: "work_room", name: "work-room-1" },
+    ]);
+
+    const registry = make_registry([entity]);
+    const bot = new TestDiscordBot(config, registry);
+
+    bot.build_channel_map();
+
+    const entity_channels = bot.get_entity_channels();
+    const entity_map = entity_channels.get("test-entity");
+
+    // general was skipped (placeholder ID), work_room has valid snowflake
+    expect(entity_map).toBeDefined();
+    expect(entity_map!.has("general")).toBe(false);
+    expect(entity_map!.has("work_room")).toBe(true);
+    expect(entity_map!.get("work_room")).toBe("1486494404784160849");
+  });
+
+  it("handles entity with all placeholder IDs gracefully", () => {
+    const config = make_config();
+    const entity = make_entity_config("test-entity", [
+      { id: "gen-1", type: "general" },
+      { id: "wr-1", type: "work_room" },
+      { id: "cat-123", type: "alerts" },
+    ]);
+
+    const registry = make_registry([entity]);
+    const bot = new TestDiscordBot(config, registry);
+
+    bot.build_channel_map();
+
+    const channel_map = bot.get_channel_map();
+    expect(channel_map.size).toBe(0);
+  });
+});
+
+// ── find_upload_channel returns valid snowflake ──
+
+describe("find_upload_channel returns valid snowflake when mixed entries exist", () => {
+  it("returns a valid snowflake ID, not a placeholder", () => {
+    const config = make_config();
+    const entity = make_entity_config("test-entity", [
+      { id: "gen-1", type: "general", name: "general-placeholder" },
+      { id: "1486494404784160849", type: "work_log", name: "work-log" },
+      { id: "wr-1", type: "work_room", name: "work-room-placeholder" },
+    ]);
+
+    const registry = make_registry([entity]);
+    const bot = new TestDiscordBot(config, registry);
+
+    bot.build_channel_map();
+
+    // find_upload_channel is private — call it through the class
+    const upload_id = (bot as unknown as { find_upload_channel: () => string | null }).find_upload_channel();
+
+    // The only valid channel in the map is the work_log one
+    expect(upload_id).toBe("1486494404784160849");
+    expect(is_discord_snowflake(upload_id!)).toBe(true);
+  });
+
+  it("returns null when no valid snowflake channels exist", () => {
+    const config = make_config();
+    const entity = make_entity_config("test-entity", [
+      { id: "gen-1", type: "general" },
+      { id: "wr-1", type: "work_room" },
+    ]);
+
+    const registry = make_registry([entity]);
+    const bot = new TestDiscordBot(config, registry);
+
+    bot.build_channel_map();
+
+    const upload_id = (bot as unknown as { find_upload_channel: () => string | null }).find_upload_channel();
+    expect(upload_id).toBeNull();
+  });
+});

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -37,6 +37,11 @@ import type { BotPool, PoolBot } from "./pool.js";
 
 const exec = promisify(execFile);
 
+/** Discord snowflake IDs are numeric strings, 17-20 digits. */
+export function is_discord_snowflake(id: string): boolean {
+  return /^\d{17,20}$/.test(id);
+}
+
 /**
  * Extract GitHub owner/repo (nwo) from a repo URL.
  * Handles both SSH (git@github.com:owner/repo.git) and
@@ -682,6 +687,14 @@ export class DiscordBot extends EventEmitter {
       const entity_map = new Map<ChannelType, string>();
 
       for (const channel of entity_config.entity.channels.list) {
+        if (!is_discord_snowflake(channel.id)) {
+          console.log(
+            `[discord] Skipping invalid channel ID "${channel.id}" ` +
+            `in entity "${entity_id}" — not a Discord snowflake`,
+          );
+          continue;
+        }
+
         this.channel_map.set(channel.id, {
           entity_id,
           channel_type: channel.type,

--- a/packages/daemon/src/persistence.ts
+++ b/packages/daemon/src/persistence.ts
@@ -138,6 +138,7 @@ export async function load_pool_state(
 
     // Old format: plain array of bots
     if (Array.isArray(data)) {
+      console.log(`[pool] Loaded pool-state.json (old array format, ${String(data.length)} entries)`);
       return { bots: data as PersistedPoolBot[], session_history: {} };
     }
 
@@ -148,11 +149,20 @@ export async function load_pool_state(
       const history = (typeof obj["session_history"] === "object" && obj["session_history"] !== null && !Array.isArray(obj["session_history"]))
         ? (obj["session_history"] as Record<string, string>)
         : {};
+      console.log(
+        `[pool] Loaded pool-state.json (${String(bots.length)} bots, ` +
+        `${String(Object.keys(history).length)} history entries)`,
+      );
       return { bots, session_history: history };
     }
 
+    console.log("[pool] pool-state.json has unexpected format — starting fresh");
     return { bots: [], session_history: {} };
-  } catch {
+  } catch (err) {
+    const msg = err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT'
+      ? "file not found"
+      : String(err);
+    console.log(`[pool] Could not load pool-state.json: ${msg} — starting fresh`);
     return { bots: [], session_history: {} };
   }
 }

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -215,6 +215,18 @@ export class BotPool extends EventEmitter {
 
     // Restore persisted assignments from last run
     const saved_state = await load_pool_state(this.config);
+    if (saved_state.bots.length > 0) {
+      console.log(`[pool] Loaded ${String(saved_state.bots.length)} saved bot entries from pool-state.json`);
+      for (const entry of saved_state.bots) {
+        console.log(
+          `[pool]   pool-${String(entry.id)}: state=${entry.state}, ` +
+          `channel=${entry.channel_id}, session=${entry.session_id?.slice(0, 8) ?? "none"}`,
+        );
+      }
+    } else {
+      console.log("[pool] No saved bot entries found in pool-state.json");
+    }
+
     let restored = 0;
     this.resume_candidates = [];
 
@@ -806,6 +818,8 @@ export class BotPool extends EventEmitter {
    * Protected so tests can call it directly without waiting for the interval.
    */
   protected async check_assigned_health(): Promise<void> {
+    if (this._draining) return;
+
     let changed = false;
 
     for (const bot of this.bots) {
@@ -856,6 +870,10 @@ export class BotPool extends EventEmitter {
   /** Stop all pool bot sessions. Used during daemon shutdown. */
   async shutdown(): Promise<void> {
     this.stop_health_monitor();
+
+    // Snapshot current state before killing tmux — this is what the next
+    // daemon startup will load for proactive resume.
+    await this.persist();
 
     for (const bot of this.bots) {
       if (bot.state === "assigned") {


### PR DESCRIPTION
## Summary

- **Session resume (#102):** `shutdown()` now explicitly calls `persist()` before killing tmux sessions, ensuring pool-state.json has the current state for the next startup's proactive resume. Added drain guard to `check_assigned_health()` to prevent race with shutdown. Added diagnostic logging to `load_pool_state()` and `initialize()` so resume failures are diagnosable from logs.

- **Avatar upload (#103):** `build_channel_map()` now validates channel IDs are Discord snowflakes (17-20 digit numeric strings) before adding them. Placeholder IDs like `gen-1` from test entities are skipped with a warning, so `find_upload_channel()` always returns a real channel.

Closes #102
Closes #103

## Test plan

- [x] 4 tests for shutdown persist ordering + drain guard behavior
- [x] 15 tests for snowflake validation + channel map filtering
- [x] All 407 existing tests pass
- [ ] After merge + daemon restart: verify avatars upload (check log for upload count > 0)
- [ ] After merge + daemon restart: verify pool-state.json has session_ids, next restart resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)