### PR TITLE
feat: event-driven PR reviews via GitHub App webhooks

### DIFF
--- a/packages/daemon/src/__tests__/github-app.test.ts
+++ b/packages/daemon/src/__tests__/github-app.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+import { createHmac, generateKeyPairSync } from "node:crypto";
+import { GitHubAppAuth, init_github_app_from_env } from "../github-app.js";
+
+// Generate a real RSA key pair for testing JWT signing
+const { privateKey } = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: "spki", format: "pem" },
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+});
+
+const TEST_CONFIG = {
+  app_id: "12345",
+  private_key: privateKey,
+  installation_id: "67890",
+  webhook_secret: "test-webhook-secret-value",
+};
+
+describe("GitHubAppAuth", () => {
+  describe("verify_signature", () => {
+    it("accepts a valid HMAC-SHA256 signature", () => {
+      const auth = new GitHubAppAuth(TEST_CONFIG);
+      const payload = '{"action":"opened","pull_request":{}}';
+      const hmac = createHmac("sha256", TEST_CONFIG.webhook_secret)
+        .update(payload)
+        .digest("hex");
+      const signature = `sha256=${hmac}`;
+
+      expect(auth.verify_signature(payload, signature)).toBe(true);
+    });
+
+    it("rejects an invalid signature", () => {
+      const auth = new GitHubAppAuth(TEST_CONFIG);
+      const payload = '{"action":"opened"}';
+      const signature = "sha256=0000000000000000000000000000000000000000000000000000000000000000";
+
+      expect(auth.verify_signature(payload, signature)).toBe(false);
+    });
+
+    it("rejects a signature without sha256= prefix", () => {
+      const auth = new GitHubAppAuth(TEST_CONFIG);
+      const payload = "test";
+      const hmac = createHmac("sha256", TEST_CONFIG.webhook_secret)
+        .update(payload)
+        .digest("hex");
+
+      expect(auth.verify_signature(payload, hmac)).toBe(false);
+    });
+
+    it("rejects an empty signature", () => {
+      const auth = new GitHubAppAuth(TEST_CONFIG);
+      expect(auth.verify_signature("payload", "")).toBe(false);
+    });
+
+    it("accepts Buffer payloads", () => {
+      const auth = new GitHubAppAuth(TEST_CONFIG);
+      const payload = Buffer.from('{"test":true}');
+      const hmac = createHmac("sha256", TEST_CONFIG.webhook_secret)
+        .update(payload)
+        .digest("hex");
+      const signature = `sha256=${hmac}`;
+
+      expect(auth.verify_signature(payload, signature)).toBe(true);
+    });
+
+    it("rejects signature with wrong length", () => {
+      const auth = new GitHubAppAuth(TEST_CONFIG);
+      // Hex digest should be 64 chars, provide one that's shorter
+      expect(auth.verify_signature("payload", "sha256=abc")).toBe(false);
+    });
+  });
+
+  describe("get_token", () => {
+    it("fetches a token from the GitHub API", async () => {
+      const auth = new GitHubAppAuth(TEST_CONFIG);
+      const expires_at = new Date(Date.now() + 3600_000).toISOString();
+
+      const mock_fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ token: "ghs_test_token_123", expires_at }),
+      });
+      vi.stubGlobal("fetch", mock_fetch);
+
+      const token = await auth.get_token();
+
+      expect(token).toBe("ghs_test_token_123");
+      expect(mock_fetch).toHaveBeenCalledTimes(1);
+
+      // Verify it called the correct URL
+      const call_url = mock_fetch.mock.calls[0]![0] as string;
+      expect(call_url).toContain("/app/installations/67890/access_tokens");
+
+      // Verify Authorization header is a Bearer JWT
+      const call_opts = mock_fetch.mock.calls[0]![1] as { headers: Record<string, string> };
+      expect(call_opts.headers["Authorization"]).toMatch(/^Bearer eyJ/);
+
+      vi.unstubAllGlobals();
+    });
+
+    it("returns cached token on subsequent calls", async () => {
+      const auth = new GitHubAppAuth(TEST_CONFIG);
+      const expires_at = new Date(Date.now() + 3600_000).toISOString();
+
+      const mock_fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ token: "ghs_cached", expires_at }),
+      });
+      vi.stubGlobal("fetch", mock_fetch);
+
+      const token1 = await auth.get_token();
+      const token2 = await auth.get_token();
+
+      expect(token1).toBe("ghs_cached");
+      expect(token2).toBe("ghs_cached");
+      // Only one API call — second call used cache
+      expect(mock_fetch).toHaveBeenCalledTimes(1);
+
+      vi.unstubAllGlobals();
+    });
+
+    it("throws on API error", async () => {
+      const auth = new GitHubAppAuth(TEST_CONFIG);
+
+      const mock_fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: async () => "Bad credentials",
+      });
+      vi.stubGlobal("fetch", mock_fetch);
+
+      await expect(auth.get_token()).rejects.toThrow("Failed to get installation token: 401");
+
+      vi.unstubAllGlobals();
+    });
+
+    it("coalesces concurrent refresh calls", async () => {
+      const auth = new GitHubAppAuth(TEST_CONFIG);
+      const expires_at = new Date(Date.now() + 3600_000).toISOString();
+
+      let resolve_fetch!: (value: unknown) => void;
+      const fetch_promise = new Promise((r) => { resolve_fetch = r; });
+
+      const mock_fetch = vi.fn().mockReturnValue(fetch_promise);
+      vi.stubGlobal("fetch", mock_fetch);
+
+      // Start two concurrent get_token calls
+      const p1 = auth.get_token();
+      const p2 = auth.get_token();
+
+      // Resolve the fetch
+      resolve_fetch({
+        ok: true,
+        json: async () => ({ token: "ghs_coalesced", expires_at }),
+      });
+
+      const [t1, t2] = await Promise.all([p1, p2]);
+
+      expect(t1).toBe("ghs_coalesced");
+      expect(t2).toBe("ghs_coalesced");
+      // Only one API call despite two concurrent requests
+      expect(mock_fetch).toHaveBeenCalledTimes(1);
+
+      vi.unstubAllGlobals();
+    });
+  });
+});
+
+describe("init_github_app_from_env", () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    // Clean env for each test
+    delete process.env["GITHUB_APP_ID"];
+    delete process.env["GITHUB_APP_PRIVATE_KEY"];
+    delete process.env["GITHUB_APP_INSTALLATION_ID"];
+    delete process.env["GITHUB_APP_WEBHOOK_SECRET"];
+  });
+
+  // Restore env after tests
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it("returns null when env vars are missing", () => {
+    const result = init_github_app_from_env();
+    expect(result).toBeNull();
+  });
+
+  it("returns null when only some env vars are set", () => {
+    process.env["GITHUB_APP_ID"] = "123";
+    process.env["GITHUB_APP_PRIVATE_KEY"] = privateKey;
+    // Missing INSTALLATION_ID and WEBHOOK_SECRET
+
+    const result = init_github_app_from_env();
+    expect(result).toBeNull();
+  });
+
+  it("returns GitHubAppAuth when all env vars are set", () => {
+    process.env["GITHUB_APP_ID"] = "123";
+    process.env["GITHUB_APP_PRIVATE_KEY"] = privateKey;
+    process.env["GITHUB_APP_INSTALLATION_ID"] = "456";
+    process.env["GITHUB_APP_WEBHOOK_SECRET"] = "secret";
+
+    const result = init_github_app_from_env();
+    expect(result).toBeInstanceOf(GitHubAppAuth);
+  });
+});

--- a/packages/daemon/src/__tests__/webhook-handler.test.ts
+++ b/packages/daemon/src/__tests__/webhook-handler.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createHmac } from "node:crypto";
+import { EventEmitter } from "node:events";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { handle_github_webhook, type WebhookContext } from "../webhook-handler.js";
+import type { GitHubAppAuth } from "../github-app.js";
+import type { EntityRegistry } from "../registry.js";
+import type { ClaudeSessionManager } from "../session.js";
+import type { FeatureManager } from "../features.js";
+
+// ── Test helpers ──
+
+const WEBHOOK_SECRET = "test-secret-for-webhook-tests";
+
+function sign_payload(payload: string, secret: string = WEBHOOK_SECRET): string {
+  const hmac = createHmac("sha256", secret).update(payload).digest("hex");
+  return `sha256=${hmac}`;
+}
+
+function make_pr_payload(
+  action: string = "opened",
+  pr_number: number = 42,
+  repo_full_name: string = "ultim88888888/lobster-farm",
+): string {
+  return JSON.stringify({
+    action,
+    pull_request: {
+      number: pr_number,
+      title: "Test PR",
+      head: { ref: "feature/test" },
+      body: "Closes #10",
+      user: { login: "testuser" },
+    },
+    repository: { full_name: repo_full_name },
+  });
+}
+
+/** Create a mock IncomingMessage that emits body data. */
+function make_request(
+  body: string,
+  headers: Record<string, string> = {},
+): IncomingMessage {
+  const emitter = new EventEmitter();
+  const req = emitter as unknown as IncomingMessage;
+  req.headers = {
+    ...headers,
+  };
+
+  // Simulate body streaming after the handler attaches listeners
+  process.nextTick(() => {
+    emitter.emit("data", Buffer.from(body));
+    emitter.emit("end");
+  });
+
+  return req;
+}
+
+/** Capture the response written by the handler. */
+function make_response(): ServerResponse & { _status: number; _body: string } {
+  let status = 0;
+  let body = "";
+  const res = {
+    _status: 0,
+    _body: "",
+    writeHead(s: number, _headers: Record<string, string>) {
+      status = s;
+      res._status = s;
+    },
+    end(data: string) {
+      body = data;
+      res._body = data;
+    },
+    headersSent: false,
+  } as unknown as ServerResponse & { _status: number; _body: string };
+  return res;
+}
+
+/** Create a mock GitHub App auth. */
+function make_github_app(): GitHubAppAuth {
+  return {
+    verify_signature: vi.fn((payload: string, sig: string) => {
+      const expected = createHmac("sha256", WEBHOOK_SECRET).update(payload).digest("hex");
+      return sig === `sha256=${expected}`;
+    }),
+    get_token: vi.fn().mockResolvedValue("ghs_mock_token"),
+  } as unknown as GitHubAppAuth;
+}
+
+/** Create a mock entity registry with one entity. */
+function make_registry(): EntityRegistry {
+  return {
+    get_active: vi.fn().mockReturnValue([
+      {
+        entity: {
+          id: "lobster-farm",
+          repos: [
+            {
+              name: "lobster-farm",
+              url: "https://github.com/ultim88888888/lobster-farm.git",
+              path: "/tmp/test-repo",
+            },
+          ],
+        },
+      },
+    ]),
+  } as unknown as EntityRegistry;
+}
+
+/** Create a mock session manager. */
+function make_session_manager(): ClaudeSessionManager {
+  const emitter = new EventEmitter();
+  const manager = Object.assign(emitter, {
+    spawn: vi.fn().mockResolvedValue({
+      session_id: "test-session-123",
+      entity_id: "lobster-farm",
+      feature_id: "pr-review-42",
+      archetype: "reviewer",
+      started_at: new Date(),
+      pid: 12345,
+    }),
+    get_active: vi.fn().mockReturnValue([]),
+  });
+  return manager as unknown as ClaudeSessionManager;
+}
+
+function make_feature_manager(): FeatureManager {
+  return {
+    find_by_pr: vi.fn().mockReturnValue(null),
+  } as unknown as FeatureManager;
+}
+
+function make_context(overrides: Partial<WebhookContext> = {}): WebhookContext {
+  return {
+    github_app: make_github_app(),
+    session_manager: make_session_manager(),
+    registry: make_registry(),
+    feature_manager: make_feature_manager(),
+    discord: null,
+    ...overrides,
+  };
+}
+
+// ── Tests ──
+
+describe("handle_github_webhook", () => {
+  describe("signature verification", () => {
+    it("returns 401 when X-Hub-Signature-256 header is missing", async () => {
+      const body = make_pr_payload();
+      const req = make_request(body, {
+        "x-github-event": "pull_request",
+      });
+      const res = make_response();
+      const ctx = make_context();
+
+      await handle_github_webhook(req, res, ctx);
+
+      expect(res._status).toBe(401);
+      expect(res._body).toContain("Missing X-Hub-Signature-256");
+    });
+
+    it("returns 401 when signature is invalid", async () => {
+      const body = make_pr_payload();
+      const req = make_request(body, {
+        "x-github-event": "pull_request",
+        "x-hub-signature-256": "sha256=invalid_signature_00000000000000000000000000000000",
+      });
+      const res = make_response();
+      const ctx = make_context();
+
+      await handle_github_webhook(req, res, ctx);
+
+      expect(res._status).toBe(401);
+      expect(res._body).toContain("Invalid signature");
+    });
+
+    it("returns 200 when signature is valid", async () => {
+      const body = make_pr_payload();
+      const req = make_request(body, {
+        "x-github-event": "pull_request",
+        "x-hub-signature-256": sign_payload(body),
+      });
+      const res = make_response();
+      const ctx = make_context();
+
+      await handle_github_webhook(req, res, ctx);
+
+      expect(res._status).toBe(200);
+    });
+  });
+
+  describe("event routing", () => {
+    it("returns 200 and ignores non-pull_request events", async () => {
+      const body = JSON.stringify({ action: "completed" });
+      const req = make_request(body, {
+        "x-github-event": "check_run",
+        "x-hub-signature-256": sign_payload(body),
+      });
+      const res = make_response();
+      const ctx = make_context();
+
+      await handle_github_webhook(req, res, ctx);
+
+      expect(res._status).toBe(200);
+      // No reviewer spawned
+      expect((ctx.session_manager as any).spawn).not.toHaveBeenCalled();
+    });
+
+    it("ignores pull_request.closed events", async () => {
+      const body = make_pr_payload("closed", 300);
+      const req = make_request(body, {
+        "x-github-event": "pull_request",
+        "x-hub-signature-256": sign_payload(body),
+      });
+      const res = make_response();
+      const ctx = make_context();
+
+      await handle_github_webhook(req, res, ctx);
+
+      // Give async route_event time to process
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(res._status).toBe(200);
+      expect((ctx.session_manager as any).spawn).not.toHaveBeenCalled();
+    });
+
+    it("spawns reviewer for pull_request.opened", async () => {
+      const body = make_pr_payload("opened", 200);
+      const req = make_request(body, {
+        "x-github-event": "pull_request",
+        "x-hub-signature-256": sign_payload(body),
+      });
+      const res = make_response();
+      const ctx = make_context();
+
+      await handle_github_webhook(req, res, ctx);
+
+      // Handler returns 200 immediately, spawning is async
+      expect(res._status).toBe(200);
+
+      // Wait for async spawn chain (get_token + spawn)
+      await vi.waitFor(() => {
+        expect((ctx.session_manager as any).spawn).toHaveBeenCalledTimes(1);
+      }, { timeout: 2000 });
+
+      const spawn_args = (ctx.session_manager as any).spawn.mock.calls[0]![0];
+      expect(spawn_args.entity_id).toBe("lobster-farm");
+      expect(spawn_args.archetype).toBe("reviewer");
+      expect(spawn_args.env).toEqual({ GH_TOKEN: "ghs_mock_token" });
+    });
+
+    it("spawns reviewer for pull_request.synchronize", async () => {
+      const body = make_pr_payload("synchronize", 201);
+      const req = make_request(body, {
+        "x-github-event": "pull_request",
+        "x-hub-signature-256": sign_payload(body),
+      });
+      const res = make_response();
+      const ctx = make_context();
+
+      await handle_github_webhook(req, res, ctx);
+
+      await vi.waitFor(() => {
+        expect((ctx.session_manager as any).spawn).toHaveBeenCalledTimes(1);
+      }, { timeout: 2000 });
+    });
+
+    it("ignores unknown repos (returns 200, no spawn)", async () => {
+      const body = make_pr_payload("opened", 301, "unknown-org/unknown-repo");
+      const req = make_request(body, {
+        "x-github-event": "pull_request",
+        "x-hub-signature-256": sign_payload(body),
+      });
+      const res = make_response();
+      const ctx = make_context();
+
+      await handle_github_webhook(req, res, ctx);
+
+      // Give async route_event time to process
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(res._status).toBe(200);
+      expect((ctx.session_manager as any).spawn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("missing event header", () => {
+    it("returns 400 when X-GitHub-Event header is missing", async () => {
+      const body = make_pr_payload();
+      const req = make_request(body, {
+        "x-hub-signature-256": sign_payload(body),
+        // No x-github-event
+      });
+      const res = make_response();
+      const ctx = make_context();
+
+      await handle_github_webhook(req, res, ctx);
+
+      expect(res._status).toBe(400);
+      expect(res._body).toContain("Missing X-GitHub-Event");
+    });
+  });
+
+  describe("invalid JSON", () => {
+    it("returns 400 for malformed JSON body", async () => {
+      const body = "this is not json";
+      const req = make_request(body, {
+        "x-github-event": "pull_request",
+        "x-hub-signature-256": sign_payload(body),
+      });
+      const res = make_response();
+      const ctx = make_context();
+
+      await handle_github_webhook(req, res, ctx);
+
+      expect(res._status).toBe(400);
+      expect(res._body).toContain("Invalid JSON");
+    });
+  });
+});

--- a/packages/daemon/src/github-app.ts
+++ b/packages/daemon/src/github-app.ts
@@ -1,0 +1,200 @@
+/**
+ * GitHub App authentication module.
+ *
+ * Handles JWT creation (RS256), installation token management, and webhook
+ * signature verification — all using Node.js built-in `crypto`. No external
+ * dependencies.
+ *
+ * Tokens are cached and refreshed 10 minutes before expiry (GitHub installation
+ * tokens last 1 hour, so we refresh at 50 min).
+ */
+
+import { createSign, createHmac, timingSafeEqual } from "node:crypto";
+
+// ── Types ──
+
+export interface GitHubAppConfig {
+  app_id: string;
+  private_key: string; // PEM contents
+  installation_id: string;
+  webhook_secret: string;
+}
+
+interface CachedToken {
+  token: string;
+  expires_at: number; // Unix ms
+}
+
+// ── Constants ──
+
+/** Refresh token when it has less than this many ms remaining. */
+const TOKEN_REFRESH_MARGIN_MS = 10 * 60 * 1000; // 10 min
+
+/** JWT is valid for 10 minutes (GitHub max). */
+const JWT_EXPIRY_SECONDS = 600;
+
+/** Clock skew allowance — backdate `iat` by 60 seconds. */
+const JWT_IAT_DRIFT_SECONDS = 60;
+
+// ── Helpers ──
+
+/** Base64url-encode a buffer or string. */
+function base64url(input: Buffer | string): string {
+  const buf = typeof input === "string" ? Buffer.from(input) : input;
+  return buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+// ── Class ──
+
+export class GitHubAppAuth {
+  private cached: CachedToken | null = null;
+  private refresh_promise: Promise<string> | null = null;
+
+  constructor(private config: GitHubAppConfig) {}
+
+  // ── JWT ──
+
+  /** Generate a short-lived JWT for the GitHub App (RS256). */
+  private sign_jwt(): string {
+    const now = Math.floor(Date.now() / 1000);
+
+    const header = base64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+    const payload = base64url(
+      JSON.stringify({
+        iss: this.config.app_id,
+        iat: now - JWT_IAT_DRIFT_SECONDS,
+        exp: now + JWT_EXPIRY_SECONDS,
+      }),
+    );
+
+    const sign = createSign("RSA-SHA256");
+    sign.update(`${header}.${payload}`);
+    sign.end();
+
+    const signature = base64url(sign.sign(this.config.private_key));
+    return `${header}.${payload}.${signature}`;
+  }
+
+  // ── Installation token ──
+
+  /**
+   * Get a valid installation access token. Cached and auto-refreshed.
+   *
+   * Concurrent callers share the same in-flight refresh to avoid
+   * redundant API calls.
+   */
+  async get_token(): Promise<string> {
+    if (this.cached && Date.now() < this.cached.expires_at - TOKEN_REFRESH_MARGIN_MS) {
+      return this.cached.token;
+    }
+
+    // Coalesce concurrent refreshes
+    if (this.refresh_promise) {
+      return this.refresh_promise;
+    }
+
+    this.refresh_promise = this.fetch_installation_token();
+    try {
+      return await this.refresh_promise;
+    } finally {
+      this.refresh_promise = null;
+    }
+  }
+
+  private async fetch_installation_token(): Promise<string> {
+    const jwt = this.sign_jwt();
+
+    const res = await fetch(
+      `https://api.github.com/app/installations/${this.config.installation_id}/access_tokens`,
+      {
+        method: "POST",
+        headers: {
+          Accept: "application/vnd.github+json",
+          Authorization: `Bearer ${jwt}`,
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+      },
+    );
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(
+        `Failed to get installation token: ${String(res.status)} ${body}`,
+      );
+    }
+
+    const data = (await res.json()) as { token: string; expires_at: string };
+
+    this.cached = {
+      token: data.token,
+      expires_at: new Date(data.expires_at).getTime(),
+    };
+
+    console.log(
+      `[github-app] Installation token refreshed (expires ${data.expires_at})`,
+    );
+
+    return data.token;
+  }
+
+  // ── Webhook signature verification ──
+
+  /**
+   * Verify the `X-Hub-Signature-256` header against the raw request body.
+   * Uses constant-time comparison to prevent timing attacks.
+   */
+  verify_signature(payload: string | Buffer, signature: string): boolean {
+    if (!signature.startsWith("sha256=")) {
+      return false;
+    }
+
+    const expected = createHmac("sha256", this.config.webhook_secret)
+      .update(payload)
+      .digest("hex");
+
+    const actual = signature.slice("sha256=".length);
+
+    // Constant-time comparison — both must be the same length for timingSafeEqual
+    if (expected.length !== actual.length) {
+      return false;
+    }
+
+    return timingSafeEqual(
+      Buffer.from(expected, "hex"),
+      Buffer.from(actual, "hex"),
+    );
+  }
+}
+
+/**
+ * Try to initialize GitHubAppAuth from environment variables.
+ * Returns null if any required var is missing (graceful degradation).
+ */
+export function init_github_app_from_env(): GitHubAppAuth | null {
+  const app_id = process.env["GITHUB_APP_ID"];
+  const private_key = process.env["GITHUB_APP_PRIVATE_KEY"];
+  const installation_id = process.env["GITHUB_APP_INSTALLATION_ID"];
+  const webhook_secret = process.env["GITHUB_APP_WEBHOOK_SECRET"];
+
+  if (!app_id || !private_key || !installation_id || !webhook_secret) {
+    const missing = [
+      !app_id && "GITHUB_APP_ID",
+      !private_key && "GITHUB_APP_PRIVATE_KEY",
+      !installation_id && "GITHUB_APP_INSTALLATION_ID",
+      !webhook_secret && "GITHUB_APP_WEBHOOK_SECRET",
+    ].filter(Boolean);
+    console.log(
+      `[github-app] Not configured — missing env vars: ${missing.join(", ")}`,
+    );
+    return null;
+  }
+
+  console.log(
+    `[github-app] Initialized (app_id=${app_id}, installation_id=${installation_id})`,
+  );
+  return new GitHubAppAuth({ app_id, private_key, installation_id, webhook_secret });
+}

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -12,6 +12,7 @@ import { write_pid, remove_pid } from "./pid.js";
 import { CommanderProcess } from "./commander-process.js";
 import { BotPool } from "./pool.js";
 import { PRReviewCron } from "./pr-cron.js";
+import { init_github_app_from_env } from "./github-app.js";
 import { check_required_binaries, propagate_tmux_env } from "./env.js";
 import type { Phase } from "@lobster-farm/shared";
 import { append_session_log } from "./persistence.js";
@@ -229,18 +230,28 @@ async function main(): Promise<void> {
     console.log("[commander] Add token to ~/.lobsterfarm/channels/pat/.env and restart.");
   }
 
-  // Start HTTP server
-  const server = start_server(registry, config, session_manager, queue, feature_manager, commander, discord_connected ? discord : null, pool);
+  // Initialize GitHub App auth (optional — graceful if not configured)
+  const github_app = init_github_app_from_env();
+  if (github_app) {
+    console.log("[github-app] Webhook-driven PR reviews enabled");
+  } else {
+    console.log("[github-app] Not configured — webhook endpoint will accept but not process events");
+  }
 
-  // Start PR review cron
+  // Start HTTP server
+  const server = start_server(registry, config, session_manager, queue, feature_manager, commander, discord_connected ? discord : null, pool, github_app);
+
+  // Start PR review cron (safety net — 30 min when webhooks are active, 5 min otherwise)
+  const cron_interval_ms = github_app ? 30 * 60 * 1000 : 5 * 60 * 1000;
   const pr_cron = new PRReviewCron(
     registry,
     session_manager,
     config,
     discord_connected ? discord : null,
     feature_manager,
+    github_app,
   );
-  await pr_cron.start();
+  await pr_cron.start(cron_interval_ms);
 
   // Write PID file
   await write_pid(config);

--- a/packages/daemon/src/pr-cron.ts
+++ b/packages/daemon/src/pr-cron.ts
@@ -6,6 +6,7 @@ import type { EntityRegistry } from "./registry.js";
 import type { ClaudeSessionManager } from "./session.js";
 import type { DiscordBot } from "./discord.js";
 import type { FeatureManager } from "./features.js";
+import type { GitHubAppAuth } from "./github-app.js";
 import { fetch_review_comments, build_review_fix_prompt } from "./features.js";
 import { detect_review_outcome } from "./actions.js";
 import { load_pr_reviews, save_pr_reviews } from "./persistence.js";
@@ -74,6 +75,7 @@ export class PRReviewCron {
     private config: LobsterFarmConfig,
     private discord: DiscordBot | null = null,
     private feature_manager: FeatureManager | null = null,
+    private github_app: GitHubAppAuth | null = null,
   ) {}
 
   /** Start the polling cron. Loads persisted review state before first poll. */
@@ -312,6 +314,18 @@ export class PRReviewCron {
 
     console.log(`[pr-cron] Spawning reviewer for PR #${String(pr.number)} in ${entity_id}`);
 
+    // Inject GitHub App token if available — gives reviewer its own identity
+    let spawn_env: Record<string, string> | undefined;
+    if (this.github_app) {
+      try {
+        const gh_token = await this.github_app.get_token();
+        spawn_env = { GH_TOKEN: gh_token };
+      } catch (err) {
+        console.error(`[pr-cron] Failed to get GitHub App token: ${String(err)}`);
+        // Continue without app token — reviewer will use default gh auth
+      }
+    }
+
     try {
       const session = await this.session_manager.spawn({
         entity_id,
@@ -322,6 +336,7 @@ export class PRReviewCron {
         worktree_path: repo_path,
         prompt,
         interactive: false,
+        env: spawn_env,
       });
 
       console.log(`[pr-cron] Reviewer session ${session.session_id.slice(0, 8)} started for PR #${String(pr.number)}`);
@@ -465,6 +480,17 @@ export class PRReviewCron {
 
     console.log(`[pr-cron] Spawning builder to fix external PR #${String(pr.number)} in ${entity_id}`);
 
+    // Inject GitHub App token if available
+    let fix_env: Record<string, string> | undefined;
+    if (this.github_app) {
+      try {
+        const gh_token = await this.github_app.get_token();
+        fix_env = { GH_TOKEN: gh_token };
+      } catch (err) {
+        console.error(`[pr-cron] Failed to get GitHub App token for fixer: ${String(err)}`);
+      }
+    }
+
     try {
       await this.session_manager.spawn({
         entity_id,
@@ -475,6 +501,7 @@ export class PRReviewCron {
         worktree_path: repo_path,
         prompt,
         interactive: false,
+        env: fix_env,
       });
     } catch (err) {
       console.error(`[pr-cron] Failed to spawn builder for external PR #${String(pr.number)}: ${String(err)}`);

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -11,6 +11,8 @@ import type { DiscordBot } from "./discord.js";
 import type { BotPool } from "./pool.js";
 import type { ArchetypeRole } from "@lobster-farm/shared";
 import { persist_entity_config } from "./actions.js";
+import type { GitHubAppAuth } from "./github-app.js";
+import { handle_github_webhook, type WebhookContext } from "./webhook-handler.js";
 
 interface ServerContext {
   registry: EntityRegistry;
@@ -21,6 +23,7 @@ interface ServerContext {
   commander: CommanderProcess | null;
   discord: DiscordBot | null;
   pool: BotPool | null;
+  github_app: GitHubAppAuth | null;
 }
 
 type RouteHandler = (
@@ -80,6 +83,7 @@ const handle_status: RouteHandler = (_req, res, ctx) => {
     },
     queue: queue_stats,
     commander: ctx.commander?.health_check() ?? { state: "not_configured" },
+    github_app: ctx.github_app ? "configured" : "not_configured",
   });
 };
 
@@ -110,10 +114,24 @@ const handle_entity_detail: RouteHandler = (req, res, ctx) => {
   json_response(res, 200, entity);
 };
 
-const handle_webhook_github: RouteHandler = async (req, res) => {
-  const body = await read_body(req);
-  console.log("GitHub webhook received:", body.slice(0, 200));
-  json_response(res, 200, { ok: true });
+const handle_webhook_github: RouteHandler = async (req, res, ctx) => {
+  if (!ctx.github_app) {
+    // Fallback when GitHub App is not configured — log and accept
+    const body = await read_body(req);
+    console.log("[webhook] GitHub webhook received but App not configured:", body.slice(0, 200));
+    json_response(res, 200, { ok: true, warning: "GitHub App not configured" });
+    return;
+  }
+
+  const webhook_ctx: WebhookContext = {
+    github_app: ctx.github_app,
+    session_manager: ctx.session_manager,
+    registry: ctx.registry,
+    feature_manager: ctx.features,
+    discord: ctx.discord,
+  };
+
+  await handle_github_webhook(req, res, webhook_ctx);
 };
 
 const handle_webhook_sentry: RouteHandler = async (req, res) => {
@@ -592,9 +610,10 @@ export function start_server(
   commander: CommanderProcess | null = null,
   discord: DiscordBot | null = null,
   pool: BotPool | null = null,
+  github_app: GitHubAppAuth | null = null,
   port: number = DAEMON_PORT,
 ): Server {
-  const ctx: ServerContext = { registry, config, session_manager, queue, features, commander, discord, pool };
+  const ctx: ServerContext = { registry, config, session_manager, queue, features, commander, discord, pool, github_app };
 
   const server = createServer((req, res) => {
     route_request(req, res, ctx);

--- a/packages/daemon/src/session.ts
+++ b/packages/daemon/src/session.ts
@@ -28,6 +28,8 @@ export interface SessionSpawnOptions {
   interactive: boolean;
   /** If set, resume this prior session instead of starting fresh. */
   resume_session_id?: string;
+  /** Extra environment variables to inject into the subprocess (e.g. GH_TOKEN). */
+  env?: Record<string, string>;
 }
 
 export interface ActiveSession {
@@ -249,7 +251,7 @@ export class ClaudeSessionManager extends EventEmitter implements SessionManager
     const proc = spawn(command, args, {
       cwd: options.worktree_path,
       stdio: ["pipe", "pipe", "pipe"],
-      env: { ...process.env },
+      env: { ...process.env, ...options.env },
     });
 
     // Write prompt to stdin and close it

--- a/packages/daemon/src/webhook-handler.ts
+++ b/packages/daemon/src/webhook-handler.ts
@@ -1,0 +1,553 @@
+/**
+ * GitHub webhook handler.
+ *
+ * Receives PR events via POST /webhooks/github, verifies the signature,
+ * maps the repo to an entity, and spawns headless reviewer sessions.
+ *
+ * Deduplication: only one reviewer runs per entity:pr# at a time. If a
+ * `synchronize` event arrives mid-review, the PR is queued for re-review
+ * once the current reviewer finishes.
+ */
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { ArchetypeRole } from "@lobster-farm/shared";
+import { expand_home } from "@lobster-farm/shared";
+import type { GitHubAppAuth } from "./github-app.js";
+import type { EntityRegistry } from "./registry.js";
+import type { ClaudeSessionManager, SessionResult } from "./session.js";
+import type { FeatureManager } from "./features.js";
+import type { DiscordBot } from "./discord.js";
+import { detect_review_outcome } from "./actions.js";
+import { fetch_review_comments, build_review_fix_prompt } from "./features.js";
+
+const exec = promisify(execFile);
+
+// ── Types ──
+
+export interface WebhookContext {
+  github_app: GitHubAppAuth;
+  session_manager: ClaudeSessionManager;
+  registry: EntityRegistry;
+  feature_manager: FeatureManager;
+  discord: DiscordBot | null;
+}
+
+/** Minimal PR shape from webhook payload. */
+interface WebhookPR {
+  number: number;
+  title: string;
+  head: { ref: string };
+  body: string | null;
+  user: { login: string };
+}
+
+interface WebhookPayload {
+  action: string;
+  pull_request?: WebhookPR;
+  repository?: { full_name: string };
+}
+
+interface ActiveWebhookReview {
+  entity_id: string;
+  pr_number: number;
+  /** Set to true if a new event arrived while this review was in-flight. */
+  needs_requeue: boolean;
+}
+
+// ── Helpers ──
+
+function json_response(res: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(payload),
+  });
+  res.end(payload);
+}
+
+function read_body(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+    req.on("error", reject);
+  });
+}
+
+/**
+ * Extract "Closes #N" or "Fixes #N" references from PR body.
+ * Returns the first matched issue number, or null.
+ */
+function extract_linked_issue(body: string | null): number | null {
+  if (!body) return null;
+  const match = body.match(/(?:closes|fixes|resolves)\s+#(\d+)/i);
+  return match ? parseInt(match[1]!, 10) : null;
+}
+
+/**
+ * Map a GitHub repo full_name (e.g. "ultim88888888/lobster-farm") to an entity.
+ * Checks each entity's repo URLs for a match.
+ */
+function find_entity_for_repo(
+  full_name: string,
+  registry: EntityRegistry,
+): { entity_id: string; repo_path: string } | null {
+  // Normalize: "owner/repo" matches against various URL formats
+  const lower = full_name.toLowerCase();
+
+  for (const entity of registry.get_active()) {
+    for (const repo of entity.entity.repos) {
+      // Match against HTTPS URL: https://github.com/owner/repo.git
+      // Match against SSH URL: git@github.com:owner/repo.git
+      const url = repo.url.toLowerCase();
+      if (
+        url.includes(lower) ||
+        url.includes(lower.replace("/", ":")) // SSH format uses colon
+      ) {
+        return {
+          entity_id: entity.entity.id,
+          repo_path: expand_home(repo.path),
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+// ── Active review tracking ──
+
+const active_reviews = new Map<string, ActiveWebhookReview>();
+
+function review_key(entity_id: string, pr_number: number): string {
+  return `${entity_id}:${String(pr_number)}`;
+}
+
+// ── Main handler ──
+
+/**
+ * Handle incoming GitHub webhook events.
+ * Must return 200 quickly — reviewer spawning is async.
+ */
+export async function handle_github_webhook(
+  req: IncomingMessage,
+  res: ServerResponse,
+  ctx: WebhookContext,
+): Promise<void> {
+  // 1. Read raw body for signature verification
+  const raw_body = await read_body(req);
+
+  // 2. Verify signature
+  const signature = req.headers["x-hub-signature-256"] as string | undefined;
+  if (!signature) {
+    json_response(res, 401, { error: "Missing X-Hub-Signature-256 header" });
+    return;
+  }
+
+  if (!ctx.github_app.verify_signature(raw_body, signature)) {
+    console.log("[webhook] Invalid signature — rejecting request");
+    json_response(res, 401, { error: "Invalid signature" });
+    return;
+  }
+
+  // 3. Parse event type and payload
+  const event_type = req.headers["x-github-event"] as string | undefined;
+  if (!event_type) {
+    json_response(res, 400, { error: "Missing X-GitHub-Event header" });
+    return;
+  }
+
+  let payload: WebhookPayload;
+  try {
+    payload = JSON.parse(raw_body) as WebhookPayload;
+  } catch {
+    json_response(res, 400, { error: "Invalid JSON payload" });
+    return;
+  }
+
+  // 4. Return 200 immediately — all processing happens async
+  json_response(res, 200, { ok: true });
+
+  // 5. Route event
+  void route_event(event_type, payload, ctx).catch((err) => {
+    console.error(`[webhook] Error handling ${event_type}.${payload.action}: ${String(err)}`);
+  });
+}
+
+// ── Event routing ──
+
+async function route_event(
+  event_type: string,
+  payload: WebhookPayload,
+  ctx: WebhookContext,
+): Promise<void> {
+  if (event_type !== "pull_request") {
+    console.log(`[webhook] Ignoring event: ${event_type}`);
+    return;
+  }
+
+  const action = payload.action;
+  const pr = payload.pull_request;
+  const repo_full_name = payload.repository?.full_name;
+
+  if (!pr || !repo_full_name) {
+    console.log(`[webhook] pull_request event missing PR or repo data`);
+    return;
+  }
+
+  // Only handle PR events that warrant a review
+  const reviewable_actions = ["opened", "synchronize", "reopened"];
+  if (!reviewable_actions.includes(action)) {
+    console.log(`[webhook] Ignoring pull_request.${action} for #${String(pr.number)}`);
+    return;
+  }
+
+  // Map repo to entity
+  const match = find_entity_for_repo(repo_full_name, ctx.registry);
+  if (!match) {
+    console.log(`[webhook] No entity found for repo ${repo_full_name} — ignoring`);
+    return;
+  }
+
+  console.log(
+    `[webhook] pull_request.${action} for #${String(pr.number)} ` +
+    `in ${match.entity_id} (${repo_full_name})`,
+  );
+
+  // Deduplicate: if review already in-flight for this PR, mark for requeue
+  const key = review_key(match.entity_id, pr.number);
+  const existing = active_reviews.get(key);
+  if (existing) {
+    console.log(
+      `[webhook] Review already in-flight for ${key} — marking for requeue`,
+    );
+    existing.needs_requeue = true;
+    return;
+  }
+
+  await spawn_review(match.entity_id, match.repo_path, pr, ctx);
+}
+
+// ── Reviewer spawning ──
+
+async function spawn_review(
+  entity_id: string,
+  repo_path: string,
+  pr: WebhookPR,
+  ctx: WebhookContext,
+): Promise<void> {
+  const key = review_key(entity_id, pr.number);
+
+  // Track active review
+  active_reviews.set(key, {
+    entity_id,
+    pr_number: pr.number,
+    needs_requeue: false,
+  });
+
+  // Get installation token for the reviewer subprocess
+  let gh_token: string;
+  try {
+    gh_token = await ctx.github_app.get_token();
+  } catch (err) {
+    console.error(`[webhook] Failed to get installation token: ${String(err)}`);
+    active_reviews.delete(key);
+    return;
+  }
+
+  // Fetch linked issue context if available (for #109)
+  let issue_context = "";
+  const linked_issue = extract_linked_issue(pr.body);
+  if (linked_issue) {
+    issue_context = await fetch_issue_context(repo_path, linked_issue, gh_token);
+  }
+
+  // Build reviewer prompt
+  const prompt = build_reviewer_prompt(pr, repo_path, issue_context);
+
+  console.log(
+    `[webhook] Spawning reviewer for PR #${String(pr.number)} in ${entity_id}`,
+  );
+
+  try {
+    const session = await ctx.session_manager.spawn({
+      entity_id,
+      feature_id: `pr-review-${String(pr.number)}`,
+      archetype: "reviewer",
+      dna: ["review-guideline"],
+      model: { model: "sonnet", think: "standard" },
+      worktree_path: repo_path,
+      prompt,
+      interactive: false,
+      env: { GH_TOKEN: gh_token },
+    });
+
+    console.log(
+      `[webhook] Reviewer session ${session.session_id.slice(0, 8)} ` +
+      `started for PR #${String(pr.number)}`,
+    );
+
+    // Listen for session completion
+    const on_complete = (result: SessionResult) => {
+      if (result.session_id !== session.session_id) return;
+      ctx.session_manager.removeListener("session:completed", on_complete);
+      ctx.session_manager.removeListener("session:failed", on_fail);
+
+      void handle_review_completion(entity_id, repo_path, pr, ctx).catch(
+        (err) => console.error(`[webhook] Post-review error: ${String(err)}`),
+      );
+    };
+
+    const on_fail = (session_id: string, error: string) => {
+      if (session_id !== session.session_id) return;
+      ctx.session_manager.removeListener("session:completed", on_complete);
+      ctx.session_manager.removeListener("session:failed", on_fail);
+
+      console.error(
+        `[webhook] Review session failed for PR #${String(pr.number)}: ${error}`,
+      );
+      cleanup_and_maybe_requeue(key, entity_id, repo_path, pr, ctx);
+    };
+
+    ctx.session_manager.on("session:completed", on_complete);
+    ctx.session_manager.on("session:failed", on_fail);
+  } catch (err) {
+    console.error(
+      `[webhook] Failed to spawn reviewer for PR #${String(pr.number)}: ${String(err)}`,
+    );
+    active_reviews.delete(key);
+  }
+}
+
+// ── Post-review handling ──
+
+async function handle_review_completion(
+  entity_id: string,
+  repo_path: string,
+  pr: WebhookPR,
+  ctx: WebhookContext,
+): Promise<void> {
+  const key = review_key(entity_id, pr.number);
+  const outcome = await detect_review_outcome(pr.number, repo_path);
+
+  console.log(
+    `[webhook] Review completed for PR #${String(pr.number)} — outcome: ${outcome}`,
+  );
+
+  // Route outcome
+  const linked_feature = ctx.feature_manager.find_by_pr(pr.number) ?? null;
+
+  if (linked_feature) {
+    // Feature-managed PR — the feature manager handles transitions
+    console.log(
+      `[webhook] PR #${String(pr.number)} linked to feature ${linked_feature.id} — deferring to feature manager`,
+    );
+  } else if (outcome === "changes_requested") {
+    // Spawn builder to fix
+    await spawn_fixer(entity_id, repo_path, pr, ctx);
+    await notify_alerts(
+      entity_id,
+      `PR #${String(pr.number)}: ${pr.title} — changes requested, spawning builder to fix`,
+      ctx,
+    );
+  } else if (outcome === "approved") {
+    // Check if reviewer already merged
+    const is_merged = await check_pr_merged(repo_path, pr.number);
+    await notify_alerts(
+      entity_id,
+      `PR #${String(pr.number)}: ${pr.title} — ${is_merged ? "approved and merged" : "approved"}`,
+      ctx,
+    );
+  } else {
+    await notify_alerts(
+      entity_id,
+      `PR #${String(pr.number)} review completed: "${pr.title}" (${outcome})`,
+      ctx,
+    );
+  }
+
+  // Check if we need to re-review (new commits arrived during review)
+  cleanup_and_maybe_requeue(key, entity_id, repo_path, pr, ctx);
+}
+
+/**
+ * Remove the active review entry and, if new events arrived mid-review,
+ * spawn a fresh review.
+ */
+function cleanup_and_maybe_requeue(
+  key: string,
+  entity_id: string,
+  repo_path: string,
+  pr: WebhookPR,
+  ctx: WebhookContext,
+): void {
+  const review = active_reviews.get(key);
+  active_reviews.delete(key);
+
+  if (review?.needs_requeue) {
+    console.log(
+      `[webhook] Re-reviewing PR #${String(pr.number)} — new commits arrived during previous review`,
+    );
+    void spawn_review(entity_id, repo_path, pr, ctx).catch((err) =>
+      console.error(`[webhook] Requeue failed for PR #${String(pr.number)}: ${String(err)}`),
+    );
+  }
+}
+
+// ── Builder spawning for failed reviews ──
+
+async function spawn_fixer(
+  entity_id: string,
+  repo_path: string,
+  pr: WebhookPR,
+  ctx: WebhookContext,
+): Promise<void> {
+  const review_comments = await fetch_review_comments(pr.number, repo_path);
+
+  const prompt = [
+    `An external PR needs fixes based on reviewer feedback.`,
+    `PR #${String(pr.number)}: "${pr.title}" on branch ${pr.head.ref}`,
+    `Repository: ${repo_path}`,
+    ``,
+    `First, check out the PR branch: git checkout ${pr.head.ref}`,
+    ``,
+    build_review_fix_prompt(pr.number, pr.title, review_comments),
+    ``,
+    `Do NOT merge the PR.`,
+  ].join("\n");
+
+  console.log(
+    `[webhook] Spawning builder to fix PR #${String(pr.number)} in ${entity_id}`,
+  );
+
+  try {
+    // Get fresh token for builder too
+    const gh_token = await ctx.github_app.get_token();
+
+    await ctx.session_manager.spawn({
+      entity_id,
+      feature_id: `webhook-pr-fix-${String(pr.number)}`,
+      archetype: "builder",
+      dna: ["coding-dna"],
+      model: { model: "opus", think: "high" },
+      worktree_path: repo_path,
+      prompt,
+      interactive: false,
+      env: { GH_TOKEN: gh_token },
+    });
+  } catch (err) {
+    console.error(
+      `[webhook] Failed to spawn builder for PR #${String(pr.number)}: ${String(err)}`,
+    );
+  }
+}
+
+// ── Prompt building ──
+
+function build_reviewer_prompt(
+  pr: WebhookPR,
+  repo_path: string,
+  issue_context: string,
+): string {
+  const lines = [
+    `Review PR #${String(pr.number)}: "${pr.title}" on branch ${pr.head.ref}.`,
+    `Repository: ${repo_path}`,
+    ``,
+    `Run /review to do a comprehensive code review.`,
+    ``,
+    `Post your review on the PR using gh cli.`,
+    `You are authenticated as the LobsterFarm Reviewer GitHub App.`,
+    ``,
+    `Review standards:`,
+    `- Every piece of actionable feedback should be included.`,
+    `- If there is ANY actionable feedback, request changes:`,
+    `  gh pr review ${String(pr.number)} --request-changes --body "<your review>"`,
+    `- If the code is genuinely clean with no improvements needed, approve:`,
+    `  gh pr review ${String(pr.number)} --approve --body "Looks good."`,
+    ``,
+    `After posting your review:`,
+    `- If you approved, merge the PR:`,
+    `  gh pr merge ${String(pr.number)} --squash --delete-branch`,
+    `- If you requested changes, do NOT merge.`,
+  ];
+
+  if (issue_context) {
+    lines.push(``, `## Linked Issue Context`, ``, issue_context);
+  }
+
+  return lines.join("\n");
+}
+
+// ── Issue context fetching ──
+
+async function fetch_issue_context(
+  repo_path: string,
+  issue_number: number,
+  gh_token: string,
+): Promise<string> {
+  try {
+    const { stdout } = await exec("gh", [
+      "issue", "view", String(issue_number),
+      "--json", "title,body",
+      "--jq", `"## Issue #" + (.number | tostring) + ": " + .title + "\\n\\n" + .body`,
+    ], {
+      cwd: repo_path,
+      timeout: 15_000,
+      env: { ...process.env, GH_TOKEN: gh_token },
+    });
+    return stdout.trim();
+  } catch (err) {
+    console.log(
+      `[webhook] Could not fetch issue #${String(issue_number)}: ${String(err)}`,
+    );
+    return "";
+  }
+}
+
+// ── Utility helpers ──
+
+async function notify_alerts(
+  entity_id: string,
+  message: string,
+  ctx: WebhookContext,
+): Promise<void> {
+  console.log(`[webhook:alerts] ${message}`);
+  if (ctx.discord) {
+    await ctx.discord.send_to_entity(
+      entity_id,
+      "alerts",
+      message,
+      "reviewer" as ArchetypeRole,
+    );
+  }
+}
+
+async function check_pr_merged(repo_path: string, pr_number: number): Promise<boolean> {
+  try {
+    const { stdout } = await exec("gh", [
+      "pr", "view", String(pr_number),
+      "--json", "state",
+      "--jq", ".state",
+    ], { cwd: repo_path, timeout: 15_000 });
+    return stdout.trim() === "MERGED";
+  } catch {
+    return false;
+  }
+}
+
+/** Get the currently active webhook reviews (for status/debugging). */
+export function get_active_webhook_reviews(): Array<{
+  key: string;
+  entity_id: string;
+  pr_number: number;
+  needs_requeue: boolean;
+}> {
+  return [...active_reviews.entries()].map(([key, review]) => ({
+    key,
+    entity_id: review.entity_id,
+    pr_number: review.pr_number,
+    needs_requeue: review.needs_requeue,
+  }));
+}


### PR DESCRIPTION
## Summary

Closes #110

- **GitHub App auth module** (`github-app.ts`): RS256 JWT signing, installation token caching with concurrent request coalescing, webhook signature verification using `crypto.timingSafeEqual` -- zero external dependencies
- **Webhook handler** (`webhook-handler.ts`): receives `POST /webhooks/github`, verifies signatures, routes `pull_request.opened/synchronize/reopened` events to spawn reviewer sessions with the App's installation token as `GH_TOKEN`
- **Deduplication**: tracks active reviews by `entity:pr#`, queues re-review if new commits arrive mid-review
- **Session env injection**: `SessionSpawnOptions` now accepts an `env` field for injecting custom environment variables (used for `GH_TOKEN`)
- **PR cron as safety net**: when GitHub App is configured, cron interval increases from 5 min to 30 min; both cron and webhook paths inject the App token
- **Graceful degradation**: if `GITHUB_APP_*` env vars are missing, the daemon starts normally and the webhook endpoint accepts but does not process events

## Files changed

| File | What |
|------|------|
| `packages/daemon/src/github-app.ts` | New -- JWT, token cache, signature verification |
| `packages/daemon/src/webhook-handler.ts` | New -- event routing, reviewer spawning, dedup |
| `packages/daemon/src/server.ts` | Replace placeholder, add `github_app` to context |
| `packages/daemon/src/session.ts` | Add `env` option to `SessionSpawnOptions` |
| `packages/daemon/src/index.ts` | Initialize GitHub App, wire into server + cron |
| `packages/daemon/src/pr-cron.ts` | Accept `GitHubAppAuth`, inject tokens |
| `packages/daemon/src/__tests__/github-app.test.ts` | New -- 13 tests |
| `packages/daemon/src/__tests__/webhook-handler.test.ts` | New -- 10 tests |

## Test plan

- [x] All 468 tests pass (445 existing + 23 new)
- [x] Build succeeds with no errors
- [ ] Webhook signature verification: valid signature -> 200, invalid -> 401, missing -> 401
- [ ] Unknown repo events accepted gracefully (200, no reviewer spawned)
- [ ] `pull_request.opened` triggers reviewer spawn with `GH_TOKEN` injected
- [ ] Concurrent events for same PR are deduplicated
- [ ] Installation token is cached and refreshed before expiry
- [ ] Safety net cron runs at 30-min interval when App is configured
- [ ] Daemon starts cleanly when `GITHUB_APP_*` env vars are absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)