### PR TITLE
fix: kill stale tmux sessions during proactive resume

### DIFF
--- a/packages/daemon/src/__tests__/pool-persistence.test.ts
+++ b/packages/daemon/src/__tests__/pool-persistence.test.ts
@@ -1100,6 +1100,133 @@ describe("BotPool persistence", () => {
       expect(events).toHaveLength(0);
     });
 
+    it("kills stale tmux and respawns when tmux survived daemon restart", async () => {
+      // This is the core fix for #112: when the daemon restarts and the old tmux
+      // session survives, the Claude process inside has a dead MCP connection.
+      // The resume path must kill the old tmux and spawn fresh with --resume.
+      const cfg = make_config();
+      await save_pool_state([
+        make_persisted_bot({
+          id: 1,
+          state: "assigned",
+          channel_id: "ch-1",
+          entity_id: "test-entity",
+          archetype: "builder",
+          session_id: "sess-stale",
+        }),
+      ], cfg);
+
+      const dir = join(temp_dir, "channels", "pool-1");
+      await mkdir(dir, { recursive: true });
+      await writeFile(join(dir, ".env"), "DISCORD_BOT_TOKEN=fake-token-1", "utf-8");
+
+      const p = new TestBotPool(cfg);
+      // tmux IS alive — the old session survived the restart
+      vi.spyOn(p as unknown as Record<string, unknown>, "is_tmux_alive" as never)
+        .mockReturnValue(true);
+      const kill_spy = vi.spyOn(p as unknown as Record<string, unknown>, "kill_tmux" as never)
+        .mockImplementation(() => {});
+      vi.spyOn(p as unknown as Record<string, unknown>, "write_access_json" as never)
+        .mockResolvedValue(undefined);
+      vi.spyOn(p as unknown as Record<string, unknown>, "set_bot_nickname" as never)
+        .mockResolvedValue(undefined);
+      const start_spy = vi.spyOn(p as unknown as Record<string, unknown>, "start_tmux" as never)
+        .mockResolvedValue(undefined);
+
+      const reg = make_registry([
+        make_entity_config("test-entity", ["ch-1"]),
+      ]);
+      await p.initialize(reg);
+
+      // Bot is "assigned" because tmux is alive, but should be queued for resume
+      const bots_before = p.get_bots();
+      expect(bots_before[0]!.state).toBe("assigned");
+      expect(p.get_resume_candidates()).toHaveLength(1);
+
+      const events: Array<{ bot_id: number; channel_id: string; entity_id: string }> = [];
+      p.on("bot:resumed", (evt: { bot_id: number; channel_id: string; entity_id: string }) => events.push(evt));
+
+      await p.resume_parked_bots();
+
+      // Old tmux was killed
+      expect(kill_spy).toHaveBeenCalledWith("pool-1");
+
+      // Fresh tmux was spawned with --resume session_id
+      const start_calls = (start_spy as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+      const resume_call = start_calls.find(c => c[4] === "sess-stale");
+      expect(resume_call).toBeDefined();
+      expect(resume_call![5]).toBe(true); // is_resume = true
+
+      // Bot is still assigned with correct metadata
+      const bots_after = p.get_bots();
+      const bot = bots_after.find(b => b.id === 1)!;
+      expect(bot.state).toBe("assigned");
+      expect(bot.channel_id).toBe("ch-1");
+      expect(bot.session_id).toBe("sess-stale");
+
+      // assigned_at was reset (new process)
+      expect(bot.assigned_at).not.toBeNull();
+      const now = Date.now();
+      expect(now - bot.assigned_at!.getTime()).toBeLessThan(5000);
+
+      // Event emitted
+      expect(events).toHaveLength(1);
+      expect(events[0]!.bot_id).toBe(1);
+
+      // Candidates cleared
+      expect(p.get_resume_candidates()).toHaveLength(0);
+    });
+
+    it("handles gracefully when tmux is already dead by resume time", async () => {
+      // Edge case: tmux was alive during initialize() but died before
+      // resume_parked_bots() runs. kill_tmux is a no-op, spawn still works.
+      const cfg = make_config();
+      await save_pool_state([
+        make_persisted_bot({
+          id: 1,
+          state: "assigned",
+          channel_id: "ch-1",
+          entity_id: "test-entity",
+          archetype: "planner",
+          session_id: "sess-died",
+        }),
+      ], cfg);
+
+      const dir = join(temp_dir, "channels", "pool-1");
+      await mkdir(dir, { recursive: true });
+      await writeFile(join(dir, ".env"), "DISCORD_BOT_TOKEN=fake-token-1", "utf-8");
+
+      const p = new TestBotPool(cfg);
+      // tmux alive during init, so bot gets "assigned" state
+      const tmux_spy = vi.spyOn(p as unknown as Record<string, unknown>, "is_tmux_alive" as never)
+        .mockReturnValue(true);
+      vi.spyOn(p as unknown as Record<string, unknown>, "kill_tmux" as never)
+        .mockImplementation(() => {});
+      vi.spyOn(p as unknown as Record<string, unknown>, "write_access_json" as never)
+        .mockResolvedValue(undefined);
+      vi.spyOn(p as unknown as Record<string, unknown>, "set_bot_nickname" as never)
+        .mockResolvedValue(undefined);
+      vi.spyOn(p as unknown as Record<string, unknown>, "start_tmux" as never)
+        .mockResolvedValue(undefined);
+
+      const reg = make_registry([
+        make_entity_config("test-entity", ["ch-1"]),
+      ]);
+      await p.initialize(reg);
+
+      expect(p.get_resume_candidates()).toHaveLength(1);
+
+      // Simulate tmux dying between init and resume
+      tmux_spy.mockReturnValue(false);
+
+      // Should still succeed — kill_tmux is a no-op, start_tmux spawns fresh
+      await p.resume_parked_bots();
+
+      const bots = p.get_bots();
+      expect(bots[0]!.state).toBe("assigned");
+      expect(bots[0]!.session_id).toBe("sess-died");
+    });
+
     it("existing assign-on-message flow still works for non-resumed parked bots", async () => {
       const p = await setup_resume_pool(
         [

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -252,7 +252,10 @@ export class BotPool extends EventEmitter {
       }
 
       if (bot.state === "assigned") {
-        // tmux is still running (survived restart, e.g. launchd) — restore metadata
+        // tmux is still running (survived restart, e.g. launchd) — restore metadata.
+        // BUT the Claude process inside has a stale MCP connection to the old daemon.
+        // We mark it as a resume candidate so resume_parked_bots() will kill the old
+        // tmux and spawn a fresh Claude process with --resume (fresh MCP connection).
         bot.channel_id = entry.channel_id;
         bot.entity_id = entry.entity_id;
         bot.archetype = entry.archetype;
@@ -260,6 +263,16 @@ export class BotPool extends EventEmitter {
         bot.session_id = entry.session_id;
         bot.last_active = entry.last_active ? new Date(entry.last_active) : null;
         bot.assigned_at = entry.assigned_at ? new Date(entry.assigned_at) : bot.last_active;
+
+        // Add to resume candidates — the live tmux session has a dead MCP socket.
+        // resume_parked_bots() will kill it and spawn fresh with --resume.
+        if (entry.state === "assigned" && entry.session_id) {
+          this.resume_candidates.push(entry);
+          console.log(
+            `[pool] pool-${String(bot.id)} has live tmux but stale MCP — ` +
+            `queued for fresh resume (session: ${entry.session_id.slice(0, 8)})`,
+          );
+        }
       } else {
         // tmux is dead — mark as parked with preserved session ID.
         // When someone messages the channel, existing parked-bot auto-resume
@@ -355,27 +368,51 @@ export class BotPool extends EventEmitter {
 
     let resumed = 0;
     for (const candidate of this.resume_candidates) {
+      // Match both parked bots (tmux died) and assigned bots (tmux survived but
+      // has stale MCP connection). Both need a fresh Claude process with --resume.
       const bot = this.bots.find(
-        b => b.id === candidate.id && b.state === "parked" && b.channel_id === candidate.channel_id,
+        b => b.id === candidate.id
+          && (b.state === "parked" || b.state === "assigned")
+          && b.channel_id === candidate.channel_id,
       );
       if (!bot) continue;
 
+      const had_live_tmux = bot.state === "assigned";
+
       try {
+        // Kill any surviving tmux session — the Claude process inside has a stale
+        // MCP connection to the old daemon and can't reply through Discord.
+        // This is safe even if the tmux session is already dead.
+        if (had_live_tmux) {
+          console.log(
+            `[pool] Killing stale tmux for pool-${String(bot.id)} ` +
+            `(MCP connection is dead after daemon restart)`,
+          );
+        }
+        this.kill_tmux(bot.tmux_session);
+
         // Write access.json so the Discord plugin listens on this channel
         await this.write_access_json(bot.state_dir, candidate.channel_id);
 
         // Set Discord nickname to match the archetype
         await this.set_bot_nickname(bot, candidate.archetype);
 
-        // Start tmux with --resume to restore the previous session
+        // Spawn a fresh Claude process with --resume — establishes a new MCP
+        // connection to this daemon while preserving conversation context
         const working_dir = entity_dir(this.config.paths, candidate.entity_id);
         await this.start_tmux(bot, candidate.archetype, candidate.entity_id, working_dir, candidate.session_id!, true);
 
         // Update bot state to assigned
         bot.state = "assigned";
         bot.last_active = new Date();
+        bot.assigned_at = new Date(); // Reset uptime — new process
 
         resumed++;
+        console.log(
+          `[pool] Resumed pool-${String(bot.id)} with fresh MCP connection ` +
+          `(session: ${candidate.session_id!.slice(0, 8)}, ` +
+          `was: ${had_live_tmux ? "stale tmux" : "parked"})`,
+        );
 
         this.emit("bot:resumed", {
           bot_id: bot.id,
@@ -386,7 +423,8 @@ export class BotPool extends EventEmitter {
         console.error(
           `[pool] Failed to resume pool-${String(bot.id)}: ${String(err)}`,
         );
-        // Leave the bot parked — it can still be resumed on next message
+        // Leave the bot in its current state — parked bots can still be resumed
+        // on next message; assigned bots with dead tmux will be caught by health monitor
       }
     }
 


### PR DESCRIPTION
## Summary

- After a daemon restart, surviving tmux sessions contain Claude processes with dead MCP connections to the old daemon -- messages arrive via `send-keys` but Claude can't reply through Discord
- The proactive resume path in `pool.ts` now always kills the old tmux session and spawns a fresh Claude process with `--resume`, establishing a new MCP connection while preserving conversation context
- Handles both cases: tmux survived restart (stale MCP -- the bug) and tmux already died (existing path, unchanged behavior)

## Changes

**`packages/daemon/src/pool.ts`**
- `initialize()`: Bots with live tmux sessions that were previously "assigned" are now added to `resume_candidates` with a log explaining the stale MCP condition
- `resume_parked_bots()`: Matches both "parked" and "assigned" bots; kills old tmux before spawning fresh; resets `assigned_at` for accurate uptime; adds structured logging for diagnostics

**`packages/daemon/src/__tests__/pool-persistence.test.ts`**
- Added test: "kills stale tmux and respawns when tmux survived daemon restart" -- verifies the core fix (kill old tmux, spawn with --resume, reset uptime, emit event)
- Added test: "handles gracefully when tmux is already dead by resume time" -- edge case where tmux dies between init and resume

## Test plan

- [x] All 470 existing tests pass (29 test suites)
- [x] New tests cover the stale-tmux-alive path and the tmux-dies-between-init-and-resume edge case
- [ ] Manual: restart daemon while a pool bot has an active session, verify the resumed session responds within 10 seconds
- [ ] Manual: verify session ID is preserved (same conversation context via --resume)
- [ ] Manual: verify uptime resets (new process) in `!lf status`

Closes #112

Generated with [Claude Code](https://claude.com/claude-code)