### PR TITLE
fix: sync review prompts + update reviewer DNA for automated loops

### DIFF
--- a/config/claude/agents/reviewer.md
+++ b/config/claude/agents/reviewer.md
@@ -16,7 +16,9 @@ You are thorough but not pedantic. You catch real issues — bugs, security vuln
 
 You review in priority order: correctness first, security second, robustness third, performance fourth, maintainability fifth. When you find an issue, you explain WHY it matters, not just WHAT is wrong. You provide concrete fix suggestions, not vague directives.
 
-You distinguish clearly between blocking issues (must fix before merge) and suggestions (could be better, not blocking). You mark them: 🔴 blocking, 🟡 suggestion, 🟢 praise.
+You categorize feedback for clarity: 🔴 must fix, 🟡 should address, 🟢 praise. But in automated review loops, ALL actionable feedback (🔴 and 🟡) warrants requesting changes. The builder has full spec context and runs on a stronger model — they evaluate each suggestion and either implement it or explain why it doesn't apply. Your job is to flag everything you see; their job is to judge with context.
+
+If there are ANY 🔴 or 🟡 items, request changes. Only approve if the code is genuinely clean with no improvements needed.
 
 You are fair. Good code deserves acknowledgment. A review that only lists problems creates a hostile environment. Highlight what's done well alongside what needs work.
 

--- a/packages/daemon/src/pr-cron.ts
+++ b/packages/daemon/src/pr-cron.ts
@@ -305,11 +305,18 @@ export class PRReviewCron {
       ``,
       `Run /review to do a comprehensive code review.`,
       `Post your review on the PR using gh cli.`,
-      `If the code is clean — approve the PR with: gh pr review ${String(pr.number)} --approve --body "Looks good."`,
-      `If changes are needed — request changes with: gh pr review ${String(pr.number)} --request-changes --body "<your findings>"`,
       ``,
-      `After posting your review, if you approved, merge the PR:`,
-      `gh pr merge ${String(pr.number)} --squash --delete-branch`,
+      `Review standards:`,
+      `- Every piece of actionable feedback should be included.`,
+      `- If there is ANY actionable feedback, request changes:`,
+      `  gh pr review ${String(pr.number)} --request-changes --body "<your review>"`,
+      `- If the code is genuinely clean with no improvements needed, approve:`,
+      `  gh pr review ${String(pr.number)} --approve --body "Looks good."`,
+      ``,
+      `After posting your review:`,
+      `- If you approved, merge the PR:`,
+      `  gh pr merge ${String(pr.number)} --squash --delete-branch`,
+      `- If you requested changes, do NOT merge.`,
     ].join("\n");
 
     console.log(`[pr-cron] Spawning reviewer for PR #${String(pr.number)} in ${entity_id}`);


### PR DESCRIPTION
## Summary
- Cron reviewer prompt updated to match webhook handler: all actionable feedback → request changes
- Reviewer DNA updated: 🔴/🟡 categorization kept for readability, but both trigger request-changes in automated loops
- Builder evaluates suggestions with full spec context — implements or rebuts

## Test plan
- [ ] Cron-triggered reviews use updated prompt
- [ ] Reviewer DNA loads correctly in review sessions
- [ ] Reviews with 🟡 suggestions result in request-changes (not approve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)