### PR TITLE
chore: remove static work rooms and work-log from scaffold + blueprint

### DIFF
--- a/config/claude/skills/entity-scaffold/SKILL.md
+++ b/config/claude/skills/entity-scaffold/SKILL.md
@@ -160,7 +160,7 @@ curl -s -X POST http://localhost:7749/scaffold/entity \
 
 The daemon handles Discord authentication internally — **never access Discord tokens directly.** See the `secrets-guideline` skill.
 
-The endpoint returns the category ID and channel IDs. Update the entity config with these. The daemon automatically sets the channel topic to "🟢 Available" for each work room during scaffolding.
+The endpoint returns the category ID and channel IDs. Update the entity config with these. Only `general` and `alerts` are created during scaffolding — work rooms are added on demand via `!lf room`.
 
 ### 7. Register with daemon
 


### PR DESCRIPTION
## Summary

- Removed 4 vestigial static channels (`work-room-1/2/3`, `work-log`) from `~/.lobsterfarm/blueprints/software/blueprint.yaml` — new entities now scaffold with only `general` and `alerts`
- Updated entity scaffold SOP (`SKILL.md`) step 6 to reflect that work rooms are added on demand via `!lf room`, replacing the stale reference to automatic work room topic setting
- Verified `scaffold_entity()`, CLI `entity create`, and `reset_idle_work_room_topics` already handle dynamic-only rooms correctly (updated in PR #81)

**Note:** `blueprint.yaml` is an instance-level config file outside this repo, edited directly on the machine. The in-repo change is the SKILL.md update only.

Closes #121

## Test plan

- [x] All 545 existing tests pass (54 shared + 21 CLI + 470 daemon)
- [x] `blueprint.yaml` channels list contains only `general` and `alerts`
- [x] `scaffold_entity()` creates only 2 channels (already correct since PR #81)
- [x] CLI entity setup only prompts for `general` and `alerts` (already correct since PR #81)
- [x] Entity scaffold SOP reflects the new channel structure
- [x] `reset_idle_work_room_topics` works correctly with zero static rooms (iterates `channels.list` filtered by `work_room` — empty list = no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)