### PR TITLE
feat: show Claude subscription usage in !lf status

### DIFF
--- a/packages/daemon/src/__tests__/fix-resume-persist.test.ts
+++ b/packages/daemon/src/__tests__/fix-resume-persist.test.ts
@@ -64,6 +64,8 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
     last_active: null,
     assigned_at: null,
     state_dir: `/tmp/test-pool-${String(overrides.id)}`,
+    model: null,
+    effort: null,
     last_avatar_archetype: null,
     last_avatar_set_at: null,
     ...overrides,

--- a/packages/daemon/src/__tests__/interactive-builder.test.ts
+++ b/packages/daemon/src/__tests__/interactive-builder.test.ts
@@ -95,6 +95,8 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
     last_active: null,
     assigned_at: null,
     state_dir: `/tmp/test-pool-${String(overrides.id)}`,
+    model: null,
+    effort: null,
     last_avatar_archetype: null,
     last_avatar_set_at: null,
     ...overrides,

--- a/packages/daemon/src/__tests__/lazy-session-resume.test.ts
+++ b/packages/daemon/src/__tests__/lazy-session-resume.test.ts
@@ -24,6 +24,8 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
     last_active: null,
     assigned_at: null,
     state_dir: `/tmp/test-pool-${String(overrides.id)}`,
+    model: null,
+    effort: null,
     last_avatar_archetype: null,
     last_avatar_set_at: null,
     ...overrides,

--- a/packages/daemon/src/__tests__/pool-avatars.test.ts
+++ b/packages/daemon/src/__tests__/pool-avatars.test.ts
@@ -35,6 +35,8 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
     last_active: null,
     assigned_at: null,
     state_dir: `/tmp/test-pool-${String(overrides.id)}`,
+    model: null,
+    effort: null,
     last_avatar_archetype: null,
     last_avatar_set_at: null,
     ...overrides,

--- a/packages/daemon/src/__tests__/pool-persistence.test.ts
+++ b/packages/daemon/src/__tests__/pool-persistence.test.ts
@@ -82,6 +82,8 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
     last_active: null,
     assigned_at: null,
     state_dir: `/tmp/test-pool-${String(overrides.id)}`,
+    model: null,
+    effort: null,
     last_avatar_archetype: null,
     last_avatar_set_at: null,
     ...overrides,

--- a/packages/daemon/src/__tests__/pool.test.ts
+++ b/packages/daemon/src/__tests__/pool.test.ts
@@ -54,6 +54,8 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
     last_active: null,
     assigned_at: null,
     state_dir: `/tmp/test-pool-${String(overrides.id)}`,
+    model: null,
+    effort: null,
     last_avatar_archetype: null,
     last_avatar_set_at: null,
     ...overrides,

--- a/packages/daemon/src/__tests__/session-history.test.ts
+++ b/packages/daemon/src/__tests__/session-history.test.ts
@@ -50,6 +50,8 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
     last_active: null,
     assigned_at: null,
     state_dir: `/tmp/test-pool-${String(overrides.id)}`,
+    model: null,
+    effort: null,
     last_avatar_archetype: null,
     last_avatar_set_at: null,
     ...overrides,

--- a/packages/daemon/src/__tests__/tmux-query.test.ts
+++ b/packages/daemon/src/__tests__/tmux-query.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+import {
+  parse_context_usage,
+  parse_subscription_usage,
+  parse_token_count,
+} from "../tmux-query.js";
+
+describe("parse_token_count", () => {
+  it("parses k suffix", () => {
+    expect(parse_token_count("19k")).toBe(19000);
+    expect(parse_token_count("45.5k")).toBe(45500);
+  });
+
+  it("parses m suffix", () => {
+    expect(parse_token_count("1m")).toBe(1000000);
+    expect(parse_token_count("1.5m")).toBe(1500000);
+  });
+
+  it("parses plain numbers", () => {
+    expect(parse_token_count("145234")).toBe(145234);
+    expect(parse_token_count("1,048,576")).toBe(1048576);
+  });
+
+  it("handles whitespace", () => {
+    expect(parse_token_count("  19k  ")).toBe(19000);
+  });
+
+  it("is case-insensitive", () => {
+    expect(parse_token_count("19K")).toBe(19000);
+    expect(parse_token_count("1M")).toBe(1000000);
+  });
+
+  it("returns null for invalid input", () => {
+    expect(parse_token_count("abc")).toBeNull();
+    expect(parse_token_count("")).toBeNull();
+  });
+});
+
+describe("parse_context_usage", () => {
+  it("parses compact format (19k / 1m)", () => {
+    const output = `
+System prompt
+Tools
+Messages
+
+Tokens: 19k / 1m (2%)
+    `;
+    const result = parse_context_usage(output);
+    expect(result).not.toBeNull();
+    expect(result!.summary).toBe("19k / 1m (2%)");
+    expect(result!.used_tokens).toBe(19000);
+    expect(result!.total_tokens).toBe(1000000);
+    expect(result!.percent).toBe(2);
+  });
+
+  it("parses full number format", () => {
+    const output = "Tokens: 145,234 / 1,048,576 (14%)";
+    const result = parse_context_usage(output);
+    expect(result).not.toBeNull();
+    expect(result!.summary).toBe("145,234 / 1,048,576 (14%)");
+    expect(result!.used_tokens).toBe(145234);
+    expect(result!.total_tokens).toBe(1048576);
+    expect(result!.percent).toBe(14);
+  });
+
+  it("parses decimal percentage", () => {
+    const output = "Tokens: 45k / 1m (4.5%)";
+    const result = parse_context_usage(output);
+    expect(result).not.toBeNull();
+    expect(result!.percent).toBe(4.5);
+    expect(result!.summary).toBe("45k / 1m (4.5%)");
+  });
+
+  it("returns null for output without token line", () => {
+    expect(parse_context_usage("No tokens here")).toBeNull();
+    expect(parse_context_usage("")).toBeNull();
+  });
+
+  it("handles output with surrounding noise", () => {
+    const output = `
+some other output
+❯ /context
+
+Context for this conversation:
+
+  System prompt   ████████░░░░░░░░  12k
+  Tools           ██████░░░░░░░░░░   8k
+  Messages        ██░░░░░░░░░░░░░░   3k
+  Free space      ░░░░░░░░░░░░░░░░ 977k
+
+Tokens: 23k / 1m (2.3%)
+
+❯
+    `;
+    const result = parse_context_usage(output);
+    expect(result).not.toBeNull();
+    expect(result!.summary).toBe("23k / 1m (2.3%)");
+    expect(result!.used_tokens).toBe(23000);
+    expect(result!.percent).toBe(2.3);
+  });
+});
+
+describe("parse_subscription_usage", () => {
+  it("parses 'Weekly usage: XX%' format", () => {
+    const output = "Weekly usage: 62%";
+    const result = parse_subscription_usage(output);
+    expect(result).not.toBeNull();
+    expect(result!.summary).toBe("62% weekly");
+    expect(result!.weekly_percent).toBe(62);
+  });
+
+  it("parses 'Usage: XX% of weekly limit' format", () => {
+    const output = "Usage: 43.5% of weekly limit";
+    const result = parse_subscription_usage(output);
+    expect(result).not.toBeNull();
+    expect(result!.summary).toBe("43.5% weekly");
+    expect(result!.weekly_percent).toBe(43.5);
+  });
+
+  it("parses percentage with 'of your' context", () => {
+    const output = "You have used 78% of your Opus limit this week";
+    const result = parse_subscription_usage(output);
+    expect(result).not.toBeNull();
+    expect(result!.summary).toBe("78% weekly");
+    expect(result!.weekly_percent).toBe(78);
+  });
+
+  it("returns null for output without usage info", () => {
+    expect(parse_subscription_usage("No usage here")).toBeNull();
+    expect(parse_subscription_usage("")).toBeNull();
+  });
+
+  it("handles output with surrounding noise", () => {
+    const output = `
+❯ /usage
+
+Claude Code usage this session:
+  Tokens in: 45,000
+  Tokens out: 12,000
+
+Weekly usage: 35%
+
+❯
+    `;
+    const result = parse_subscription_usage(output);
+    expect(result).not.toBeNull();
+    expect(result!.summary).toBe("35% weekly");
+    expect(result!.weekly_percent).toBe(35);
+  });
+});

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -35,6 +35,8 @@ import type { FeatureManager, CreateFeatureOptions } from "./features.js";
 import { route_message, type RouteAction, type RoutedMessage } from "./router.js";
 import type { TaskQueue } from "./queue.js";
 import type { BotPool, PoolBot } from "./pool.js";
+import { query_context_usage, query_subscription_usage } from "./tmux-query.js";
+import type { ContextUsage, SubscriptionUsage } from "./tmux-query.js";
 import * as sentry from "./sentry.js";
 
 const exec = promisify(execFile);
@@ -1136,8 +1138,20 @@ export class DiscordBot extends EventEmitter {
       return;
     }
 
-    // Full session status — bot is assigned to this channel
-    const lines = this.format_session_status(assignment, routed, features);
+    // Full session status — bot is assigned to this channel.
+    // Query context/usage from the live tmux session (best-effort, non-blocking).
+    // Queries run sequentially — both target the same tmux pane, so parallel injection
+    // would interleave commands and corrupt output.
+    let context_usage: ContextUsage | null = null;
+    let subscription_usage: SubscriptionUsage | null = null;
+    try {
+      context_usage = await query_context_usage(assignment.tmux_session);
+      subscription_usage = await query_subscription_usage(assignment.tmux_session);
+    } catch {
+      // Non-fatal: tmux queries are best-effort
+    }
+
+    const lines = this.format_session_status(assignment, routed, features, context_usage, subscription_usage);
     if (pool_summary) lines.push("", pool_summary);
     await this.reply(message, lines.join("\n"));
   }
@@ -1147,6 +1161,8 @@ export class DiscordBot extends EventEmitter {
     bot: PoolBot,
     routed: RoutedMessage,
     features: FeatureManager | null,
+    context_usage?: ContextUsage | null,
+    subscription_usage?: SubscriptionUsage | null,
   ): string[] {
     const identity = bot.archetype
       ? this.resolve_agent_identity(bot.archetype)
@@ -1173,6 +1189,21 @@ export class DiscordBot extends EventEmitter {
     }
 
     lines.push(`Bot: pool-${String(bot.id)} (lf-${String(bot.id)})`);
+
+    if (bot.model) {
+      lines.push(`Model: ${bot.model}`);
+    }
+    if (bot.effort) {
+      lines.push(`Effort: ${bot.effort}`);
+    }
+
+    // Context and subscription usage from live tmux query
+    if (context_usage) {
+      lines.push(`Context: ${context_usage.summary}`);
+    }
+    if (subscription_usage) {
+      lines.push(`Subscription: ${subscription_usage.summary}`);
+    }
 
     // Active features for this entity
     if (features && bot.entity_id) {

--- a/packages/daemon/src/persistence.ts
+++ b/packages/daemon/src/persistence.ts
@@ -96,6 +96,10 @@ export interface PersistedPoolBot {
   archetype: ArchetypeRole;
   channel_type: ChannelType | null;
   session_id: string | null;
+  /** Claude CLI model ID (e.g., "claude-opus-4-6"). Added in #101. */
+  model?: string | null;
+  /** Claude CLI effort level (e.g., "high"). Added in #101. */
+  effort?: string | null;
   last_active: string | null;  // ISO timestamp
   assigned_at?: string | null;  // ISO timestamp — when the bot was assigned to its current channel
   /** The archetype whose avatar is currently set on this bot's Discord profile.

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -5,11 +5,12 @@ import { writeFile, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import type { ArchetypeRole, LobsterFarmConfig } from "@lobster-farm/shared";
-import { lobsterfarm_dir, entity_dir } from "@lobster-farm/shared";
+import { lobsterfarm_dir, entity_dir, DEFAULT_ARCHETYPES } from "@lobster-farm/shared";
 import type { ChannelType } from "@lobster-farm/shared";
 import { save_pool_state, load_pool_state } from "./persistence.js";
 import type { PersistedPoolBot, PersistedBotAvatarState } from "./persistence.js";
 import type { EntityRegistry } from "./registry.js";
+import { resolve_model_id, resolve_effort } from "./models.js";
 import { sq } from "./shell.js";
 import * as sentry from "./sentry.js";
 
@@ -28,6 +29,10 @@ export interface PoolBot {
   /** When this bot was assigned to its current channel. Used for uptime calculation. */
   assigned_at: Date | null;
   state_dir: string;
+  /** Claude CLI model ID used for this session (e.g., "claude-opus-4-6"). */
+  model: string | null;
+  /** Claude CLI effort level used for this session (e.g., "high"). */
+  effort: string | null;
   /** The archetype whose avatar was last set on this bot's Discord profile.
    * Used to skip redundant avatar updates when the archetype hasn't changed. */
   last_avatar_archetype: ArchetypeRole | null;
@@ -235,6 +240,8 @@ export class BotPool extends EventEmitter {
         last_active: is_running ? new Date() : null,
         assigned_at: is_running ? new Date() : null,
         state_dir,
+        model: null,
+        effort: null,
         last_avatar_archetype: null,
         last_avatar_set_at: null,
       });
@@ -293,6 +300,11 @@ export class BotPool extends EventEmitter {
         continue;
       }
 
+      // Restore model/effort — fall back to archetype defaults for older pool-state.json
+      // files that don't have these fields yet.
+      const restored_model = entry.model ?? (entry.archetype ? resolve_model_id(DEFAULT_ARCHETYPES[entry.archetype]) : null);
+      const restored_effort = entry.effort ?? (entry.archetype ? resolve_effort(DEFAULT_ARCHETYPES[entry.archetype].think) : null);
+
       if (bot.state === "assigned") {
         // tmux is still running (survived restart, e.g. launchd) — restore metadata.
         // BUT the Claude process inside has a stale MCP connection to the old daemon.
@@ -303,6 +315,8 @@ export class BotPool extends EventEmitter {
         bot.archetype = entry.archetype;
         bot.channel_type = entry.channel_type;
         bot.session_id = entry.session_id;
+        bot.model = restored_model;
+        bot.effort = restored_effort;
         bot.last_active = entry.last_active ? new Date(entry.last_active) : null;
         bot.assigned_at = entry.assigned_at ? new Date(entry.assigned_at) : bot.last_active;
         bot.last_avatar_archetype = entry.last_avatar_archetype ?? null;
@@ -326,6 +340,8 @@ export class BotPool extends EventEmitter {
         bot.archetype = entry.archetype;
         bot.channel_type = entry.channel_type;
         bot.session_id = entry.session_id;
+        bot.model = restored_model;
+        bot.effort = restored_effort;
         bot.last_active = entry.last_active ? new Date(entry.last_active) : null;
         bot.assigned_at = entry.assigned_at ? new Date(entry.assigned_at) : bot.last_active;
         bot.last_avatar_archetype = entry.last_avatar_archetype ?? null;
@@ -361,6 +377,8 @@ export class BotPool extends EventEmitter {
         bot.archetype = null;
         bot.channel_type = null;
         bot.session_id = null;
+        bot.model = null;
+        bot.effort = null;
         bot.last_active = null;
         // Clear the stale access.json so the bot doesn't listen on the old channel
         await this.write_access_json(bot.state_dir, null);
@@ -648,12 +666,15 @@ export class BotPool extends EventEmitter {
       await this.start_tmux(bot, archetype, entity_id, resolved_dir, session_id, !!resume_session_id);
 
       // Update bot state
+      const assigned_defaults = DEFAULT_ARCHETYPES[archetype];
       bot.state = "assigned";
       bot.channel_id = channel_id;
       bot.entity_id = entity_id;
       bot.archetype = archetype;
       bot.channel_type = channel_type ?? null;
       bot.session_id = session_id;
+      bot.model = resolve_model_id(assigned_defaults);
+      bot.effort = resolve_effort(assigned_defaults.think);
       bot.last_active = new Date();
       bot.assigned_at = new Date();
 
@@ -713,6 +734,8 @@ export class BotPool extends EventEmitter {
       bot.archetype = null;
       bot.channel_type = null;
       bot.session_id = null;
+      bot.model = null;
+      bot.effort = null;
       bot.last_active = null;
       bot.assigned_at = null;
 
@@ -957,6 +980,8 @@ export class BotPool extends EventEmitter {
       bot.archetype = null;
       bot.channel_type = null;
       bot.session_id = null;
+      bot.model = null;
+      bot.effort = null;
       bot.last_active = null;
       bot.assigned_at = null;
       changed = true;
@@ -1002,6 +1027,8 @@ export class BotPool extends EventEmitter {
         archetype: b.archetype!,
         channel_type: b.channel_type,
         session_id: b.session_id,
+        model: b.model,
+        effort: b.effort,
         last_active: b.last_active?.toISOString() ?? null,
         assigned_at: b.assigned_at?.toISOString() ?? null,
         last_avatar_archetype: b.last_avatar_archetype,
@@ -1110,15 +1137,24 @@ export class BotPool extends EventEmitter {
     const claude_bin = process.env["CLAUDE_BIN"] ?? "claude";
     const agent_name = resolve_agent_name(archetype, this.config);
 
+    // Resolve model and effort from archetype defaults
+    const archetype_defaults = DEFAULT_ARCHETYPES[archetype];
+    const model_id = resolve_model_id(archetype_defaults);
+    const effort = resolve_effort(archetype_defaults.think);
+
     const claude_args = [
       sq(claude_bin),
       "--channels", "plugin:discord@claude-plugins-official",
       "--agent", sq(agent_name),
-      "--model", "claude-opus-4-6",
+      "--model", model_id,
       "--permission-mode", "bypassPermissions",
       "--add-dir", sq(working_dir),
       "--add-dir", sq(homedir()),
     ];
+
+    if (effort) {
+      claude_args.push("--effort", effort);
+    }
 
     if (is_resume) {
       claude_args.push("--resume", sq(session_id));

--- a/packages/daemon/src/tmux-query.ts
+++ b/packages/daemon/src/tmux-query.ts
@@ -1,0 +1,194 @@
+/**
+ * Query Claude Code session slash commands (/context, /usage) via tmux injection.
+ *
+ * Pattern: send a slash command to a tmux pane, wait for output, capture and parse.
+ * Only injects when the session is idle (prompt visible) to avoid interference.
+ */
+import { execFileSync } from "node:child_process";
+
+// ── Types ──
+
+export interface ContextUsage {
+  /** e.g., "45k / 1m (4.5%)" */
+  summary: string;
+  /** Raw token count (e.g., 45000) */
+  used_tokens: number | null;
+  /** Total context window (e.g., 1000000) */
+  total_tokens: number | null;
+  /** Percentage (e.g., 4.5) */
+  percent: number | null;
+}
+
+export interface SubscriptionUsage {
+  /** e.g., "62% weekly" */
+  summary: string;
+  /** Weekly percentage (e.g., 62) */
+  weekly_percent: number | null;
+}
+
+// ── Pane state check ──
+
+/**
+ * Check if the tmux pane is at the Claude Code prompt (idle).
+ * Returns false if the session is working, not found, or unreadable.
+ */
+function is_session_at_prompt(tmux_session: string): boolean {
+  try {
+    const output = execFileSync(
+      "tmux", ["capture-pane", "-t", tmux_session, "-p"],
+      { encoding: "utf-8", timeout: 2000 },
+    );
+    const lines = output.trim().split("\n");
+    const last_line = lines[lines.length - 1] ?? "";
+    return last_line.includes("\u276F"); // ❯ prompt character
+  } catch {
+    return false;
+  }
+}
+
+// ── Core query helper ──
+
+/**
+ * Send a slash command to a Claude Code tmux session and capture the output.
+ *
+ * Safety: only injects when the session is idle at the prompt. If the session
+ * is actively working, returns null to avoid interference.
+ *
+ * @param tmux_session - tmux session name (e.g., "pool-3")
+ * @param command - slash command to send (e.g., "/context" or "/usage")
+ * @param wait_ms - how long to wait for output (default 2000ms)
+ * @returns raw captured pane output, or null if injection was unsafe or failed
+ */
+export async function query_session_slash_command(
+  tmux_session: string,
+  command: string,
+  wait_ms: number = 2000,
+): Promise<string | null> {
+  // Guard: only inject when session is idle at the prompt
+  if (!is_session_at_prompt(tmux_session)) {
+    return null;
+  }
+
+  try {
+    // Send the command
+    execFileSync("tmux", ["send-keys", "-t", tmux_session, command, "Enter"], {
+      timeout: 2000,
+    });
+
+    // Wait for the command to produce output
+    await new Promise(resolve => setTimeout(resolve, wait_ms));
+
+    // Capture the pane content
+    const output = execFileSync(
+      "tmux", ["capture-pane", "-t", tmux_session, "-p", "-S", "-100"],
+      { encoding: "utf-8", timeout: 2000 },
+    );
+
+    return output;
+  } catch {
+    return null;
+  }
+}
+
+// ── Parsers ──
+
+/**
+ * Parse /context output to extract token usage.
+ *
+ * Expected format includes a line like:
+ *   "Tokens: 19k / 1m (2%)"
+ * or
+ *   "Tokens: 145,234 / 1,048,576 (14%)"
+ */
+export function parse_context_usage(output: string): ContextUsage | null {
+  // Look for the token summary line: "Tokens: <used> / <total> (<percent>%)"
+  const token_line = output.match(/Tokens:\s*([0-9,.]+[km]?)\s*\/\s*([0-9,.]+[km]?)\s*\(([0-9.]+)%\)/i);
+  if (!token_line) return null;
+
+  const [, used_str, total_str, percent_str] = token_line;
+  if (!used_str || !total_str || !percent_str) return null;
+
+  return {
+    summary: `${used_str} / ${total_str} (${percent_str}%)`,
+    used_tokens: parse_token_count(used_str),
+    total_tokens: parse_token_count(total_str),
+    percent: parseFloat(percent_str),
+  };
+}
+
+/**
+ * Parse /usage output to extract subscription usage.
+ *
+ * Expected format includes lines like:
+ *   "Weekly usage: 62%"
+ * or
+ *   "Usage: 62% of weekly limit"
+ * or table-style output with percentage values.
+ */
+export function parse_subscription_usage(output: string): SubscriptionUsage | null {
+  // Try "Usage: XX% of weekly" or "Weekly usage: XX%"
+  const weekly_match = output.match(/(?:weekly\s+usage|usage).*?(\d+(?:\.\d+)?)%/i);
+  if (weekly_match?.[1]) {
+    const percent = parseFloat(weekly_match[1]);
+    return {
+      summary: `${String(percent)}% weekly`,
+      weekly_percent: percent,
+    };
+  }
+
+  // Fallback: look for any prominent percentage in the output
+  // (e.g., "62.3%  of your Opus limit")
+  const pct_match = output.match(/(\d+(?:\.\d+)?)%\s*(?:of\s+(?:your|the)|weekly|limit)/i);
+  if (pct_match?.[1]) {
+    const percent = parseFloat(pct_match[1]);
+    return {
+      summary: `${String(percent)}% weekly`,
+      weekly_percent: percent,
+    };
+  }
+
+  return null;
+}
+
+// ── Token count normalization ──
+
+/** Parse a human-readable token count like "19k", "1m", "145,234" to a number. */
+export function parse_token_count(s: string): number | null {
+  const clean = s.replace(/,/g, "").trim().toLowerCase();
+  if (clean.endsWith("k")) {
+    const n = parseFloat(clean.slice(0, -1));
+    return isNaN(n) ? null : Math.round(n * 1000);
+  }
+  if (clean.endsWith("m")) {
+    const n = parseFloat(clean.slice(0, -1));
+    return isNaN(n) ? null : Math.round(n * 1_000_000);
+  }
+  const n = parseFloat(clean);
+  return isNaN(n) ? null : Math.round(n);
+}
+
+// ── High-level queries ──
+
+/**
+ * Query a Claude Code session's context usage via /context.
+ * Returns null if the session is busy or the query fails.
+ */
+export async function query_context_usage(
+  tmux_session: string,
+): Promise<ContextUsage | null> {
+  const output = await query_session_slash_command(tmux_session, "/context");
+  if (!output) return null;
+  return parse_context_usage(output);
+}
+
+/**
+ * Query a Claude Code session's subscription usage via /usage.
+ * Returns null if the session is busy or the query fails.
+ */
+export async function query_subscription_usage(
+  tmux_session: string,
+): Promise<SubscriptionUsage | null> {
+  const output = await query_session_slash_command(tmux_session, "/usage");
+  if (!output) return null;
+  return parse_subscription_usage(output);
+}


### PR DESCRIPTION
## Summary

- Add `model` and `effort` fields to `PoolBot` interface, persisted in `pool-state.json` and restored on daemon restart (with backward-compatible fallback to archetype defaults for older state files)
- Replace hardcoded `--model claude-opus-4-6` in pool bot spawn with dynamic resolution from `DEFAULT_ARCHETYPES` via `resolve_model_id`/`resolve_effort`, and pass `--effort` flag to Claude CLI
- Add `tmux-query.ts` module for live session introspection: sends `/context` or `/usage` to the tmux pane (guarded -- only when idle at prompt), waits for output, parses the result
- `!lf status` now shows model, effort, context usage, and subscription usage when an active session is present

## Test plan

- [x] All 499 existing tests pass (no regressions)
- [x] 16 new tests for tmux-query parsers: `parse_token_count` (6 cases), `parse_context_usage` (5 cases), `parse_subscription_usage` (5 cases)
- [x] Updated `make_bot` helpers in 7 test files for new `model`/`effort` fields
- [ ] Manual: `!lf status` in a channel with an active session shows Model, Effort, Context, Subscription lines
- [ ] Manual: `!lf status` in a channel where session is busy omits Context/Subscription (tmux guard works)
- [ ] Manual: daemon restart preserves model/effort in pool-state.json

Closes #101

Generated with [Claude Code](https://claude.com/claude-code)