### PR TITLE
fix: pr-cron gh ENOENT -- PATH not inherited in subprocess

### DIFF
--- a/packages/daemon/src/__tests__/env.test.ts
+++ b/packages/daemon/src/__tests__/env.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { check_required_binaries, propagate_tmux_env } from "../env.js";
+import { check_required_binaries, propagate_tmux_env, resolve_binary } from "../env.js";
 
 describe("check_required_binaries", () => {
   let original_exit: typeof process.exit;
@@ -168,5 +168,26 @@ describe("propagate_tmux_env", () => {
     expect(log_spy).toHaveBeenCalledWith("[env] tmux server not running, will inherit daemon env");
 
     log_spy.mockRestore();
+  });
+});
+
+describe("resolve_binary", () => {
+  it("returns an absolute path for a known binary", () => {
+    // `node` is guaranteed to be present since tests are running under it
+    const result = resolve_binary("node");
+    expect(result).toMatch(/^\//);
+    expect(result).toContain("node");
+  });
+
+  it("returns the bare name when the binary does not exist", () => {
+    const result = resolve_binary("definitely-not-a-real-binary-xyz");
+    expect(result).toBe("definitely-not-a-real-binary-xyz");
+  });
+
+  it("resolves gh to an absolute path", () => {
+    // gh is a required binary for this daemon, so it should exist in CI/dev
+    const result = resolve_binary("gh");
+    expect(result).toMatch(/^\//);
+    expect(result).toContain("gh");
   });
 });

--- a/packages/daemon/src/__tests__/pr-cron.test.ts
+++ b/packages/daemon/src/__tests__/pr-cron.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
-import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
-import type { LobsterFarmConfig } from "@lobster-farm/shared";
+import { LobsterFarmConfigSchema, EntityConfigSchema } from "@lobster-farm/shared";
+import type { LobsterFarmConfig, EntityConfig } from "@lobster-farm/shared";
 import { PRReviewCron } from "../pr-cron.js";
 
 // ── Helpers ──
@@ -270,6 +270,111 @@ describe("PRReviewCron.should_skip_pr", () => {
     const log_messages = log_spy.mock.calls.map(c => c[0]) as string[];
     expect(log_messages.some(m =>
       typeof m === "string" && m.includes("PR #42") && m.includes("already reviewed"),
+    )).toBe(true);
+  });
+});
+
+// ── Repo path validation ──
+
+// Mock persistence to avoid filesystem writes during test
+vi.mock("../persistence.js", () => ({
+  load_pr_reviews: vi.fn().mockResolvedValue({}),
+  save_pr_reviews: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock sentry to avoid real Sentry calls
+vi.mock("../sentry.js", () => ({
+  cronCheckInStart: vi.fn().mockReturnValue("test-checkin-id"),
+  cronCheckInFinish: vi.fn(),
+  captureException: vi.fn(),
+  addBreadcrumb: vi.fn(),
+}));
+
+// Mock actions to avoid real execFile calls
+vi.mock("../actions.js", () => ({
+  detect_review_outcome: vi.fn().mockResolvedValue("approved"),
+}));
+
+function make_entity_with_repo(repo_path: string): EntityConfig {
+  return EntityConfigSchema.parse({
+    entity: {
+      id: "test-entity",
+      name: "Test Entity",
+      status: "active",
+      repos: [
+        { name: "test", url: "git@github.com:test/test.git", path: repo_path },
+      ],
+      accounts: {},
+      channels: { category_id: "cat-1", list: [] },
+      memory: { path: "/tmp/memory" },
+      secrets: { vault: "1password", vault_name: "test" },
+    },
+  });
+}
+
+describe("PRReviewCron — repo path validation", () => {
+  let log_spy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    log_spy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    log_spy.mockRestore();
+  });
+
+  it("skips repos with non-existent paths without calling gh", async () => {
+    const mock_registry = {
+      get_active: () => [make_entity_with_repo("/tmp/does-not-exist-xyz-9999")],
+      get: vi.fn(),
+    };
+
+    const cron = new PRReviewCron(
+      mock_registry as never,
+      { spawn: vi.fn(), on: vi.fn(), removeListener: vi.fn() } as never,
+      make_config(),
+      null,
+      null,
+    );
+
+    // Start the cron — this triggers an immediate poll
+    await cron.start(999_999_999); // Very long interval so only the immediate poll fires
+    cron.stop();
+
+    // Give the immediate poll a tick to execute
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    const log_messages = log_spy.mock.calls.map(c => c[0]) as string[];
+    expect(log_messages.some(m =>
+      typeof m === "string" && m.includes("Repo path does not exist") && m.includes("test-entity"),
+    )).toBe(true);
+
+    // Should NOT have "Could not list PRs" — we should skip before calling gh
+    expect(log_messages.some(m =>
+      typeof m === "string" && m.includes("Could not list PRs"),
+    )).toBe(false);
+  });
+
+  it("resolves gh binary to absolute path on start", async () => {
+    const mock_registry = {
+      get_active: () => [],
+      get: vi.fn(),
+    };
+
+    const cron = new PRReviewCron(
+      mock_registry as never,
+      { spawn: vi.fn(), on: vi.fn(), removeListener: vi.fn() } as never,
+      make_config(),
+      null,
+      null,
+    );
+
+    await cron.start(999_999_999);
+    cron.stop();
+
+    const log_messages = log_spy.mock.calls.map(c => c[0]) as string[];
+    expect(log_messages.some(m =>
+      typeof m === "string" && m.includes("Resolved gh binary:"),
     )).toBe(true);
   });
 });

--- a/packages/daemon/src/env.ts
+++ b/packages/daemon/src/env.ts
@@ -33,6 +33,22 @@ function default_binary_checker(name: string): boolean {
 }
 
 /**
+ * Resolve a binary name to its absolute path via `which`.
+ * Returns the absolute path if found, or the bare name as fallback
+ * so callers still work (relying on PATH at exec time).
+ *
+ * Useful for launchd environments where PATH in the parent process
+ * may not propagate correctly to child processes in all cases.
+ */
+export function resolve_binary(name: string): string {
+  try {
+    return execFileSync("which", [name], { encoding: "utf-8" }).trim();
+  } catch {
+    return name;
+  }
+}
+
+/**
  * Set a tmux global environment variable. Returns true on success.
  * Extracted for testability.
  */

--- a/packages/daemon/src/pr-cron.ts
+++ b/packages/daemon/src/pr-cron.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { stat } from "node:fs/promises";
 import { promisify } from "node:util";
 import type { LobsterFarmConfig, EntityConfig, ArchetypeRole } from "@lobster-farm/shared";
 import { expand_home } from "@lobster-farm/shared";
@@ -17,6 +18,7 @@ import {
   close_linked_issues,
   nwo_from_url,
 } from "./issue-utils.js";
+import { resolve_binary } from "./env.js";
 import * as sentry from "./sentry.js";
 
 const exec = promisify(execFile);
@@ -77,6 +79,7 @@ export class PRReviewCron {
   private processed: PRReviewState = {}; // persisted to disk — tracks completed reviews
   private running = false;
   private interval_ms: number = DEFAULT_INTERVAL_MS;
+  private gh_bin: string = "gh"; // resolved to absolute path in start()
 
   constructor(
     private registry: EntityRegistry,
@@ -90,6 +93,11 @@ export class PRReviewCron {
   /** Start the polling cron. Loads persisted review state before first poll. */
   async start(interval_ms: number = DEFAULT_INTERVAL_MS): Promise<void> {
     if (this.timer) return;
+
+    // Resolve gh to absolute path once — prevents ENOENT in launchd environments
+    // where child processes may not inherit PATH correctly
+    this.gh_bin = resolve_binary("gh");
+    console.log(`[pr-cron] Resolved gh binary: ${this.gh_bin}`);
 
     // Load persisted review state so we don't re-review after restart
     this.processed = await load_pr_reviews(this.config);
@@ -170,13 +178,22 @@ export class PRReviewCron {
     repo_path: string,
     entity_config: EntityConfig,
   ): Promise<void> {
+    // Verify repo path exists before shelling out — avoids confusing ENOENT
+    // errors for entities with stale or placeholder paths (e.g. alpha → /tmp/test-repo)
+    try {
+      await stat(repo_path);
+    } catch {
+      console.log(`[pr-cron] Repo path does not exist for ${entity_id}: ${repo_path} — skipping`);
+      return;
+    }
+
     let prs: OpenPR[];
     try {
-      const { stdout } = await exec("gh", [
+      const { stdout } = await exec(this.gh_bin, [
         "pr", "list",
         "--state", "open",
         "--json", "number,title,headRefName,updatedAt,url,body,author",
-      ], { cwd: repo_path, timeout: 30_000 });
+      ], { cwd: repo_path, env: process.env, timeout: 30_000 });
 
       prs = JSON.parse(stdout) as OpenPR[];
     } catch (err) {
@@ -298,10 +315,10 @@ export class PRReviewCron {
     pr_number: number,
   ): Promise<PRFeedbackData | null> {
     try {
-      const { stdout } = await exec("gh", [
+      const { stdout } = await exec(this.gh_bin, [
         "pr", "view", String(pr_number),
         "--json", "reviews,comments,commits",
-      ], { cwd: repo_path, timeout: 15_000 });
+      ], { cwd: repo_path, env: process.env, timeout: 15_000 });
 
       return JSON.parse(stdout) as PRFeedbackData;
     } catch {
@@ -604,11 +621,11 @@ export class PRReviewCron {
   /** Check if a PR has been merged. */
   private async check_pr_merged(repo_path: string, pr_number: number): Promise<boolean> {
     try {
-      const { stdout } = await exec("gh", [
+      const { stdout } = await exec(this.gh_bin, [
         "pr", "view", String(pr_number),
         "--json", "state",
         "--jq", ".state",
-      ], { cwd: repo_path, timeout: 15_000 });
+      ], { cwd: repo_path, env: process.env, timeout: 15_000 });
       return stdout.trim() === "MERGED";
     } catch {
       return false;


### PR DESCRIPTION
## Summary

- Resolves `gh` to its absolute path (via `which`) once at cron startup, so `execFile` never depends on PATH propagation in child processes under launchd
- Passes `env: process.env` explicitly to all `execFile` calls in pr-cron as belt-and-suspenders
- Validates repo paths exist before shelling out, so entities with placeholder paths (like alpha's `/tmp/test-repo`) get a clean skip message instead of a confusing ENOENT
- Adds `resolve_binary()` export to `env.ts` for reuse by other daemon modules

## Test plan

- [x] All 520 existing tests pass (31 test files)
- [x] New `resolve_binary` tests: resolves known binary to absolute path, falls back to bare name for unknown
- [x] New repo path validation tests: skips non-existent paths with descriptive log, confirms gh resolution logged on start
- [x] No new TypeScript errors introduced

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)