### PR TITLE
fix: remove entity/channel from /status output

### DIFF
--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -1446,8 +1446,6 @@ export class DiscordBot extends EventEmitter {
     const lines = [
       "**Session Status**",
       `Agent: ${agent_label}`,
-      `Entity: ${bot.entity_id ?? routed.entity_id}`,
-      `Channel: <#${routed.channel_id}>`,
     ];
 
     if (bot.session_id) {


### PR DESCRIPTION
## Summary
- Removes redundant `Entity:` and `Channel:` lines from `/status` slash command output
- Users already know which entity and channel they're in — showing it adds noise without information

Closes #131

## Test plan
- [ ] Run `/status` in a channel with an active session — should show Agent, Model, Effort, Context, Subscription but no Entity/Channel lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)