### PR TITLE
fix: cache context/usage in health monitor so /status can display it

### DIFF
--- a/packages/daemon/src/__tests__/fix-resume-persist.test.ts
+++ b/packages/daemon/src/__tests__/fix-resume-persist.test.ts
@@ -68,6 +68,9 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
     effort: null,
     last_avatar_archetype: null,
     last_avatar_set_at: null,
+    cached_context: null,
+    cached_subscription: null,
+    cache_updated_at: null,
     ...overrides,
   };
 }

--- a/packages/daemon/src/__tests__/interactive-builder.test.ts
+++ b/packages/daemon/src/__tests__/interactive-builder.test.ts
@@ -99,6 +99,9 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
     effort: null,
     last_avatar_archetype: null,
     last_avatar_set_at: null,
+    cached_context: null,
+    cached_subscription: null,
+    cache_updated_at: null,
     ...overrides,
   };
 }

--- a/packages/daemon/src/__tests__/lazy-session-resume.test.ts
+++ b/packages/daemon/src/__tests__/lazy-session-resume.test.ts
@@ -28,6 +28,9 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
     effort: null,
     last_avatar_archetype: null,
     last_avatar_set_at: null,
+    cached_context: null,
+    cached_subscription: null,
+    cache_updated_at: null,
     ...overrides,
   };
 }

--- a/packages/daemon/src/__tests__/pool-avatars.test.ts
+++ b/packages/daemon/src/__tests__/pool-avatars.test.ts
@@ -39,6 +39,9 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
     effort: null,
     last_avatar_archetype: null,
     last_avatar_set_at: null,
+    cached_context: null,
+    cached_subscription: null,
+    cache_updated_at: null,
     ...overrides,
   };
 }

--- a/packages/daemon/src/__tests__/pool-persistence.test.ts
+++ b/packages/daemon/src/__tests__/pool-persistence.test.ts
@@ -86,6 +86,9 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
     effort: null,
     last_avatar_archetype: null,
     last_avatar_set_at: null,
+    cached_context: null,
+    cached_subscription: null,
+    cache_updated_at: null,
     ...overrides,
   };
 }

--- a/packages/daemon/src/__tests__/pool.test.ts
+++ b/packages/daemon/src/__tests__/pool.test.ts
@@ -58,6 +58,9 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
     effort: null,
     last_avatar_archetype: null,
     last_avatar_set_at: null,
+    cached_context: null,
+    cached_subscription: null,
+    cache_updated_at: null,
     ...overrides,
   };
 }

--- a/packages/daemon/src/__tests__/session-history.test.ts
+++ b/packages/daemon/src/__tests__/session-history.test.ts
@@ -54,6 +54,9 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
     effort: null,
     last_avatar_archetype: null,
     last_avatar_set_at: null,
+    cached_context: null,
+    cached_subscription: null,
+    cache_updated_at: null,
     ...overrides,
   };
 }

--- a/packages/daemon/src/__tests__/status-command.test.ts
+++ b/packages/daemon/src/__tests__/status-command.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { format_duration } from "../discord.js";
+import { format_duration, format_cache_staleness } from "../discord.js";
 
 describe("format_duration", () => {
   it("formats hours and minutes", () => {
@@ -30,5 +30,45 @@ describe("format_duration", () => {
   it("formats large durations", () => {
     const start = new Date(Date.now() - 25 * 60 * 60_000 - 30 * 60_000);
     expect(format_duration(start)).toBe("25h 30m");
+  });
+});
+
+describe("format_cache_staleness", () => {
+  it("returns empty string for null", () => {
+    expect(format_cache_staleness(null)).toBe("");
+  });
+
+  it("returns empty string for fresh cache (under 60s)", () => {
+    const recent = new Date(Date.now() - 30_000); // 30s ago
+    expect(format_cache_staleness(recent)).toBe("");
+  });
+
+  it("returns empty string at exactly 0s", () => {
+    expect(format_cache_staleness(new Date())).toBe("");
+  });
+
+  it("returns seconds label for 60-119s staleness", () => {
+    const stale = new Date(Date.now() - 90_000); // 90s ago
+    expect(format_cache_staleness(stale)).toBe(" *(90s ago)*");
+  });
+
+  it("returns minutes label for 2+ minutes staleness", () => {
+    const stale = new Date(Date.now() - 180_000); // 3m ago
+    expect(format_cache_staleness(stale)).toBe(" *(3m ago)*");
+  });
+
+  it("returns minutes label for large staleness", () => {
+    const stale = new Date(Date.now() - 600_000); // 10m ago
+    expect(format_cache_staleness(stale)).toBe(" *(10m ago)*");
+  });
+
+  it("returns empty string for future dates", () => {
+    const future = new Date(Date.now() + 60_000);
+    expect(format_cache_staleness(future)).toBe("");
+  });
+
+  it("shows seconds at the 60s boundary", () => {
+    const boundary = new Date(Date.now() - 60_000); // exactly 60s
+    expect(format_cache_staleness(boundary)).toBe(" *(60s ago)*");
   });
 });

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -38,8 +38,6 @@ import type { FeatureManager, CreateFeatureOptions } from "./features.js";
 import { route_message, type RouteAction, type RoutedMessage } from "./router.js";
 import type { TaskQueue } from "./queue.js";
 import type { BotPool, PoolBot } from "./pool.js";
-import { query_context_usage, query_subscription_usage } from "./tmux-query.js";
-import type { ContextUsage, SubscriptionUsage } from "./tmux-query.js";
 import * as sentry from "./sentry.js";
 
 const exec = promisify(execFile);
@@ -74,6 +72,23 @@ export function format_duration(start: Date): string {
   const minutes = total_minutes % 60;
   if (hours > 0) return `${String(hours)}h ${String(minutes)}m`;
   return `${String(minutes)}m`;
+}
+
+/**
+ * Format a staleness label for cached usage data.
+ * Returns empty string if cache is fresh (under 60s) or missing,
+ * e.g., " *(30s ago)*" or " *(2m ago)*".
+ */
+export function format_cache_staleness(cache_updated_at: Date | null): string {
+  if (!cache_updated_at) return "";
+  const age_ms = Date.now() - cache_updated_at.getTime();
+  if (age_ms < 0) return "";
+  // Under 60s: considered fresh, no indicator needed
+  if (age_ms < 60_000) return "";
+  const age_seconds = Math.floor(age_ms / 1000);
+  if (age_seconds < 120) return ` *(${String(age_seconds)}s ago)*`;
+  const age_minutes = Math.floor(age_seconds / 60);
+  return ` *(${String(age_minutes)}m ago)*`;
 }
 
 // ── Channel index entry ──
@@ -1411,30 +1426,21 @@ export class DiscordBot extends EventEmitter {
     }
 
     // Full session status — bot is assigned to this channel.
-    // Query context/usage from the live tmux session (best-effort, non-blocking).
-    // Queries run sequentially — both target the same tmux pane, so parallel injection
-    // would interleave commands and corrupt output.
-    let context_usage: ContextUsage | null = null;
-    let subscription_usage: SubscriptionUsage | null = null;
-    try {
-      context_usage = await query_context_usage(assignment.tmux_session);
-      subscription_usage = await query_subscription_usage(assignment.tmux_session);
-    } catch {
-      // Non-fatal: tmux queries are best-effort
-    }
-
-    const lines = this.format_session_status(assignment, routed, features, context_usage, subscription_usage);
+    // Read cached context/usage from the health monitor instead of querying tmux
+    // synchronously. The health monitor updates the cache every 30s when the session
+    // is idle. Querying here would always fail because the session is busy processing
+    // this very /status command (catch-22 with the idle guard).
+    const lines = this.format_session_status(assignment, routed, features);
     if (pool_summary) lines.push("", pool_summary);
     await target.reply(lines.join("\n"));
   }
 
-  /** Format the full session status block for a channel with an assigned bot. */
+  /** Format the full session status block for a channel with an assigned bot.
+   * Reads context/usage from the bot's cache (populated by the health monitor). */
   private format_session_status(
     bot: PoolBot,
     routed: RoutedMessage,
     features: FeatureManager | null,
-    context_usage?: ContextUsage | null,
-    subscription_usage?: SubscriptionUsage | null,
   ): string[] {
     const identity = bot.archetype
       ? this.resolve_agent_identity(bot.archetype)
@@ -1469,12 +1475,13 @@ export class DiscordBot extends EventEmitter {
       lines.push(`Effort: ${bot.effort}`);
     }
 
-    // Context and subscription usage from live tmux query
-    if (context_usage) {
-      lines.push(`Context: ${context_usage.summary}`);
+    // Context and subscription usage from health monitor cache
+    const staleness_label = format_cache_staleness(bot.cache_updated_at);
+    if (bot.cached_context) {
+      lines.push(`Context: ${bot.cached_context.summary}${staleness_label}`);
     }
-    if (subscription_usage) {
-      lines.push(`Subscription: ${subscription_usage.summary}`);
+    if (bot.cached_subscription) {
+      lines.push(`Subscription: ${bot.cached_subscription.summary}${staleness_label}`);
     }
 
     // Active features for this entity

--- a/packages/daemon/src/persistence.ts
+++ b/packages/daemon/src/persistence.ts
@@ -88,6 +88,20 @@ export async function load_pr_reviews(
 
 // ── Pool State ──
 
+/** Serializable mirror of ContextUsage from tmux-query.ts — no import needed. */
+export interface PersistedContextUsage {
+  summary: string;
+  used_tokens: number | null;
+  total_tokens: number | null;
+  percent: number | null;
+}
+
+/** Serializable mirror of SubscriptionUsage from tmux-query.ts — no import needed. */
+export interface PersistedSubscriptionUsage {
+  summary: string;
+  weekly_percent: number | null;
+}
+
 export interface PersistedPoolBot {
   id: number;
   state: "assigned" | "parked";  // free bots are not persisted
@@ -105,6 +119,12 @@ export interface PersistedPoolBot {
   /** The archetype whose avatar is currently set on this bot's Discord profile.
    * Persisted so we don't redundantly set avatars on restart. */
   last_avatar_archetype?: ArchetypeRole | null;
+  /** Cached /context output. Survives restarts so /status has data immediately. */
+  cached_context?: PersistedContextUsage | null;
+  /** Cached /usage output. Survives restarts so /status has data immediately. */
+  cached_subscription?: PersistedSubscriptionUsage | null;
+  /** When the cache was last updated. ISO timestamp. */
+  cache_updated_at?: string | null;
 }
 
 /** Per-bot avatar state, persisted for ALL bots (including free ones).

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -13,6 +13,8 @@ import type { EntityRegistry } from "./registry.js";
 import { resolve_model_id, resolve_effort } from "./models.js";
 import { sq } from "./shell.js";
 import * as sentry from "./sentry.js";
+import { query_context_usage, query_subscription_usage } from "./tmux-query.js";
+import type { ContextUsage, SubscriptionUsage } from "./tmux-query.js";
 
 // ── Types ──
 
@@ -39,6 +41,14 @@ export interface PoolBot {
   /** When the avatar was last set via the Discord API. Used for rate limit safety
    * (~2 changes per hour per bot, we enforce a 30-minute cooldown). */
   last_avatar_set_at: Date | null;
+  /** Cached context usage from the last successful /context query.
+   * Updated by the health monitor every 30s when the session is idle. */
+  cached_context: ContextUsage | null;
+  /** Cached subscription usage from the last successful /usage query.
+   * Updated by the health monitor every 30s when the session is idle. */
+  cached_subscription: SubscriptionUsage | null;
+  /** When the cache was last successfully updated. Used for staleness display. */
+  cache_updated_at: Date | null;
 }
 
 export interface PoolAssignment {
@@ -244,6 +254,9 @@ export class BotPool extends EventEmitter {
         effort: null,
         last_avatar_archetype: null,
         last_avatar_set_at: null,
+        cached_context: null,
+        cached_subscription: null,
+        cache_updated_at: null,
       });
     }
 
@@ -320,6 +333,9 @@ export class BotPool extends EventEmitter {
         bot.last_active = entry.last_active ? new Date(entry.last_active) : null;
         bot.assigned_at = entry.assigned_at ? new Date(entry.assigned_at) : bot.last_active;
         bot.last_avatar_archetype = entry.last_avatar_archetype ?? null;
+        bot.cached_context = entry.cached_context ?? null;
+        bot.cached_subscription = entry.cached_subscription ?? null;
+        bot.cache_updated_at = entry.cache_updated_at ? new Date(entry.cache_updated_at) : null;
 
         // Add to resume candidates — the live tmux session has a dead MCP socket.
         // resume_parked_bots() will kill it and spawn fresh with --resume.
@@ -345,6 +361,9 @@ export class BotPool extends EventEmitter {
         bot.last_active = entry.last_active ? new Date(entry.last_active) : null;
         bot.assigned_at = entry.assigned_at ? new Date(entry.assigned_at) : bot.last_active;
         bot.last_avatar_archetype = entry.last_avatar_archetype ?? null;
+        bot.cached_context = entry.cached_context ?? null;
+        bot.cached_subscription = entry.cached_subscription ?? null;
+        bot.cache_updated_at = entry.cache_updated_at ? new Date(entry.cache_updated_at) : null;
 
         // If this bot was actively assigned (not already parked) before shutdown
         // and has a session_id, it's a candidate for proactive resume.
@@ -738,6 +757,9 @@ export class BotPool extends EventEmitter {
       bot.effort = null;
       bot.last_active = null;
       bot.assigned_at = null;
+      bot.cached_context = null;
+      bot.cached_subscription = null;
+      bot.cache_updated_at = null;
 
       // Clear access.json
       await this.write_access_json(bot.state_dir, null);
@@ -984,10 +1006,37 @@ export class BotPool extends EventEmitter {
       bot.effort = null;
       bot.last_active = null;
       bot.assigned_at = null;
+      bot.cached_context = null;
+      bot.cached_subscription = null;
+      bot.cache_updated_at = null;
       changed = true;
 
       this.emit("bot:session_ended", event_data);
       this.emit("bot:released", { bot_id: bot.id });
+    }
+
+    // Update context/usage cache for live assigned bots.
+    // Queries are sequential per bot (same tmux pane). If the session is busy
+    // (returns null), we skip — stale cache is better than no cache.
+    for (const bot of this.bots) {
+      if (bot.state !== "assigned") continue;
+
+      try {
+        const context = await query_context_usage(bot.tmux_session);
+        const subscription = await query_subscription_usage(bot.tmux_session);
+
+        // Only update cache if at least one query succeeded — partial updates
+        // are fine (e.g., /context works but /usage doesn't), but skip entirely
+        // if both fail (session was busy)
+        if (context || subscription) {
+          if (context) bot.cached_context = context;
+          if (subscription) bot.cached_subscription = subscription;
+          bot.cache_updated_at = new Date();
+          changed = true;
+        }
+      } catch {
+        // Non-fatal: tmux queries are best-effort
+      }
     }
 
     if (changed) await this.persist();
@@ -1032,6 +1081,9 @@ export class BotPool extends EventEmitter {
         last_active: b.last_active?.toISOString() ?? null,
         assigned_at: b.assigned_at?.toISOString() ?? null,
         last_avatar_archetype: b.last_avatar_archetype,
+        cached_context: b.cached_context,
+        cached_subscription: b.cached_subscription,
+        cache_updated_at: b.cache_updated_at?.toISOString() ?? null,
       }));
 
     // Convert session_history Map to a plain object for serialization


### PR DESCRIPTION
## Summary

- `/status` was unable to show context/usage because the tmux idle guard blocks injection when the session is busy processing `/status` itself (catch-22)
- The health monitor (30s interval) now caches context/usage for idle sessions on the `PoolBot`; `/status` reads from the cache instead of querying tmux synchronously
- Shows a staleness indicator when cache is older than 60s (e.g., `Context: 45k / 1m (4.5%) *(30s ago)*`)
- Cache persists in `pool-state.json` so data is available immediately after daemon restart

## Changes

**pool.ts** -- Add `cached_context`, `cached_subscription`, `cache_updated_at` fields to `PoolBot`. Extend `check_assigned_health()` to query and cache usage for live idle bots after the dead-session check. Clear cache on release and dead-session cleanup. Persist/restore cache fields.

**discord.ts** -- Remove synchronous tmux queries from `handle_status_command()`. Read cached data from `bot.cached_context`/`bot.cached_subscription` instead. Add `format_cache_staleness()` for staleness display. Remove unused `tmux-query` imports.

**persistence.ts** -- Add `PersistedContextUsage`/`PersistedSubscriptionUsage` types (serializable mirrors of tmux-query types). Add cache fields to `PersistedPoolBot`.

**Tests** -- 8 new tests for `format_cache_staleness` (fresh, stale seconds, stale minutes, null, future, boundary). Updated 7 `make_bot` helpers with new cache fields.

## Test plan

- [x] `npm run build` compiles cleanly
- [x] 663 tests pass (1 pre-existing flaky timeout in queue.test.ts, unrelated)
- [x] All 8 new staleness formatter tests pass
- [ ] Manual: `/status` in a channel with an assigned bot shows context/usage from cache
- [ ] Manual: staleness indicator appears when cache is >60s old
- [ ] Manual: cache clears when bot is released

Closes #132

Generated with [Claude Code](https://claude.com/claude-code)