### PR TITLE
feat: per-entity GitHub token injection via 1Password

### DIFF
--- a/packages/daemon/src/__tests__/gh-token-injection.test.ts
+++ b/packages/daemon/src/__tests__/gh-token-injection.test.ts
@@ -1,0 +1,353 @@
+/**
+ * Tests for per-entity GitHub token injection via 1Password.
+ *
+ * Verifies that start_tmux():
+ * - Wraps the claude command with `op run` when entity has github_token_ref
+ * - Leaves the command unchanged when entity has no github_token_ref
+ * - Writes correct .env.op file content (reference only, never the token)
+ * - Cleans up temp .env.op files after tmux starts
+ * - Gracefully falls back if op run setup fails
+ */
+
+import { EventEmitter } from "node:events";
+import { describe, expect, it, beforeEach, vi, type Mock } from "vitest";
+import { LobsterFarmConfigSchema, EntityConfigSchema } from "@lobster-farm/shared";
+import type { LobsterFarmConfig, EntityConfig } from "@lobster-farm/shared";
+import { BotPool } from "../pool.js";
+import type { PoolBot } from "../pool.js";
+
+// ── Module-level mocks ──
+
+// Track spawn calls for assertions
+let spawn_calls: Array<{ command: string; args: string[]; options: Record<string, unknown> }> = [];
+let spawn_emitter: EventEmitter;
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: vi.fn((...args: unknown[]) => {
+      spawn_calls.push({
+        command: args[0] as string,
+        args: args[1] as string[],
+        options: args[2] as Record<string, unknown>,
+      });
+      spawn_emitter = new EventEmitter();
+      // Emit close with code 0 on next tick
+      setTimeout(() => spawn_emitter.emit("close", 0), 0);
+      return spawn_emitter;
+    }),
+  };
+});
+
+// Track writeFile and unlink calls
+let write_file_calls: Array<{ path: string; content: string }> = [];
+let write_file_should_fail = false;
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    writeFile: vi.fn(async (path: string, content: string) => {
+      if (write_file_should_fail && typeof path === "string" && path.includes("lf-env-pool")) {
+        throw new Error("Permission denied");
+      }
+      write_file_calls.push({ path, content: String(content) });
+    }),
+    readFile: vi.fn(actual.readFile),
+    unlink: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock("../env.js", () => ({
+  resolve_binary: vi.fn((name: string) => `/usr/local/bin/${name}`),
+}));
+
+import { unlink } from "node:fs/promises";
+import { resolve_binary } from "../env.js";
+
+// ── Minimal mock registry ──
+
+class MockRegistry {
+  private entities = new Map<string, EntityConfig>();
+
+  add(config: EntityConfig): void {
+    this.entities.set(config.entity.id, config);
+  }
+
+  get(id: string): EntityConfig | undefined {
+    return this.entities.get(id);
+  }
+}
+
+function make_entity_config(overrides: {
+  id: string;
+  github_token_ref?: string;
+}): EntityConfig {
+  return EntityConfigSchema.parse({
+    entity: {
+      id: overrides.id,
+      name: overrides.id,
+      repos: [],
+      channels: { category_id: "", list: [] },
+      memory: { path: `/tmp/test-memory/${overrides.id}` },
+      secrets: {
+        vault_name: `entity-${overrides.id}`,
+        ...(overrides.github_token_ref
+          ? { github_token_ref: overrides.github_token_ref }
+          : {}),
+      },
+    },
+  });
+}
+
+function make_config(): LobsterFarmConfig {
+  return LobsterFarmConfigSchema.parse({
+    user: { name: "Test" },
+  });
+}
+
+/** Test subclass that stubs tmux-dependent behavior and exposes internals. */
+class GhTokenTestPool extends BotPool {
+  inject_bots(bots: PoolBot[]): void {
+    (this as unknown as { bots: PoolBot[] }).bots = bots;
+  }
+
+  inject_registry(registry: MockRegistry): void {
+    (this as unknown as { registry: MockRegistry }).registry = registry;
+  }
+
+  protected override is_bot_idle(): boolean {
+    return true;
+  }
+}
+
+function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
+  return {
+    state: "free",
+    channel_id: null,
+    entity_id: null,
+    archetype: null,
+    channel_type: null,
+    session_id: null,
+    tmux_session: `pool-${String(overrides.id)}`,
+    last_active: null,
+    assigned_at: null,
+    state_dir: `/tmp/test-pool-${String(overrides.id)}`,
+    model: null,
+    effort: null,
+    last_avatar_archetype: null,
+    last_avatar_set_at: null,
+    ...overrides,
+  };
+}
+
+describe("per-entity GitHub token injection", () => {
+  let config: LobsterFarmConfig;
+  let pool: GhTokenTestPool;
+  let registry: MockRegistry;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    spawn_calls = [];
+    write_file_calls = [];
+    write_file_should_fail = false;
+
+    config = make_config();
+    pool = new GhTokenTestPool(config);
+    registry = new MockRegistry();
+
+    // Stub pool side effects unrelated to start_tmux
+    vi.spyOn(pool as unknown as { kill_tmux: (s: string) => void }, "kill_tmux" as never)
+      .mockImplementation(() => {});
+    vi.spyOn(pool as unknown as { write_access_json: (d: string, c: string | null) => Promise<void> }, "write_access_json" as never)
+      .mockResolvedValue(undefined);
+    vi.spyOn(pool as unknown as { set_bot_nickname: (d: string, a: string) => Promise<void> }, "set_bot_nickname" as never)
+      .mockResolvedValue(undefined);
+    vi.spyOn(pool as unknown as { set_bot_avatar: (b: PoolBot, a: string) => Promise<void> }, "set_bot_avatar" as never)
+      .mockResolvedValue(undefined);
+    // is_tmux_alive must return true AFTER spawn so start_tmux resolves successfully
+    vi.spyOn(pool as unknown as { is_tmux_alive: (s: string) => boolean }, "is_tmux_alive" as never)
+      .mockReturnValue(true);
+    vi.spyOn(pool as unknown as { park_bot: (b: PoolBot) => Promise<void> }, "park_bot" as never)
+      .mockImplementation(async (bot: PoolBot) => {
+        bot.state = "parked";
+      });
+  });
+
+  describe("resolve_github_token_ref", () => {
+    it("returns null when registry is not set", () => {
+      const resolve = (pool as unknown as { resolve_github_token_ref: (id: string) => string | null })
+        .resolve_github_token_ref.bind(pool);
+      expect(resolve("some-entity")).toBeNull();
+    });
+
+    it("returns null when entity is not in registry", () => {
+      pool.inject_registry(registry);
+      const resolve = (pool as unknown as { resolve_github_token_ref: (id: string) => string | null })
+        .resolve_github_token_ref.bind(pool);
+      expect(resolve("nonexistent")).toBeNull();
+    });
+
+    it("returns null when entity has no github_token_ref", () => {
+      registry.add(make_entity_config({ id: "no-token" }));
+      pool.inject_registry(registry);
+      const resolve = (pool as unknown as { resolve_github_token_ref: (id: string) => string | null })
+        .resolve_github_token_ref.bind(pool);
+      expect(resolve("no-token")).toBeNull();
+    });
+
+    it("returns the reference when entity has github_token_ref", () => {
+      const ref = "op://entity-my-app/github/credential";
+      registry.add(make_entity_config({ id: "with-token", github_token_ref: ref }));
+      pool.inject_registry(registry);
+      const resolve = (pool as unknown as { resolve_github_token_ref: (id: string) => string | null })
+        .resolve_github_token_ref.bind(pool);
+      expect(resolve("with-token")).toBe(ref);
+    });
+  });
+
+  describe("tmux command without github_token_ref", () => {
+    it("does NOT wrap with op run", async () => {
+      registry.add(make_entity_config({ id: "no-gh-token" }));
+      pool.inject_registry(registry);
+      pool.inject_bots([make_bot({ id: 3, state: "free" })]);
+
+      await pool.assign("ch-test", "no-gh-token", "builder", undefined, "work_room");
+
+      // Find the tmux spawn call
+      const tmux_call = spawn_calls.find(c => c.command === "tmux");
+      expect(tmux_call).toBeDefined();
+
+      // The tmux command string (last element in the args array)
+      const cmd_string = tmux_call!.args[tmux_call!.args.length - 1];
+      expect(cmd_string).not.toContain("op' run");
+      expect(cmd_string).toContain("claude");
+    });
+
+    it("does not write a .env.op file", async () => {
+      registry.add(make_entity_config({ id: "no-env-op" }));
+      pool.inject_registry(registry);
+      pool.inject_bots([make_bot({ id: 1, state: "free" })]);
+
+      await pool.assign("ch-test", "no-env-op", "builder", undefined, "work_room");
+
+      const env_op_writes = write_file_calls.filter(c => c.path.includes("lf-env-pool"));
+      expect(env_op_writes).toHaveLength(0);
+    });
+
+    it("does not call unlink", async () => {
+      registry.add(make_entity_config({ id: "no-cleanup" }));
+      pool.inject_registry(registry);
+      pool.inject_bots([make_bot({ id: 8, state: "free" })]);
+
+      await pool.assign("ch-test", "no-cleanup", "builder", undefined, "work_room");
+
+      // Wait for the close handler to run
+      await new Promise(resolve => setTimeout(resolve, 10));
+      expect(unlink).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("tmux command with github_token_ref", () => {
+    it("wraps with op run", async () => {
+      const ref = "op://entity-client/github/credential";
+      registry.add(make_entity_config({ id: "gh-token-entity", github_token_ref: ref }));
+      pool.inject_registry(registry);
+      pool.inject_bots([make_bot({ id: 5, state: "free" })]);
+
+      await pool.assign("ch-test", "gh-token-entity", "builder", undefined, "work_room");
+
+      const tmux_call = spawn_calls.find(c => c.command === "tmux");
+      expect(tmux_call).toBeDefined();
+      const cmd_string = tmux_call!.args[tmux_call!.args.length - 1];
+
+      // op binary is shell-quoted by sq(), so look for the resolved path + "run"
+      expect(cmd_string).toContain("/usr/local/bin/op' run");
+      expect(cmd_string).toContain("--env-file");
+      expect(cmd_string).toContain("lf-env-pool-5.op");
+      // claude command should come after the op run wrapper (after --)
+      expect(cmd_string).toContain("-- ");
+      expect(cmd_string).toContain("claude");
+    });
+
+    it("writes correct .env.op file content", async () => {
+      const ref = "op://entity-client/github/credential";
+      registry.add(make_entity_config({ id: "env-op-entity", github_token_ref: ref }));
+      pool.inject_registry(registry);
+      pool.inject_bots([make_bot({ id: 7, state: "free" })]);
+
+      await pool.assign("ch-test", "env-op-entity", "builder", undefined, "work_room");
+
+      const env_op_write = write_file_calls.find(c => c.path.includes("lf-env-pool-7.op"));
+      expect(env_op_write).toBeDefined();
+      expect(env_op_write!.path).toBe("/tmp/lf-env-pool-7.op");
+      expect(env_op_write!.content).toBe(`GH_TOKEN=${ref}\n`);
+    });
+
+    it("cleans up temp .env.op file after tmux starts", async () => {
+      const ref = "op://entity-cleanup/github/credential";
+      registry.add(make_entity_config({ id: "cleanup-entity", github_token_ref: ref }));
+      pool.inject_registry(registry);
+      pool.inject_bots([make_bot({ id: 2, state: "free" })]);
+
+      await pool.assign("ch-test", "cleanup-entity", "builder", undefined, "work_room");
+
+      // Wait for the close handler's unlink call
+      await new Promise(resolve => setTimeout(resolve, 10));
+      expect(unlink).toHaveBeenCalledWith("/tmp/lf-env-pool-2.op");
+    });
+
+    it("resolves op binary path via resolve_binary", async () => {
+      const ref = "op://entity-resolve/github/credential";
+      registry.add(make_entity_config({ id: "resolve-entity", github_token_ref: ref }));
+      pool.inject_registry(registry);
+      pool.inject_bots([make_bot({ id: 4, state: "free" })]);
+
+      await pool.assign("ch-test", "resolve-entity", "builder", undefined, "work_room");
+
+      expect(resolve_binary).toHaveBeenCalledWith("op");
+
+      const tmux_call = spawn_calls.find(c => c.command === "tmux");
+      const cmd_string = tmux_call!.args[tmux_call!.args.length - 1];
+      expect(cmd_string).toContain("/usr/local/bin/op");
+    });
+  });
+
+  describe("graceful fallback", () => {
+    it("session starts without op run when .env.op write fails", async () => {
+      const ref = "op://entity-fail/github/credential";
+      registry.add(make_entity_config({ id: "fail-entity", github_token_ref: ref }));
+      pool.inject_registry(registry);
+      pool.inject_bots([make_bot({ id: 6, state: "free" })]);
+
+      write_file_should_fail = true;
+
+      // Should NOT throw — session starts without GH_TOKEN
+      await pool.assign("ch-test", "fail-entity", "builder", undefined, "work_room");
+
+      const tmux_call = spawn_calls.find(c => c.command === "tmux");
+      expect(tmux_call).toBeDefined();
+      const cmd_string = tmux_call!.args[tmux_call!.args.length - 1];
+
+      // Should NOT contain "op run" since setup failed
+      expect(cmd_string).not.toContain("op' run");
+      // But should still contain claude
+      expect(cmd_string).toContain("claude");
+    });
+
+    it("backward compatible — no registry means no op run wrapping", async () => {
+      // Pool without a registry (legacy path)
+      pool.inject_bots([make_bot({ id: 9, state: "free" })]);
+
+      await pool.assign("ch-test", "some-entity", "builder", undefined, "work_room");
+
+      const tmux_call = spawn_calls.find(c => c.command === "tmux");
+      expect(tmux_call).toBeDefined();
+      const cmd_string = tmux_call!.args[tmux_call!.args.length - 1];
+
+      expect(cmd_string).not.toContain("op' run");
+      expect(cmd_string).toContain("claude");
+    });
+  });
+});

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from "node:events";
 import { execFileSync, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { writeFile, readFile } from "node:fs/promises";
+import { writeFile, readFile, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import type { ArchetypeRole, LobsterFarmConfig } from "@lobster-farm/shared";
@@ -12,6 +12,7 @@ import type { PersistedPoolBot, PersistedBotAvatarState } from "./persistence.js
 import type { EntityRegistry } from "./registry.js";
 import { resolve_model_id, resolve_effort } from "./models.js";
 import { sq } from "./shell.js";
+import { resolve_binary } from "./env.js";
 import * as sentry from "./sentry.js";
 
 // ── Types ──
@@ -144,6 +145,9 @@ export class BotPool extends EventEmitter {
   /** Maps "{entity_id}:{channel_id}" → session_id. Preserves session context
    * across evictions so a channel can resume its old session when reassigned. */
   private session_history = new Map<string, string>();
+  /** Entity registry reference — set during initialize(), used by start_tmux()
+   * to look up per-entity config (e.g., github_token_ref). */
+  private registry: EntityRegistry | null = null;
 
   constructor(config: LobsterFarmConfig) {
     super();
@@ -177,6 +181,9 @@ export class BotPool extends EventEmitter {
 
   /** Discover pool bot directories, restore persisted state, and initialize. */
   async initialize(registry?: EntityRegistry): Promise<void> {
+    if (registry) {
+      this.registry = registry;
+    }
     const channels_dir = join(lobsterfarm_dir(this.config.paths), "channels");
     const pool_dirs: string[] = [];
 
@@ -1170,14 +1177,42 @@ export class BotPool extends EventEmitter {
 
     const display_name = resolve_agent_display_name(archetype, this.config);
     const git_env = `GIT_AUTHOR_NAME=${sq(`${display_name} (LobsterFarm)`)} GIT_AUTHOR_EMAIL=${sq(`${agent_name}@lobsterfarm.dev`)} GIT_COMMITTER_NAME=${sq(`${display_name} (LobsterFarm)`)} GIT_COMMITTER_EMAIL=${sq(`${agent_name}@lobsterfarm.dev`)}`;
+
+    // Check if this entity has a per-entity GitHub token reference.
+    // If so, wrap the claude command with `op run` to inject GH_TOKEN at runtime.
+    const env_op_path = `/tmp/lf-env-pool-${String(bot.id)}.op`;
+    const github_token_ref = this.resolve_github_token_ref(entity_id);
+    let op_prefix = "";
+
+    if (github_token_ref) {
+      try {
+        await writeFile(env_op_path, `GH_TOKEN=${github_token_ref}\n`, "utf-8");
+        const op_bin = resolve_binary("op");
+        op_prefix = `${sq(op_bin)} run --env-file ${sq(env_op_path)} -- `;
+        console.log(
+          `[pool] pool-${String(bot.id)}: wrapping with op run for entity "${entity_id}" GH_TOKEN`,
+        );
+      } catch (err) {
+        // Non-fatal: session starts without GH_TOKEN, inheriting global gh auth
+        console.warn(
+          `[pool] pool-${String(bot.id)}: failed to set up op run for GH_TOKEN: ${String(err)}`,
+        );
+        sentry.captureException(err, {
+          tags: { module: "pool", bot_id: String(bot.id), action: "gh_token_setup" },
+        });
+        op_prefix = "";
+      }
+    }
+
     const claude_cmd = claude_args.join(" ");
+    const full_cmd = `${op_prefix}${claude_cmd}`;
 
     return new Promise<void>((resolve, reject) => {
       const proc = spawn("tmux", [
         "new-session", "-d",
         "-s", bot.tmux_session,
         "-x", "200", "-y", "50",
-        `DISCORD_STATE_DIR=${sq(bot.state_dir)} ${git_env} ${claude_cmd}`,
+        `DISCORD_STATE_DIR=${sq(bot.state_dir)} ${git_env} ${full_cmd}`,
       ], {
         cwd: working_dir,
         stdio: "ignore",
@@ -1192,6 +1227,12 @@ export class BotPool extends EventEmitter {
       });
 
       proc.on("close", (code) => {
+        // Clean up the temp .env.op file after tmux has started (op run reads
+        // the file then execs the command, so it's safe to remove).
+        if (github_token_ref) {
+          unlink(env_op_path).catch(() => { /* best effort cleanup */ });
+        }
+
         if (code !== 0) {
           console.error(`[pool] tmux new-session failed for pool-${String(bot.id)} (code ${String(code)})`);
           sentry.captureException(new Error(`tmux new-session failed for pool-${String(bot.id)} with code ${String(code)}`), {
@@ -1222,6 +1263,15 @@ export class BotPool extends EventEmitter {
         }
       });
     });
+  }
+
+  /** Look up the github_token_ref for an entity from the registry.
+   * Returns the 1Password reference string if configured, or null. */
+  private resolve_github_token_ref(entity_id: string): string | null {
+    if (!this.registry) return null;
+    const entity_config = this.registry.get(entity_id);
+    if (!entity_config) return null;
+    return entity_config.entity.secrets.github_token_ref ?? null;
   }
 
   /** Set a pool bot's server nickname via the daemon bot's Discord client.

--- a/packages/shared/src/schemas/entity.ts
+++ b/packages/shared/src/schemas/entity.ts
@@ -74,6 +74,10 @@ export const EntityConfigSchema = z.object({
     secrets: z.object({
       vault: z.string().default("1password"),
       vault_name: z.string(),
+      // 1Password reference for entity-specific GitHub token.
+      // When set, injected as GH_TOKEN into agent tmux sessions via `op run`.
+      // e.g., "op://entity-my-app/github/credential"
+      github_token_ref: z.string().optional(),
     }),
   }),
 });


### PR DESCRIPTION
## Summary

- Add optional `github_token_ref` to entity config secrets schema for per-entity GitHub identity
- Inject `GH_TOKEN` into agent tmux sessions via `op run` wrapper when the entity has a 1Password reference configured
- Graceful fallback: if `op run` setup fails, the session starts normally without `GH_TOKEN` (inherits global `gh` auth)

## How it works

When an entity's `config.yaml` has `github_token_ref` set (e.g., `op://entity-my-client/github/credential`):

1. Pool writes a temp `.env.op` file at `/tmp/lf-env-pool-{bot_id}.op` containing `GH_TOKEN={ref}`
2. The `claude` command is wrapped with `op run --env-file /tmp/lf-env-pool-{id}.op --`
3. `op run` resolves the 1Password reference at runtime and injects the real token as an env var
4. The temp file is cleaned up after tmux starts (it contains only the reference, not the token)

When `github_token_ref` is NOT set, behavior is completely unchanged (backward compatible).

## Files changed

| File | Change |
|------|--------|
| `packages/shared/src/schemas/entity.ts` | Add `github_token_ref` to secrets schema |
| `packages/daemon/src/pool.ts` | Store registry ref, resolve token ref in `start_tmux`, wrap with `op run` |
| `packages/daemon/src/__tests__/gh-token-injection.test.ts` | 13 new tests |

## Test plan

- [x] Entity WITHOUT `github_token_ref` -- no `op run` wrapper, no `.env.op` file written
- [x] Entity WITH `github_token_ref` -- command wrapped with `op run --env-file`
- [x] `.env.op` file content is correct (reference only, never the token)
- [x] Temp `.env.op` file cleaned up after tmux starts
- [x] `op` binary resolved via `resolve_binary`
- [x] Graceful fallback when `.env.op` write fails (session starts without `GH_TOKEN`)
- [x] Backward compatible -- no registry means no wrapping
- [x] All 31 existing pool tests still pass
- [x] Build compiles clean

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)