### PR TITLE
fix: update /status -- 1M context window + compaction count

### DIFF
--- a/packages/daemon/src/__tests__/session-context.test.ts
+++ b/packages/daemon/src/__tests__/session-context.test.ts
@@ -96,9 +96,10 @@ describe("session-context", () => {
       expect(result).not.toBeNull();
       // Last turn: input_tokens=5000 + cache_creation=1000 + cache_read=4000 = 10000
       expect(result!.used_tokens).toBe(10_000);
-      expect(result!.total_tokens).toBe(200_000);
-      expect(result!.percent).toBe(5);
-      expect(result!.summary).toBe("10k / 200k (5%)");
+      expect(result!.total_tokens).toBe(1_000_000);
+      expect(result!.percent).toBe(1);
+      expect(result!.summary).toBe("10k / 1m (1%)");
+      expect(result!.compactions).toBe(0);
     });
 
     it("returns null when session file is not found", async () => {
@@ -163,8 +164,8 @@ describe("session-context", () => {
       expect(result).not.toBeNull();
       // Last turn: 50000 + 0 + 100000 = 150000
       expect(result!.used_tokens).toBe(150_000);
-      expect(result!.percent).toBe(75);
-      expect(result!.summary).toBe("150k / 200k (75%)");
+      expect(result!.percent).toBe(15);
+      expect(result!.summary).toBe("150k / 1m (15%)");
     });
 
     it("does not carry cache tokens forward from earlier turns", async () => {
@@ -206,6 +207,76 @@ describe("session-context", () => {
       expect(result!.used_tokens).toBe(5000);
     });
 
+    it("detects compaction events", async () => {
+      const session_id = "compact-ev-1234-5678-9012-123456789012";
+      const file_path = join(tmp_dir, ".claude", "projects", "test-project", `${session_id}.jsonl`);
+
+      // Simulate: context grows, then drops sharply (compaction), grows again,
+      // drops sharply again (second compaction).
+      const lines = [
+        // Turn 1: 100k total
+        JSON.stringify({
+          type: "assistant",
+          message: { usage: { input_tokens: 80000, cache_creation_input_tokens: 10000, cache_read_input_tokens: 10000, output_tokens: 500 } },
+        }),
+        // Turn 2: grows to 200k
+        JSON.stringify({
+          type: "assistant",
+          message: { usage: { input_tokens: 150000, cache_creation_input_tokens: 20000, cache_read_input_tokens: 30000, output_tokens: 600 } },
+        }),
+        // Turn 3: drops to 50k — compaction #1 (50k < 200k * 0.5)
+        JSON.stringify({
+          type: "assistant",
+          message: { usage: { input_tokens: 40000, cache_creation_input_tokens: 5000, cache_read_input_tokens: 5000, output_tokens: 300 } },
+        }),
+        // Turn 4: grows back to 150k
+        JSON.stringify({
+          type: "assistant",
+          message: { usage: { input_tokens: 100000, cache_creation_input_tokens: 20000, cache_read_input_tokens: 30000, output_tokens: 400 } },
+        }),
+        // Turn 5: drops to 30k — compaction #2 (30k < 150k * 0.5)
+        JSON.stringify({
+          type: "assistant",
+          message: { usage: { input_tokens: 20000, cache_creation_input_tokens: 5000, cache_read_input_tokens: 5000, output_tokens: 200 } },
+        }),
+      ];
+      await writeFile(file_path, lines.join("\n"));
+
+      const result = await read_session_context(session_id);
+      expect(result).not.toBeNull();
+      expect(result!.compactions).toBe(2);
+      expect(result!.used_tokens).toBe(30_000);
+    });
+
+    it("does not count minor token decreases as compactions", async () => {
+      const session_id = "no-cmpact-1234-5678-9012-123456789012";
+      const file_path = join(tmp_dir, ".claude", "projects", "test-project", `${session_id}.jsonl`);
+
+      // Simulate minor decreases (10-20%) — not compactions
+      const lines = [
+        // Turn 1: 100k total
+        JSON.stringify({
+          type: "assistant",
+          message: { usage: { input_tokens: 80000, cache_creation_input_tokens: 10000, cache_read_input_tokens: 10000, output_tokens: 500 } },
+        }),
+        // Turn 2: drops to 90k (10% decrease — NOT a compaction)
+        JSON.stringify({
+          type: "assistant",
+          message: { usage: { input_tokens: 70000, cache_creation_input_tokens: 10000, cache_read_input_tokens: 10000, output_tokens: 400 } },
+        }),
+        // Turn 3: drops to 72k (20% decrease — NOT a compaction, still above 50%)
+        JSON.stringify({
+          type: "assistant",
+          message: { usage: { input_tokens: 52000, cache_creation_input_tokens: 10000, cache_read_input_tokens: 10000, output_tokens: 300 } },
+        }),
+      ];
+      await writeFile(file_path, lines.join("\n"));
+
+      const result = await read_session_context(session_id);
+      expect(result).not.toBeNull();
+      expect(result!.compactions).toBe(0);
+    });
+
     it("formats sub-thousand token counts correctly", async () => {
       const session_id = "small-tok-1234-5678-9012-123456789012";
       const file_path = join(tmp_dir, ".claude", "projects", "test-project", `${session_id}.jsonl`);
@@ -220,7 +291,7 @@ describe("session-context", () => {
 
       const result = await read_session_context(session_id);
       expect(result).not.toBeNull();
-      expect(result!.summary).toBe("500 / 200k (0.3%)");
+      expect(result!.summary).toBe("500 / 1m (0.1%)");
     });
   });
 });

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -1404,7 +1404,12 @@ export class DiscordBot extends EventEmitter {
     ]);
 
     if (context_usage) {
-      lines.push(`Context: ${context_usage.summary}`);
+      let context_line = `Context: ${context_usage.summary}`;
+      if (context_usage.compactions > 0) {
+        const label = context_usage.compactions === 1 ? "compaction" : "compactions";
+        context_line += ` \u00b7 ${String(context_usage.compactions)} ${label}`;
+      }
+      lines.push(context_line);
     }
     if (subscription_usage) {
       lines.push(`Usage: ${subscription_usage.summary}`);

--- a/packages/daemon/src/session-context.ts
+++ b/packages/daemon/src/session-context.ts
@@ -15,12 +15,14 @@ import * as sentry from "./sentry.js";
 export interface SessionContextUsage {
   /** Total tokens consumed across all assistant turns. */
   used_tokens: number;
-  /** Model context window size (200k for opus/sonnet). */
+  /** Model context window size (1M for opus/sonnet). */
   total_tokens: number;
   /** Percentage of context used, e.g. 22.5 */
   percent: number;
-  /** Formatted summary, e.g. "45k / 200k (22.5%)" */
+  /** Formatted summary, e.g. "45k / 1m (4.5%)" */
   summary: string;
+  /** Number of compaction events detected in this session. */
+  compactions: number;
 }
 
 /** Token usage fields from a single assistant message in the JSONL transcript. */
@@ -34,7 +36,7 @@ interface MessageUsage {
 // ── Constants ──
 
 /** Default context window size for Claude opus/sonnet models. */
-const DEFAULT_CONTEXT_WINDOW = 200_000;
+const DEFAULT_CONTEXT_WINDOW = 1_000_000;
 
 /** Root directory for Claude Code project sessions.
  * Resolved lazily via function so tests can mock homedir(). */
@@ -89,7 +91,7 @@ export async function find_session_file(session_id: string): Promise<string | nu
  * We use the LAST assistant turn's input_tokens as the context fill indicator,
  * since each turn's input_tokens includes all prior context.
  */
-async function parse_session_usage(file_path: string): Promise<{ used_tokens: number; model: string | null }> {
+async function parse_session_usage(file_path: string): Promise<{ used_tokens: number; model: string | null; compactions: number }> {
   const content = await readFile(file_path, "utf-8");
   const lines = content.split("\n").filter(Boolean);
 
@@ -97,6 +99,10 @@ async function parse_session_usage(file_path: string): Promise<{ used_tokens: nu
   let last_cache_creation = 0;
   let last_cache_read = 0;
   let model: string | null = null;
+
+  // Compaction detection: track previous turn's total and count sharp drops.
+  let prev_total = 0;
+  let compactions = 0;
 
   for (const line of lines) {
     try {
@@ -122,6 +128,14 @@ async function parse_session_usage(file_path: string): Promise<{ used_tokens: nu
         last_input_tokens = usage.input_tokens;
         last_cache_creation = usage.cache_creation_input_tokens ?? 0;
         last_cache_read = usage.cache_read_input_tokens ?? 0;
+
+        // Detect compaction: if the current turn's total drops below 50% of
+        // the previous turn's total, Claude compacted the conversation.
+        const current_total = last_input_tokens + last_cache_creation + last_cache_read;
+        if (prev_total > 0 && current_total < prev_total * 0.5) {
+          compactions++;
+        }
+        prev_total = current_total;
       }
     } catch {
       // Skip malformed lines
@@ -132,7 +146,7 @@ async function parse_session_usage(file_path: string): Promise<{ used_tokens: nu
   // input_tokens counts non-cached tokens; cache_creation + cache_read
   // count the cached portion. Together they represent the full prompt.
   const used_tokens = last_input_tokens + last_cache_creation + last_cache_read;
-  return { used_tokens, model };
+  return { used_tokens, model, compactions };
 }
 
 // ── Public API ──
@@ -152,12 +166,12 @@ export async function read_session_context(session_id: string): Promise<SessionC
       return null;
     }
 
-    const { used_tokens, model } = await parse_session_usage(file_path);
+    const { used_tokens, model, compactions } = await parse_session_usage(file_path);
     if (used_tokens === 0) {
       return null;
     }
 
-    // Determine context window from model. Default 200k for opus/sonnet.
+    // Determine context window from model. Default 1M for opus/sonnet.
     const total_tokens = resolve_context_window(model);
     const percent = Math.round((used_tokens / total_tokens) * 1000) / 10; // one decimal
 
@@ -166,6 +180,7 @@ export async function read_session_context(session_id: string): Promise<SessionC
       total_tokens,
       percent,
       summary: format_context_summary(used_tokens, total_tokens, percent),
+      compactions,
     };
   } catch (err) {
     const msg = err instanceof Error ? err.message : "unknown error";
@@ -181,7 +196,7 @@ export async function read_session_context(session_id: string): Promise<SessionC
 // ── Helpers ──
 
 /** Resolve the context window size based on model name.
- * All current Claude models (opus, sonnet) share a 200k window.
+ * All current Claude models (opus, sonnet) share a 1M window.
  * Expand the lookup here when models with different windows ship. */
 function resolve_context_window(_model: string | null): number {
   return DEFAULT_CONTEXT_WINDOW;


### PR DESCRIPTION
## Summary

- Update `DEFAULT_CONTEXT_WINDOW` from 200k to 1M tokens to reflect Claude's current context window
- Add compaction detection to `parse_session_usage()` -- counts turns where total tokens drop below 50% of the previous turn's total, which indicates a context compaction event
- Display compaction count inline on the `/status` context line (e.g. `Context: 450k / 1m (45%) · 3 compactions`)
- Update all existing test assertions for the new 1M denominator and add two new tests: compaction detection and false-positive resistance

## Test plan

- [x] `vitest run packages/daemon/src/__tests__/session-context.test.ts` -- 12 tests pass
- [x] `pnpm build` compiles cleanly
- [ ] Manual: run `/status` in Discord -- verify context shows against 1M window
- [ ] Manual: run a session long enough to trigger compaction, verify count appears

Closes #143

Generated with [Claude Code](https://claude.com/claude-code)