### PR TITLE
feat: 1Password improvements, post-setup guidance, and test fixture cleanup

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -246,14 +246,35 @@ export const init_command = new Command("init")
         p.note(
           "Create a service account at https://my.1password.com → Developer → Service Accounts\n\n" +
             "Grant it:\n" +
-            "  • Create and manage vaults (each entity gets its own vault)\n" +
-            "  • Read/write access to a master \"lobsterfarm\" vault for shared credentials",
+            '  • "Create and manage vaults" permission (LobsterFarm will create vaults automatically)\n\n' +
+            "Note: Vaults created by the service account are auto-shared with it.\n" +
+            "You may need to share new vaults with your personal account too —\n" +
+            "go to 1Password app → Vaults → [vault name] → Sharing → Add your account",
           "1Password Setup",
         );
         await prompt_and_save_op_token(path_overrides);
         op.token_configured = true;
         op.status = "op CLI installed, service account token configured";
       }
+    }
+
+    // Auto-create command-center vault after 1Password token is configured
+    if (op.cli_installed && op.token_configured) {
+      const { exec_command } = await import("../lib/process.js");
+      const vault_result = await exec_command("op vault create command-center --format json");
+      if (vault_result.exitCode === 0) {
+        p.log.success("1Password vault 'command-center' created");
+      } else if (vault_result.stderr?.includes("already exists")) {
+        p.log.info("1Password vault 'command-center' already exists");
+      } else {
+        p.log.warning("Could not create command-center vault. Create it manually: op vault create command-center");
+      }
+
+      p.log.warning(
+        'New vaults are only accessible to the service account by default.\n' +
+        'Share the "command-center" vault with yourself:\n' +
+        "  1Password app → Vaults → command-center → Sharing → Add your account",
+      );
     }
 
     // ── Step 7: Bun (required by Discord channel plugin) ──

--- a/packages/cli/src/commands/init/prompts.ts
+++ b/packages/cli/src/commands/init/prompts.ts
@@ -171,7 +171,7 @@ export async function prompt_github(): Promise<{
 }> {
   const username = await p.text({
     message: "Default GitHub account (used for all entities unless overridden):",
-    placeholder: "e.g. spacelobsterfarm",
+    placeholder: "e.g. my-org",
     defaultValue: "",
   });
   if (p.isCancel(username)) {

--- a/packages/cli/src/commands/init/tools.ts
+++ b/packages/cli/src/commands/init/tools.ts
@@ -471,7 +471,7 @@ async function setup_sentry(
     p.note(
       "Generate a Sentry auth token at:\n" +
       "https://sentry.io/settings/account/api/auth-tokens/\n\n" +
-      "Scopes needed: project:read, project:write, org:read, event:read, event:write",
+      "Required scopes: project:write, org:read",
       "Sentry Token",
     );
     const prompted_token = await p.password({ message: "Paste your Sentry auth token:" });

--- a/packages/daemon/src/__tests__/issue-utils.test.ts
+++ b/packages/daemon/src/__tests__/issue-utils.test.ts
@@ -78,11 +78,11 @@ describe("extract_first_linked_issue", () => {
 
 describe("nwo_from_url", () => {
   it("parses HTTPS URL", () => {
-    expect(nwo_from_url("https://github.com/ultim88888888/lobster-farm.git")).toBe("ultim88888888/lobster-farm");
+    expect(nwo_from_url("https://github.com/test-org/lobster-farm.git")).toBe("test-org/lobster-farm");
   });
 
   it("parses SSH URL", () => {
-    expect(nwo_from_url("git@github.com:ultim88888888/lobster-farm.git")).toBe("ultim88888888/lobster-farm");
+    expect(nwo_from_url("git@github.com:test-org/lobster-farm.git")).toBe("test-org/lobster-farm");
   });
 
   it("handles URL without .git suffix", () => {

--- a/packages/daemon/src/__tests__/pr-cron-author.test.ts
+++ b/packages/daemon/src/__tests__/pr-cron-author.test.ts
@@ -100,19 +100,19 @@ describe("PR cron — author-based alert labeling", () => {
   }
 
   it("labels internal PR without 'External' prefix when author matches github.user", async () => {
-    mock_registry.get.mockReturnValue(make_entity("ultim88888888"));
+    mock_registry.get.mockReturnValue(make_entity("test-org"));
     const cron = await create_cron();
 
-    await trigger_review(cron, "ultim88888888", "changes_requested");
+    await trigger_review(cron, "test-org", "changes_requested");
 
     expect(alerts).toHaveLength(1);
     expect(alerts[0]).toMatch(/^PR #42:/);
     expect(alerts[0]).not.toContain("External");
-    expect(alerts[0]).not.toContain("@ultim88888888");
+    expect(alerts[0]).not.toContain("@test-org");
   });
 
   it("labels external PR with 'External' prefix and @author when author differs", async () => {
-    mock_registry.get.mockReturnValue(make_entity("ultim88888888"));
+    mock_registry.get.mockReturnValue(make_entity("test-org"));
     const cron = await create_cron();
 
     await trigger_review(cron, "contributor123", "changes_requested");
@@ -125,14 +125,14 @@ describe("PR cron — author-based alert labeling", () => {
     mock_registry.get.mockReturnValue(make_entity()); // No github user configured
     const cron = await create_cron();
 
-    await trigger_review(cron, "ultim88888888", "changes_requested");
+    await trigger_review(cron, "test-org", "changes_requested");
 
     expect(alerts).toHaveLength(1);
-    expect(alerts[0]).toMatch(/^External PR #42 from @ultim88888888:/);
+    expect(alerts[0]).toMatch(/^External PR #42 from @test-org:/);
   });
 
   it("labels approved+merged internal PR without 'External'", async () => {
-    mock_registry.get.mockReturnValue(make_entity("ultim88888888"));
+    mock_registry.get.mockReturnValue(make_entity("test-org"));
 
     // Mock check_pr_merged — we need execFile to return MERGED state
     const { execFile } = await import("node:child_process");
@@ -143,7 +143,7 @@ describe("PR cron — author-based alert labeling", () => {
     // Mock the private check_pr_merged to return true
     (cron as any).check_pr_merged = vi.fn().mockResolvedValue(true);
 
-    await trigger_review(cron, "ultim88888888", "approved");
+    await trigger_review(cron, "test-org", "approved");
 
     expect(alerts).toHaveLength(1);
     expect(alerts[0]).toMatch(/^PR #42:/);
@@ -152,7 +152,7 @@ describe("PR cron — author-based alert labeling", () => {
   });
 
   it("labels approved+merged external PR with 'External' and @author", async () => {
-    mock_registry.get.mockReturnValue(make_entity("ultim88888888"));
+    mock_registry.get.mockReturnValue(make_entity("test-org"));
     const cron = await create_cron();
 
     (cron as any).check_pr_merged = vi.fn().mockResolvedValue(true);
@@ -165,7 +165,7 @@ describe("PR cron — author-based alert labeling", () => {
   });
 
   it("labels approved but unmerged external PR with human merge note", async () => {
-    mock_registry.get.mockReturnValue(make_entity("ultim88888888"));
+    mock_registry.get.mockReturnValue(make_entity("test-org"));
     const cron = await create_cron();
 
     (cron as any).check_pr_merged = vi.fn().mockResolvedValue(false);
@@ -178,7 +178,7 @@ describe("PR cron — author-based alert labeling", () => {
   });
 
   it("still spawns fixer for both internal and external PRs needing changes", async () => {
-    mock_registry.get.mockReturnValue(make_entity("ultim88888888"));
+    mock_registry.get.mockReturnValue(make_entity("test-org"));
     const cron = await create_cron();
 
     // Stub the fixer spawn to track calls
@@ -186,7 +186,7 @@ describe("PR cron — author-based alert labeling", () => {
     (cron as any).spawn_external_pr_fixer = spawn_fixer;
 
     // Internal PR
-    await trigger_review(cron, "ultim88888888", "changes_requested");
+    await trigger_review(cron, "test-org", "changes_requested");
     expect(spawn_fixer).toHaveBeenCalledTimes(1);
 
     // External PR

--- a/packages/daemon/src/__tests__/webhook-handler.test.ts
+++ b/packages/daemon/src/__tests__/webhook-handler.test.ts
@@ -18,7 +18,7 @@ function sign_payload(payload: string, secret: string = WEBHOOK_SECRET): string 
 function make_pr_payload(
   action: string = "opened",
   pr_number: number = 42,
-  repo_full_name: string = "ultim88888888/lobster-farm",
+  repo_full_name: string = "test-org/lobster-farm",
   overrides: Record<string, unknown> = {},
 ): string {
   return JSON.stringify({
@@ -96,7 +96,7 @@ function make_registry(): EntityRegistry {
           repos: [
             {
               name: "lobster-farm",
-              url: "https://github.com/ultim88888888/lobster-farm.git",
+              url: "https://github.com/test-org/lobster-farm.git",
               path: "/tmp/test-repo",
             },
           ],
@@ -199,7 +199,7 @@ describe("handle_github_webhook", () => {
     });
 
     it("does not spawn reviewer for pull_request.closed without merge", async () => {
-      const body = make_pr_payload("closed", 300, "ultim88888888/lobster-farm", { merged: false });
+      const body = make_pr_payload("closed", 300, "test-org/lobster-farm", { merged: false });
       const req = make_request(body, {
         "x-github-event": "pull_request",
         "x-hub-signature-256": sign_payload(body),
@@ -223,7 +223,7 @@ describe("handle_github_webhook", () => {
       const log_spy = vi.spyOn(console, "log").mockImplementation(() => {});
 
       try {
-        const body = make_pr_payload("closed", 300, "ultim88888888/lobster-farm", { merged: true });
+        const body = make_pr_payload("closed", 300, "test-org/lobster-farm", { merged: true });
         const req = make_request(body, {
           "x-github-event": "pull_request",
           "x-hub-signature-256": sign_payload(body),
@@ -237,11 +237,11 @@ describe("handle_github_webhook", () => {
         await vi.waitFor(() => {
           // Should have called fetch for the comment + close API calls on issue #10
           expect(fetch_spy).toHaveBeenCalledWith(
-            "https://api.github.com/repos/ultim88888888/lobster-farm/issues/10/comments",
+            "https://api.github.com/repos/test-org/lobster-farm/issues/10/comments",
             expect.objectContaining({ method: "POST" }),
           );
           expect(fetch_spy).toHaveBeenCalledWith(
-            "https://api.github.com/repos/ultim88888888/lobster-farm/issues/10",
+            "https://api.github.com/repos/test-org/lobster-farm/issues/10",
             expect.objectContaining({ method: "PATCH" }),
           );
         }, { timeout: 2000 });

--- a/packages/daemon/src/pr-cron.ts
+++ b/packages/daemon/src/pr-cron.ts
@@ -262,8 +262,7 @@ export class PRReviewCron {
     }
 
     // Extract feedback timestamps from reviews and comments.
-    // Note: we don't filter by author here. In this codebase all reviews come from
-    // the same GitHub account (ultim88888888). If CI bots start posting comments,
+    // Note: we don't filter by author here. If CI bots start posting comments,
     // add author filtering (e.g., skip authors with [bot] suffix or known CI logins).
     const feedback_timestamps: number[] = [];
 

--- a/packages/daemon/src/webhook-handler.ts
+++ b/packages/daemon/src/webhook-handler.ts
@@ -83,7 +83,7 @@ function read_body(req: IncomingMessage): Promise<string> {
 }
 
 /**
- * Map a GitHub repo full_name (e.g. "ultim88888888/lobster-farm") to an entity.
+ * Map a GitHub repo full_name (e.g. "my-org/my-repo") to an entity.
  * Checks each entity's repo URLs for a match.
  */
 function find_entity_for_repo(

--- a/packages/shared/src/__tests__/schemas.test.ts
+++ b/packages/shared/src/__tests__/schemas.test.ts
@@ -154,13 +154,13 @@ describe("EntityConfigSchema", () => {
       entity: {
         ...MINIMAL_ENTITY.entity,
         accounts: {
-          github: { org: "spacelobsterfarm", user: "ultim88888888" },
+          github: { org: "test-org", user: "test-org" },
           vercel: { project: "alpha-platform" },
           sentry: { project: "alpha" },
         },
       },
     });
-    expect(config.entity.accounts.github?.org).toBe("spacelobsterfarm");
+    expect(config.entity.accounts.github?.org).toBe("test-org");
     expect(config.entity.accounts.vercel?.project).toBe("alpha-platform");
   });
 


### PR DESCRIPTION
## Summary

- **1Password improvements**: Enhanced service account setup guidance with vault permission details, auto-create `command-center` vault after token verification, and vault sharing instructions for new vaults
- **Sentry scope guidance**: Simplified required scopes to `project:write` and `org:read`
- **Test fixture cleanup**: Replaced personal references (`ultim88888888`, `spacelobsterfarm`) with `test-org` across all test files and source comments

Implements Phases 4, 5, and 7 of #140. Closes #140

## Test plan

- [x] Full build passes (`pnpm build`)
- [x] All 585 tests pass across shared (53), cli (32), and daemon (500)
- [ ] Manual: run `lf init` and verify 1Password guidance text renders correctly
- [ ] Manual: verify vault creation attempt runs after token save

🤖 Generated with [Claude Code](https://claude.com/claude-code)