### PR TITLE
fix: address remaining codebase review findings

### DIFF
--- a/packages/daemon/src/README.md
+++ b/packages/daemon/src/README.md
@@ -16,7 +16,6 @@ The LobsterFarm daemon process. Manages entities, spawns Claude Code agent sessi
 - `pool.ts` -- `BotPool`. Manages a pool of Discord bot accounts (pool-0 through pool-N) for assigning to channels. Handles assignment, release, LRU eviction, parking (session preservation), nickname setting, and pre-assignment of planners to entity #general channels.
 - `actions.ts` -- Side-effect functions: git worktree create/cleanup, GitHub PR create/merge via `gh`, test runner, and Discord notification dispatch.
 - `review-utils.ts` -- Utility functions for PR review feedback: fetch review comments from GitHub and build fix prompts for the auto-fix loop.
-- `context.ts` -- Compiles the context payload injected into agent sessions: entity memory path, daily log paths, and project CLAUDE.md content.
 - `hooks.ts` -- Post-session hooks. Extracts session learnings via Haiku and appends them to daily logs. Also manages the global learnings file.
 - `models.ts` -- Maps abstract model tiers (opus/sonnet/haiku + think level) to Claude CLI flags.
 - `persistence.ts` -- JSON file persistence for PR review state and pool state. Saves to and loads from `~/.lobsterfarm/state/`.

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -725,7 +725,7 @@ export class BotPool extends EventEmitter {
 
   /** Release a bot from its channel assignment. */
   async release(channel_id: string): Promise<void> {
-    const bot = this.bots.find(b => b.channel_id === channel_id);
+    const bot = this.bots.find(b => b.channel_id === channel_id && b.state === "assigned");
     if (!bot) return;
 
     // Synchronous in-flight lock: prevents double-release when two callers


### PR DESCRIPTION
## Summary

Addresses the remaining non-stale findings from the comprehensive codebase review (#35). Most original findings were already resolved by prior work (feature lifecycle strip #148, shell quoting via `sq()`, `CLAUDE_BIN` env var, `exec_shell` for test commands, model resolution via `resolve_model_id`, pool-dir scanning in stop.ts, and inline documentation comments).

Two findings remained:

- **#11 — `release()` matches channel_id regardless of state**: Added `&& b.state === "assigned"` to the `find()` predicate in `pool.ts` so parked bots aren't accidentally released when a channel_id happens to match.
- **#27 — Dead `context.ts` reference in README**: The file was deleted previously but its entry in `packages/daemon/src/README.md` survived. Removed it.

## Test plan

- [x] Full test suite passes (585 tests across 41 files)
- [x] Build succeeds for all packages
- [x] Verified existing pool release tests still pass (they always release assigned bots)

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)