### PR TITLE
feat: weekly memory pruning cron for daily logs

### DIFF
--- a/packages/daemon/src/__tests__/memory-pruning.test.ts
+++ b/packages/daemon/src/__tests__/memory-pruning.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile, readdir, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { LobsterFarmConfig } from "@lobster-farm/shared";
+import { prune_daily_logs } from "../memory-pruning.js";
+
+// ── Helpers ──
+
+/** Build a minimal config pointing at a temp lobsterfarm dir. */
+function make_config(lf_dir: string): LobsterFarmConfig {
+  return {
+    paths: {
+      lobsterfarm_dir: lf_dir,
+      projects_dir: "/tmp",
+      claude_dir: "/tmp",
+    },
+  } as LobsterFarmConfig;
+}
+
+/** Format a Date as YYYY-MM-DD. */
+function fmt(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/** Return a Date that is `days` days ago from now. */
+function days_ago(days: number): Date {
+  const d = new Date();
+  d.setDate(d.getDate() - days);
+  return d;
+}
+
+// ── Test suite ──
+
+describe("prune_daily_logs", () => {
+  let tmp_dir: string;
+  let entities_path: string;
+
+  beforeEach(async () => {
+    tmp_dir = await mkdtemp(join(tmpdir(), "lf-prune-"));
+    entities_path = join(tmp_dir, "entities");
+    await mkdir(entities_path);
+  });
+
+  afterEach(async () => {
+    await rm(tmp_dir, { recursive: true, force: true });
+  });
+
+  it("archives files older than 30 days", async () => {
+    const daily = join(entities_path, "test-entity", "daily");
+    await mkdir(daily, { recursive: true });
+
+    const old_file = `${fmt(days_ago(45))}.md`;
+    const new_file = `${fmt(days_ago(10))}.md`;
+
+    await writeFile(join(daily, old_file), "old content");
+    await writeFile(join(daily, new_file), "new content");
+
+    await prune_daily_logs(make_config(tmp_dir));
+
+    // Old file should be in archive/
+    const archive = await readdir(join(daily, "archive"));
+    expect(archive).toContain(old_file);
+
+    // New file should still be in daily/
+    const remaining = await readdir(daily);
+    expect(remaining).toContain(new_file);
+    expect(remaining).not.toContain(old_file);
+  });
+
+  it("leaves files 30 days old or younger untouched", async () => {
+    const daily = join(entities_path, "test-entity", "daily");
+    await mkdir(daily, { recursive: true });
+
+    // Use 29 days to avoid boundary ambiguity from time-of-day offsets
+    // (file dates are midnight UTC, but age is computed against current time)
+    const recent_file = `${fmt(days_ago(29))}.md`;
+    await writeFile(join(daily, recent_file), "recent");
+
+    await prune_daily_logs(make_config(tmp_dir));
+
+    const remaining = await readdir(daily);
+    expect(remaining).toContain(recent_file);
+  });
+
+  it("creates archive/ directory if missing", async () => {
+    const daily = join(entities_path, "test-entity", "daily");
+    await mkdir(daily, { recursive: true });
+
+    await writeFile(join(daily, `${fmt(days_ago(60))}.md`), "old");
+
+    await prune_daily_logs(make_config(tmp_dir));
+
+    const archive_entries = await readdir(join(daily, "archive"));
+    expect(archive_entries.length).toBe(1);
+  });
+
+  it("is idempotent — running twice does not error", async () => {
+    const daily = join(entities_path, "test-entity", "daily");
+    await mkdir(daily, { recursive: true });
+
+    const old_file = `${fmt(days_ago(45))}.md`;
+    await writeFile(join(daily, old_file), "old");
+
+    await prune_daily_logs(make_config(tmp_dir));
+    // Second run: old_file is already in archive/, daily/ has no more old files
+    await prune_daily_logs(make_config(tmp_dir));
+
+    const archive = await readdir(join(daily, "archive"));
+    expect(archive).toContain(old_file);
+  });
+
+  it("handles entity with no daily/ directory gracefully", async () => {
+    // Entity dir exists but has no daily/ subdirectory
+    await mkdir(join(entities_path, "empty-entity"), { recursive: true });
+
+    // Should not throw
+    await expect(prune_daily_logs(make_config(tmp_dir))).resolves.toBeUndefined();
+  });
+
+  it("handles missing entities directory gracefully", async () => {
+    // Point at a config with a non-existent lobsterfarm dir
+    const bad_config = make_config("/tmp/does-not-exist-lf-test");
+    await expect(prune_daily_logs(bad_config)).resolves.toBeUndefined();
+  });
+
+  it("ignores non-date files in daily/", async () => {
+    const daily = join(entities_path, "test-entity", "daily");
+    await mkdir(daily, { recursive: true });
+
+    await writeFile(join(daily, "notes.md"), "not a date file");
+    await writeFile(join(daily, "2024-13-99.md"), "invalid date");
+
+    await prune_daily_logs(make_config(tmp_dir));
+
+    const remaining = await readdir(daily);
+    expect(remaining).toContain("notes.md");
+    expect(remaining).toContain("2024-13-99.md");
+  });
+
+  it("processes multiple entities independently", async () => {
+    const daily_a = join(entities_path, "entity-a", "daily");
+    const daily_b = join(entities_path, "entity-b", "daily");
+    await mkdir(daily_a, { recursive: true });
+    await mkdir(daily_b, { recursive: true });
+
+    const old_file = `${fmt(days_ago(45))}.md`;
+    const new_file = `${fmt(days_ago(5))}.md`;
+
+    await writeFile(join(daily_a, old_file), "a-old");
+    await writeFile(join(daily_a, new_file), "a-new");
+    await writeFile(join(daily_b, old_file), "b-old");
+
+    await prune_daily_logs(make_config(tmp_dir));
+
+    // Entity A: old archived, new kept
+    const archive_a = await readdir(join(daily_a, "archive"));
+    expect(archive_a).toContain(old_file);
+    const remaining_a = await readdir(daily_a);
+    expect(remaining_a).toContain(new_file);
+
+    // Entity B: old archived
+    const archive_b = await readdir(join(daily_b, "archive"));
+    expect(archive_b).toContain(old_file);
+  });
+});

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -15,6 +15,7 @@ import { init_github_app_from_env } from "./github-app.js";
 import { check_required_binaries, propagate_tmux_env } from "./env.js";
 import { append_session_log } from "./persistence.js";
 import { sweep_stale_worktrees } from "./worktree-cleanup.js";
+import { prune_daily_logs } from "./memory-pruning.js";
 import * as sentry from "./sentry.js";
 
 async function main(): Promise<void> {
@@ -254,6 +255,25 @@ async function main(): Promise<void> {
   }, WORKTREE_SWEEP_INTERVAL_MS);
   console.log("[worktree-cleanup] Stale worktree sweep scheduled (every 60 min)");
 
+  // Start weekly memory pruning — archives daily logs older than 30 days.
+  // Runs once on startup (catches up if daemon was down) then weekly.
+  const MEMORY_PRUNE_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000; // 1 week
+  void prune_daily_logs(config).catch((err) => {
+    console.error(`[memory] Startup pruning failed: ${String(err)}`);
+    sentry.captureException(err, {
+      tags: { module: "memory-pruning", action: "startup" },
+    });
+  });
+  const memory_prune_timer = setInterval(() => {
+    void prune_daily_logs(config).catch((err) => {
+      console.error(`[memory] Pruning failed: ${String(err)}`);
+      sentry.captureException(err, {
+        tags: { module: "memory-pruning", action: "scheduled" },
+      });
+    });
+  }, MEMORY_PRUNE_INTERVAL_MS);
+  console.log("[memory] Weekly daily-log pruning scheduled");
+
   // Write PID file
   await write_pid(config);
   console.log(`PID file written (pid: ${String(process.pid)})`);
@@ -287,6 +307,7 @@ async function main(): Promise<void> {
     pool.drain();
     pr_cron.stop();
     clearInterval(worktree_sweep_timer);
+    clearInterval(memory_prune_timer);
 
     // Check for active work
     const work_check = pool.has_active_work();

--- a/packages/daemon/src/memory-pruning.ts
+++ b/packages/daemon/src/memory-pruning.ts
@@ -1,0 +1,75 @@
+/**
+ * Weekly memory pruning — moves daily log files older than 30 days
+ * into an archive/ subdirectory per entity.
+ *
+ * Pure housekeeping: no AI, no summarization, no token cost.
+ */
+
+import { readdir, rename, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import type { LobsterFarmConfig } from "@lobster-farm/shared";
+import { entities_dir } from "@lobster-farm/shared";
+
+/** Number of days after which daily logs are archived. */
+const MAX_AGE_DAYS = 30;
+
+/** Date pattern for daily log filenames: YYYY-MM-DD.md */
+const DATE_PATTERN = /^(\d{4}-\d{2}-\d{2})\.md$/;
+
+/**
+ * Scan all entities and move daily logs older than 30 days to daily/archive/.
+ * Designed to run weekly + once on startup. Idempotent and failure-tolerant.
+ */
+export async function prune_daily_logs(config: LobsterFarmConfig): Promise<void> {
+  const base_dir = entities_dir(config.paths);
+
+  let entity_dirs: string[];
+  try {
+    const entries = await readdir(base_dir, { withFileTypes: true });
+    entity_dirs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
+  } catch {
+    // No entities directory — nothing to do
+    return;
+  }
+
+  const now = new Date();
+
+  for (const entity_id of entity_dirs) {
+    const daily_dir = join(base_dir, entity_id, "daily");
+
+    let files: string[];
+    try {
+      const entries = await readdir(daily_dir);
+      files = entries.filter((f) => DATE_PATTERN.test(f));
+    } catch {
+      // Entity has no daily/ directory — skip gracefully
+      continue;
+    }
+
+    const to_archive: string[] = [];
+
+    for (const file of files) {
+      const match = DATE_PATTERN.exec(file);
+      if (!match) continue;
+
+      const file_date = new Date(match[1]!);
+      const age_days = (now.getTime() - file_date.getTime()) / (1000 * 60 * 60 * 24);
+
+      if (age_days > MAX_AGE_DAYS) {
+        to_archive.push(file);
+      }
+    }
+
+    if (to_archive.length === 0) continue;
+
+    // Ensure archive/ exists
+    const archive_dir = join(daily_dir, "archive");
+    await mkdir(archive_dir, { recursive: true });
+
+    for (const file of to_archive) {
+      await rename(join(daily_dir, file), join(archive_dir, file));
+    }
+
+    console.log(`[memory] Archived ${String(to_archive.length)} daily log(s) for ${entity_id}`);
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `prune_daily_logs()` in `packages/daemon/src/memory-pruning.ts` — scans all entities, moves daily log files older than 30 days to `daily/archive/`
- Registered in `index.ts`: runs once on startup (catch-up) then weekly via `setInterval`, cleaned up on shutdown
- 8 tests covering archival, boundary conditions, idempotency, missing directories, multiple entities

## Design decisions

- Uses filesystem scanning (`readdir` on entities dir) rather than the entity registry, keeping the module dependency-free and testable without mocks
- Age threshold is >30 days (file date parsed from filename vs current date)
- Mirrors the worktree sweep pattern: fire-and-forget with error logging to Sentry

## Test plan

- [x] All 8 tests pass (`pnpm vitest run`)
- [x] No type errors in new/modified files
- [ ] Verify daemon starts cleanly with the new cron registered

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)