### PR TITLE
chore: clean up stale feature lifecycle references

### DIFF
--- a/config/claude/agents/commander.md
+++ b/config/claude/agents/commander.md
@@ -2,8 +2,8 @@
 name: {{COMMANDER_NAME_LOWER}}
 description: >
   System administrator and orchestrator. Invoked for entity management,
-  system configuration, Discord scaffolding, feature lifecycle management,
-  and any meta-level operations on the LobsterFarm platform itself.
+  system configuration, Discord scaffolding, and any meta-level operations
+  on the LobsterFarm platform itself.
   The only agent that operates at the platform level, not the entity level.
 model: opus
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Skill
@@ -34,15 +34,10 @@ You know the LobsterFarm platform intimately:
 - Global config at `~/.lobsterfarm/config.yaml`
 - The daemon API runs at `http://localhost:7749`
 - Discord scaffolding (channels, categories) is handled by the daemon bot — tell it what to create via the API
-- Features are managed via the daemon API
 
 Query the daemon for current state — it's always fresh:
 - `curl -s http://localhost:7749/status` — system status (includes your own health)
 - `curl -s http://localhost:7749/entities` — list entities
-- `curl -s http://localhost:7749/features` — list features
-- `curl -s -X POST http://localhost:7749/features -H 'Content-Type: application/json' -d '{"entity_id":"...","title":"...","github_issue":N}'` — create feature
-- `curl -s -X POST http://localhost:7749/features/{id}/approve` — approve phase
-- `curl -s -X POST http://localhost:7749/features/{id}/advance` — advance phase
 
 You can also directly create and modify entity configs, MEMORY files, and context docs by reading and writing files.
 

--- a/config/claude/skills/README.md
+++ b/config/claude/skills/README.md
@@ -6,7 +6,7 @@ Skills fall into three categories:
 
 - **DNA** -- Deep domain knowledge. How we write code, design interfaces, plan features, manage databases. Loaded by the primary archetype for that domain.
 - **Guidelines** -- Operational requirements. Secret handling, code review standards, README maintenance, Discord management. Loaded across archetypes as needed.
-- **SOPs** -- Step-by-step procedures. Feature lifecycle flow, PR review-merge workflow, entity scaffolding process. Loaded when executing a specific process.
+- **SOPs** -- Step-by-step procedures. PR review-merge workflow, entity scaffolding process. Loaded when executing a specific process.
 
 ## Directories
 
@@ -18,6 +18,5 @@ Skills fall into three categories:
 - `secrets-guideline/` -- 1Password-based secret management. The "never handle raw secrets" rule.
 - `readme-guideline/` -- Directory documentation standards. When and how to write READMEs.
 - `discord-guideline/` -- Discord server management. Channel scaffolding, bot architecture, webhook patterns.
-- `feature-lifecycle/` -- SOP for how features move from idea to shipped code.
 - `pr-review-merge/` -- SOP for the PR review, feedback, and merge workflow.
 - `entity-scaffold/` -- SOP for standing up a new entity from a blueprint.

--- a/config/claude/skills/pr-review-merge/SKILL.md
+++ b/config/claude/skills/pr-review-merge/SKILL.md
@@ -3,7 +3,7 @@ name: pr-review-merge
 description: >
   PR review and merge workflow. Auto-loads when reviewing pull requests,
   handling review feedback, merging code, or resolving merge conflicts.
-  Independent of the feature lifecycle — works for any PR on any entity repo.
+  Works for any PR on any entity repo.
 ---
 
 # PR Review-Merge SOP
@@ -14,7 +14,7 @@ _How pull requests get reviewed, fixed, and merged in LobsterFarm._
 
 ## Overview
 
-This SOP runs independently of the feature lifecycle. Any PR on any entity repo triggers it — whether the PR came from the feature lifecycle, a manual push, or an external contributor.
+Any PR on any entity repo triggers this SOP — whether from a planned feature, a manual push, or an external contributor.
 
 ```
 PR opened → Review → Changes needed? → Fix → Re-review → Merge
@@ -76,15 +76,9 @@ When the review is approved:
    - If the rebase requires decisions (conflicting changes in the same area), escalate to #alerts with the conflict details and wait for guidance
 4. **Post-merge** — notify #general
 
-### 5. Notify Feature Lifecycle (if applicable)
-
-If this PR belongs to a feature managed by the feature lifecycle (tracked in `features.json`), the daemon advances the feature from "review" to "ship" upon merge.
-
-For PRs not associated with a feature, the SOP completes after merge.
-
 ## Agent Behavior During Build
 
-This applies to both the build phase of the feature lifecycle and the fix step above:
+This applies to the fix step above:
 
 **Agents should surface discoveries.** Plans drift during implementation. New information emerges. When an agent discovers something that could affect a decision or the outcome — a gotcha, a better approach, a dependency that changes the scope — it should ask, not assume.
 
@@ -99,7 +93,6 @@ This isn't about asking permission for every line of code. It's about being a co
 - Trigger review-merge SOP for new/updated PRs
 - Spawn reviewer and builder agents
 - Track which PRs are being processed
-- Detect merge and notify feature lifecycle
 - Handle merge mechanics (squash, rebase)
 
 **Agents (intelligent):**


### PR DESCRIPTION
## Summary

- Removed "feature lifecycle management" from commander agent description and dropped the `/features` API curl examples (create, approve, advance) that referenced the deleted feature state machine
- Cleaned up pr-review-merge SOP: removed "Independent of the feature lifecycle" framing, deleted the "Notify Feature Lifecycle" step (section 5), removed "Detect merge and notify feature lifecycle" from daemon responsibilities
- Removed `feature-lifecycle/` directory listing and "Feature lifecycle flow" mention from the skills README

Closes #167

## Test plan

- [ ] Verify commander agent loads correctly without feature lifecycle references
- [ ] Verify pr-review-merge skill loads and reads coherently
- [ ] Verify skills README accurately reflects the directories that exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)