### PR TITLE
fix: thread GH_TOKEN through post-review flow for cross-account repos

### DIFF
--- a/packages/daemon/src/__tests__/actions.test.ts
+++ b/packages/daemon/src/__tests__/actions.test.ts
@@ -623,6 +623,48 @@ describe("detect_review_outcome", () => {
     const result = await detect_review_outcome(42, "/repos/test-repo");
     expect(result).toBe("approved");
   });
+
+  it("passes GH_TOKEN in env when gh_token is provided", async () => {
+    exec_mock_impl = async (_cmd, args) => {
+      if (args.includes("state")) {
+        return { stdout: "OPEN", stderr: "" };
+      }
+      if (args.includes("reviewDecision")) {
+        return { stdout: "APPROVED", stderr: "" };
+      }
+      return { stdout: "", stderr: "" };
+    };
+
+    await detect_review_outcome(42, "/repos/test-repo", "ghs_cross_account_token");
+
+    // All gh calls should have GH_TOKEN in their env
+    const gh_calls = exec_calls.filter((c) => c.command === "gh");
+    expect(gh_calls.length).toBeGreaterThan(0);
+    for (const call of gh_calls) {
+      expect((call.options as Record<string, unknown>)?.env).toBeDefined();
+      expect(
+        ((call.options as Record<string, unknown>)?.env as Record<string, string>)?.GH_TOKEN,
+      ).toBe("ghs_cross_account_token");
+    }
+  });
+
+  it("does not set env when gh_token is not provided", async () => {
+    exec_mock_impl = async (_cmd, args) => {
+      if (args.includes("state")) {
+        return { stdout: "MERGED", stderr: "" };
+      }
+      return { stdout: "", stderr: "" };
+    };
+
+    await detect_review_outcome(42, "/repos/test-repo");
+
+    const gh_calls = exec_calls.filter((c) => c.command === "gh");
+    expect(gh_calls.length).toBeGreaterThan(0);
+    for (const call of gh_calls) {
+      // When no token is provided, env should not be set on the options
+      expect((call.options as Record<string, unknown>)?.env).toBeUndefined();
+    }
+  });
 });
 
 describe("classify_merge_error", () => {

--- a/packages/daemon/src/__tests__/webhook-handler.test.ts
+++ b/packages/daemon/src/__tests__/webhook-handler.test.ts
@@ -863,4 +863,146 @@ describe("handle_github_webhook", () => {
       }
     });
   });
+
+  describe("post-review token threading", () => {
+    it("passes installation token to detect_review_outcome after review completes", async () => {
+      const { detect_review_outcome } = await import("../actions.js");
+      const log_spy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      try {
+        // Use installation_id to test cross-account token threading
+        const body = make_pr_payload("opened", 950, "test-org/lobster-farm", {}, {
+          installation_id: 88888,
+        });
+        const req = make_request(body, {
+          "x-github-event": "pull_request",
+          "x-hub-signature-256": sign_payload(body),
+        });
+        const res = make_response();
+        const ctx = make_context();
+
+        await handle_github_webhook(req, res, ctx);
+
+        // Wait for reviewer to be spawned
+        await vi.waitFor(() => {
+          expect((ctx.session_manager as any).spawn).toHaveBeenCalledTimes(1);
+        }, { timeout: 2000 });
+
+        // Simulate reviewer session completion
+        const spawn_result = await (ctx.session_manager as any).spawn.mock.results[0].value;
+        (ctx.session_manager as any).emit("session:completed", {
+          session_id: spawn_result.session_id,
+          exit_code: 0,
+        });
+
+        // Wait for post-review handling (resolve_token + detect_review_outcome)
+        await vi.waitFor(() => {
+          expect(detect_review_outcome).toHaveBeenCalled();
+        }, { timeout: 2000 });
+
+        // detect_review_outcome should have been called with the installation token
+        // get_token_for_installation("88888") returns "ghs_install_88888"
+        expect(detect_review_outcome).toHaveBeenCalledWith(
+          950,
+          "/tmp/test-repo",
+          "ghs_install_88888",
+        );
+      } finally {
+        log_spy.mockRestore();
+      }
+    });
+
+    it("passes default token to detect_review_outcome when no installation_id", async () => {
+      const { detect_review_outcome } = await import("../actions.js");
+      const log_spy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      try {
+        const body = make_pr_payload("opened", 951, "test-org/lobster-farm");
+        const req = make_request(body, {
+          "x-github-event": "pull_request",
+          "x-hub-signature-256": sign_payload(body),
+        });
+        const res = make_response();
+        const ctx = make_context();
+
+        await handle_github_webhook(req, res, ctx);
+
+        await vi.waitFor(() => {
+          expect((ctx.session_manager as any).spawn).toHaveBeenCalledTimes(1);
+        }, { timeout: 2000 });
+
+        // Simulate reviewer session completion
+        const spawn_result = await (ctx.session_manager as any).spawn.mock.results[0].value;
+        (ctx.session_manager as any).emit("session:completed", {
+          session_id: spawn_result.session_id,
+          exit_code: 0,
+        });
+
+        await vi.waitFor(() => {
+          expect(detect_review_outcome).toHaveBeenCalled();
+        }, { timeout: 2000 });
+
+        // Default token from get_token() is "ghs_mock_token"
+        expect(detect_review_outcome).toHaveBeenCalledWith(
+          951,
+          "/tmp/test-repo",
+          "ghs_mock_token",
+        );
+      } finally {
+        log_spy.mockRestore();
+      }
+    });
+
+    it("falls back gracefully when post-review token resolution fails", async () => {
+      const { detect_review_outcome } = await import("../actions.js");
+      const log_spy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const error_spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      try {
+        const body = make_pr_payload("opened", 952, "test-org/lobster-farm");
+        const req = make_request(body, {
+          "x-github-event": "pull_request",
+          "x-hub-signature-256": sign_payload(body),
+        });
+        const res = make_response();
+        const ctx = make_context();
+
+        // First call succeeds (for spawn_review), subsequent calls fail (for post-review)
+        let call_count = 0;
+        (ctx.github_app.get_token as ReturnType<typeof vi.fn>).mockImplementation(() => {
+          call_count++;
+          if (call_count === 1) return Promise.resolve("ghs_mock_token");
+          return Promise.reject(new Error("token expired"));
+        });
+
+        await handle_github_webhook(req, res, ctx);
+
+        await vi.waitFor(() => {
+          expect((ctx.session_manager as any).spawn).toHaveBeenCalledTimes(1);
+        }, { timeout: 2000 });
+
+        // Simulate reviewer session completion
+        const spawn_result = await (ctx.session_manager as any).spawn.mock.results[0].value;
+        (ctx.session_manager as any).emit("session:completed", {
+          session_id: spawn_result.session_id,
+          exit_code: 0,
+        });
+
+        // Wait for detect_review_outcome — should still be called (with undefined token)
+        await vi.waitFor(() => {
+          expect(detect_review_outcome).toHaveBeenCalled();
+        }, { timeout: 2000 });
+
+        // Token should be undefined since resolution failed
+        expect(detect_review_outcome).toHaveBeenCalledWith(
+          952,
+          "/tmp/test-repo",
+          undefined,
+        );
+      } finally {
+        log_spy.mockRestore();
+        error_spy.mockRestore();
+      }
+    });
+  });
 });

--- a/packages/daemon/src/actions.ts
+++ b/packages/daemon/src/actions.ts
@@ -35,11 +35,13 @@ async function run(
   command: string,
   args: string[],
   cwd?: string,
+  env?: Record<string, string>,
 ): Promise<string> {
   const { stdout } = await exec(command, args, {
     cwd,
     timeout: 60_000,
     maxBuffer: 10 * 1024 * 1024,
+    ...(env ? { env: { ...process.env, ...env } } : {}),
   });
   return stdout.trim();
 }
@@ -374,18 +376,25 @@ export type ReviewOutcome = "approved" | "changes_requested" | "pending";
  * Detect the review outcome for a PR by querying GitHub.
  * Returns "approved", "changes_requested", or "pending".
  * An already-merged PR is treated as "approved".
+ *
+ * @param gh_token - Optional GitHub token for cross-account authentication.
+ *   Without this, `gh` inherits the daemon's default auth, which can't see
+ *   private repos on other GitHub accounts.
  */
 export async function detect_review_outcome(
   pr_number: number,
   repo_path: string,
+  gh_token?: string,
 ): Promise<ReviewOutcome> {
+  const env = gh_token ? { GH_TOKEN: gh_token } : undefined;
+
   try {
     // Check if PR is already merged
     const state = await run("gh", [
       "pr", "view", String(pr_number),
       "--json", "state",
       "--jq", ".state",
-    ], repo_path);
+    ], repo_path, env);
 
     if (state === "MERGED") {
       return "approved";
@@ -396,7 +405,7 @@ export async function detect_review_outcome(
       "pr", "view", String(pr_number),
       "--json", "reviewDecision",
       "--jq", ".reviewDecision",
-    ], repo_path);
+    ], repo_path, env);
 
     switch (decision.toUpperCase()) {
       case "APPROVED": return "approved";

--- a/packages/daemon/src/pr-cron.ts
+++ b/packages/daemon/src/pr-cron.ts
@@ -435,7 +435,7 @@ export class PRReviewCron {
         console.log(`[pr-cron] Review completed for PR #${String(pr.number)} in ${entity_id}`);
 
         // Persist completion so we don't re-review after restart
-        void this.persist_review_completion(entity_id, pr, repo_path)
+        void this.persist_review_completion(entity_id, pr, repo_path, entity_config)
           .catch(err => {
             console.error(`[pr-cron] Failed to persist review for PR #${String(pr.number)}: ${String(err)}`);
             sentry.captureException(err, {
@@ -475,9 +475,15 @@ export class PRReviewCron {
     entity_id: string,
     pr: OpenPR,
     repo_path: string,
+    entity_config: EntityConfig,
   ): Promise<void> {
     const key = `${entity_id}:${String(pr.number)}`;
-    const outcome = await detect_review_outcome(pr.number, repo_path);
+
+    // Resolve a token so detect_review_outcome and check_pr_merged can
+    // authenticate against the correct GitHub account (cross-account repos).
+    const gh_token = await this.resolve_entity_token(entity_config);
+
+    const outcome = await detect_review_outcome(pr.number, repo_path, gh_token);
 
     this.processed[key] = {
       entity_id,
@@ -489,7 +495,7 @@ export class PRReviewCron {
     console.log(`[pr-cron] Persisted review for PR #${String(pr.number)} (${outcome})`);
 
     // Route the outcome (alerts, fix spawning, etc.)
-    await this.handle_review_completion(entity_id, repo_path, pr, outcome);
+    await this.handle_review_completion(entity_id, repo_path, pr, outcome, gh_token);
   }
 
   /** After a reviewer session completes, detect the outcome and route accordingly. */
@@ -498,8 +504,9 @@ export class PRReviewCron {
     repo_path: string,
     pr: OpenPR,
     review_outcome?: "approved" | "changes_requested" | "pending",
+    gh_token?: string,
   ): Promise<void> {
-    const review_state = review_outcome ?? await detect_review_outcome(pr.number, repo_path);
+    const review_state = review_outcome ?? await detect_review_outcome(pr.number, repo_path, gh_token);
 
     // Determine if internal (our agents) or truly external
     const entity_config = this.registry.get(entity_id);
@@ -521,7 +528,7 @@ export class PRReviewCron {
       }
     } else if (review_state === "approved") {
       // Check if the reviewer already merged (they're instructed to merge on approval)
-      const is_merged = await this.check_pr_merged(repo_path, pr.number);
+      const is_merged = await this.check_pr_merged(repo_path, pr.number, gh_token);
 
       // Close linked issues after merge — GitHub Apps don't trigger auto-close
       if (is_merged) {
@@ -623,13 +630,20 @@ export class PRReviewCron {
   }
 
   /** Check if a PR has been merged. */
-  private async check_pr_merged(repo_path: string, pr_number: number): Promise<boolean> {
+  private async check_pr_merged(
+    repo_path: string,
+    pr_number: number,
+    gh_token?: string,
+  ): Promise<boolean> {
     try {
+      const env = gh_token
+        ? { ...process.env, GH_TOKEN: gh_token }
+        : process.env;
       const { stdout } = await exec(this.gh_bin, [
         "pr", "view", String(pr_number),
         "--json", "state",
         "--jq", ".state",
-      ], { cwd: repo_path, env: process.env, timeout: 15_000 });
+      ], { cwd: repo_path, env, timeout: 15_000 });
       return stdout.trim() === "MERGED";
     } catch {
       return false;

--- a/packages/daemon/src/webhook-handler.ts
+++ b/packages/daemon/src/webhook-handler.ts
@@ -388,7 +388,22 @@ async function handle_review_completion(
   installation_id?: string,
 ): Promise<void> {
   const key = review_key(entity_id, pr.number);
-  const outcome = await detect_review_outcome(pr.number, repo_path);
+
+  // Resolve a token so detect_review_outcome and check_pr_merged can
+  // authenticate against the correct GitHub account (cross-account repos).
+  let gh_token: string | undefined;
+  try {
+    gh_token = await resolve_token(ctx.github_app, installation_id);
+  } catch (err) {
+    console.error(`[webhook] Failed to get token for post-review: ${String(err)}`);
+    sentry.captureException(err, {
+      tags: { module: "webhook", entity: entity_id, action: "post_review_token" },
+      contexts: { pr: { number: pr.number, title: pr.title } },
+    });
+    // Fall through — detect_review_outcome will use daemon's default auth
+  }
+
+  const outcome = await detect_review_outcome(pr.number, repo_path, gh_token);
 
   console.log(
     `[webhook] Review completed for PR #${String(pr.number)} — outcome: ${outcome}`,
@@ -405,7 +420,7 @@ async function handle_review_completion(
     );
   } else if (outcome === "approved") {
     // Check if reviewer already merged
-    const is_merged = await check_pr_merged(repo_path, pr.number);
+    const is_merged = await check_pr_merged(repo_path, pr.number, gh_token);
     await notify_alerts(
       entity_id,
       `PR #${String(pr.number)}: ${pr.title} — ${is_merged ? "approved and merged" : "approved"}`,
@@ -631,13 +646,20 @@ async function notify_alerts(
   }
 }
 
-async function check_pr_merged(repo_path: string, pr_number: number): Promise<boolean> {
+async function check_pr_merged(
+  repo_path: string,
+  pr_number: number,
+  gh_token?: string,
+): Promise<boolean> {
   try {
+    const env = gh_token
+      ? { ...process.env, GH_TOKEN: gh_token }
+      : undefined;
     const { stdout } = await exec("gh", [
       "pr", "view", String(pr_number),
       "--json", "state",
       "--jq", ".state",
-    ], { cwd: repo_path, timeout: 15_000 });
+    ], { cwd: repo_path, timeout: 15_000, ...(env ? { env } : {}) });
     return stdout.trim() === "MERGED";
   } catch {
     return false;


### PR DESCRIPTION
## Summary

- **Bug**: `detect_review_outcome` and `check_pr_merged` in the daemon process called `gh` without a token, inheriting the daemon's default `ultim88888888` auth. For private repos on other GitHub accounts (e.g. `rg-jax`), the `gh` call failed silently, returning `"pending"`, and the fix loop never triggered.
- **Fix**: Thread the installation-specific `GH_TOKEN` through the post-review flow in `actions.ts`, `webhook-handler.ts`, and `pr-cron.ts` so all `gh` CLI calls authenticate against the correct GitHub account.
- **Tests**: Added tests verifying token threading through `detect_review_outcome` (with and without token), and end-to-end tests in `webhook-handler.test.ts` for the post-review completion flow including cross-account and fallback scenarios.

## Changes

| File | Change |
|------|--------|
| `actions.ts` | `run()` accepts optional `env`; `detect_review_outcome` accepts optional `gh_token` |
| `webhook-handler.ts` | `handle_review_completion` resolves token and passes to `detect_review_outcome` and `check_pr_merged` |
| `pr-cron.ts` | `persist_review_completion` threads entity token through `detect_review_outcome`, `handle_review_completion`, and `check_pr_merged` |
| `actions.test.ts` | 2 new tests: token threading and no-token default behavior |
| `webhook-handler.test.ts` | 3 new tests: installation token, default token, and token failure fallback |

## Test plan

- [x] All 649 daemon tests pass
- [x] All 57 shared tests pass
- [x] New tests verify GH_TOKEN appears in exec env when provided
- [x] New tests verify no env override when token is absent
- [x] New tests verify graceful fallback when post-review token resolution fails

Closes #169