### PR TITLE
fix: isolate pool test persistence to temp dirs

### DIFF
--- a/packages/daemon/src/__tests__/crash-recovery.test.ts
+++ b/packages/daemon/src/__tests__/crash-recovery.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it, beforeEach, vi } from "vitest";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
 import type { LobsterFarmConfig } from "@lobster-farm/shared";
 import { BotPool } from "../pool.js";
@@ -27,9 +30,12 @@ vi.mock("../sentry.js", () => ({
 
 // ── Test helpers ──
 
+let temp_dir: string;
+
 function make_config(): LobsterFarmConfig {
   return LobsterFarmConfigSchema.parse({
     user: { name: "Test" },
+    paths: { lobsterfarm_dir: temp_dir },
   });
 }
 
@@ -95,6 +101,7 @@ describe("crash recovery (issue #157)", () => {
   let mock_notify: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
+    temp_dir = await mkdtemp(join(tmpdir(), "crash-recovery-test-"));
     config = make_config();
     pool = new TestBotPool(config);
 
@@ -121,6 +128,11 @@ describe("crash recovery (issue #157)", () => {
     mock_is_tmux_alive = vi.spyOn(
       pool as unknown as Record<string, unknown>, "is_tmux_alive" as never,
     ).mockReturnValue(false) as unknown as ReturnType<typeof vi.fn>;
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(temp_dir, { recursive: true, force: true });
   });
 
   // ── Single crash → restart ──

--- a/packages/daemon/src/__tests__/fix-resume-persist.test.ts
+++ b/packages/daemon/src/__tests__/fix-resume-persist.test.ts
@@ -1,12 +1,18 @@
-import { describe, expect, it, beforeEach, vi } from "vitest";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
 import type { LobsterFarmConfig } from "@lobster-farm/shared";
 import { BotPool } from "../pool.js";
 import type { PoolBot } from "../pool.js";
 
+let temp_dir: string;
+
 function make_config(): LobsterFarmConfig {
   return LobsterFarmConfigSchema.parse({
     user: { name: "Test" },
+    paths: { lobsterfarm_dir: temp_dir },
   });
 }
 
@@ -76,9 +82,15 @@ describe("shutdown() persists state before killing tmux", () => {
   let config: LobsterFarmConfig;
   let pool: TestBotPool;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    temp_dir = await mkdtemp(join(tmpdir(), "fix-resume-persist-test-"));
     config = make_config();
     pool = new TestBotPool(config);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(temp_dir, { recursive: true, force: true });
   });
 
   it("calls persist() before killing any tmux sessions", async () => {
@@ -142,7 +154,8 @@ describe("check_assigned_health() drain guard", () => {
   let config: LobsterFarmConfig;
   let pool: TestBotPool;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    temp_dir = await mkdtemp(join(tmpdir(), "fix-resume-persist-test-"));
     config = make_config();
     pool = new TestBotPool(config);
 
@@ -153,6 +166,11 @@ describe("check_assigned_health() drain guard", () => {
       .mockReturnValue(false);
     vi.spyOn(pool as unknown as Record<string, unknown>, "persist" as never)
       .mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(temp_dir, { recursive: true, force: true });
   });
 
   it("returns early without modifying state when draining", async () => {

--- a/packages/daemon/src/__tests__/lazy-session-resume.test.ts
+++ b/packages/daemon/src/__tests__/lazy-session-resume.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it, beforeEach, vi } from "vitest";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
 import type { LobsterFarmConfig } from "@lobster-farm/shared";
 import { BotPool } from "../pool.js";
@@ -6,9 +9,12 @@ import type { PoolBot } from "../pool.js";
 
 // ── Test helpers ──
 
+let temp_dir: string;
+
 function make_config(): LobsterFarmConfig {
   return LobsterFarmConfigSchema.parse({
     user: { name: "Test" },
+    paths: { lobsterfarm_dir: temp_dir },
   });
 }
 
@@ -73,7 +79,8 @@ describe("lazy session resume (issue #72)", () => {
   let config: LobsterFarmConfig;
   let pool: TestBotPool;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    temp_dir = await mkdtemp(join(tmpdir(), "lazy-session-resume-test-"));
     config = make_config();
     pool = new TestBotPool(config);
 
@@ -101,6 +108,11 @@ describe("lazy session resume (issue #72)", () => {
               .tmux_alive_overrides.get(session_name) ?? false
           : false;
       });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(temp_dir, { recursive: true, force: true });
   });
 
   // ── is_session_alive() ──

--- a/packages/daemon/src/__tests__/pool-avatars.test.ts
+++ b/packages/daemon/src/__tests__/pool-avatars.test.ts
@@ -1,12 +1,18 @@
-import { describe, expect, it, beforeEach, vi } from "vitest";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
 import type { LobsterFarmConfig, ArchetypeRole } from "@lobster-farm/shared";
 import { BotPool, AVATAR_COOLDOWN_MS } from "../pool.js";
 import type { PoolBot, AvatarHandler } from "../pool.js";
 
+let temp_dir: string;
+
 function make_config(): LobsterFarmConfig {
   return LobsterFarmConfigSchema.parse({
     user: { name: "Test" },
+    paths: { lobsterfarm_dir: temp_dir },
   });
 }
 
@@ -52,7 +58,8 @@ describe("Pool bot avatar management", () => {
   let pool: TestBotPool;
   let avatar_handler: ReturnType<typeof vi.fn>;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    temp_dir = await mkdtemp(join(tmpdir(), "pool-avatars-test-"));
     config = make_config();
     pool = new TestBotPool(config);
 
@@ -75,6 +82,11 @@ describe("Pool bot avatar management", () => {
     // Register a spy avatar handler
     avatar_handler = vi.fn<AvatarHandler>().mockResolvedValue(undefined);
     pool.set_avatar_handler(avatar_handler);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(temp_dir, { recursive: true, force: true });
   });
 
   describe("avatar set on assign", () => {

--- a/packages/daemon/src/__tests__/pool.test.ts
+++ b/packages/daemon/src/__tests__/pool.test.ts
@@ -1,12 +1,18 @@
-import { describe, expect, it, beforeEach, vi } from "vitest";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
 import type { LobsterFarmConfig } from "@lobster-farm/shared";
 import { BotPool } from "../pool.js";
 import type { PoolBot } from "../pool.js";
 
+let temp_dir: string;
+
 function make_config(): LobsterFarmConfig {
   return LobsterFarmConfigSchema.parse({
     user: { name: "Test" },
+    paths: { lobsterfarm_dir: temp_dir },
   });
 }
 
@@ -71,7 +77,8 @@ describe("BotPool", () => {
   let config: LobsterFarmConfig;
   let pool: TestBotPool;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    temp_dir = await mkdtemp(join(tmpdir(), "pool-test-"));
     config = make_config();
     pool = new TestBotPool(config);
 
@@ -93,6 +100,11 @@ describe("BotPool", () => {
       .mockImplementation(async (bot: PoolBot) => {
         bot.state = "parked";
       });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(temp_dir, { recursive: true, force: true });
   });
 
   describe("compute_activity_state", () => {

--- a/packages/daemon/src/__tests__/resume-nudge.test.ts
+++ b/packages/daemon/src/__tests__/resume-nudge.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it, beforeEach, afterEach, vi, type Mock } from "vitest";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
 import type { LobsterFarmConfig } from "@lobster-farm/shared";
 import { BotPool } from "../pool.js";
@@ -34,9 +36,14 @@ import { execFileSync } from "node:child_process";
 
 // ── Test helpers ──
 
+// Use a static temp path per test run — mkdtemp is not mocked but we use a
+// unique-enough path since fs writes are already mocked in this file.
+let temp_dir: string;
+
 function make_config(): LobsterFarmConfig {
   return LobsterFarmConfigSchema.parse({
     user: { name: "Test" },
+    paths: { lobsterfarm_dir: temp_dir },
   });
 }
 
@@ -93,6 +100,10 @@ describe("resume nudge (issue #156)", () => {
     // Use fake timers so we can skip the readiness polling delays
     vi.useFakeTimers({ shouldAdvanceTime: true });
 
+    // Use a unique temp path to isolate config from production ~/.lobsterfarm.
+    // mkdtemp is not available here (fs mocked), but mkdir is also mocked so
+    // the directory doesn't need to actually exist — we just need a non-production path.
+    temp_dir = join(tmpdir(), `resume-nudge-test-${Date.now()}`);
     config = make_config();
     pool = new TestBotPool(config);
 


### PR DESCRIPTION
## Summary

- Six test files (`pool.test.ts`, `pool-avatars.test.ts`, `lazy-session-resume.test.ts`, `fix-resume-persist.test.ts`, `crash-recovery.test.ts`, `resume-nudge.test.ts`) were creating `BotPool` instances with configs that defaulted `paths.lobsterfarm_dir` to `~/.lobsterfarm`
- When `assign()` triggered `persist()`, test fixture data was written to the **production** `pool-state.json`, corrupting daemon state and causing orphan session kills on restart
- Each file now creates a unique temp directory in `beforeEach` and cleans it up in `afterEach`, following the pattern established in `pool-persistence.test.ts` and `session-history.test.ts`

## Test plan

- [x] All 5 modified test files with real fs (pool, pool-avatars, lazy-session-resume, fix-resume-persist, crash-recovery) pass: 91 tests, 0 failures
- [x] `resume-nudge.test.ts` has a pre-existing `vi.importActual` bun compatibility issue unrelated to this change
- [x] Full daemon test suite shows identical pass/fail counts vs main (490 pass, 76 fail — all failures pre-existing)

Closes #171

Generated with [Claude Code](https://claude.com/claude-code)