### PR TITLE
Remove stale work-log channel references from docs

### DIFF
--- a/config/claude/CLAUDE.md
+++ b/config/claude/CLAUDE.md
@@ -100,7 +100,6 @@ Always escalate to {{USER_NAME}} (via alerts channel) when:
 Everything not listed above: use your judgment and move fast.
 
 ### Communication
-- Post progress to the **work-log** channel during autonomous work
 - Post questions and approval requests to the **alerts** channel
 - Keep messages concise. No filler. Context + question + options if applicable.
 

--- a/config/claude/skills/discord-guideline/SKILL.md
+++ b/config/claude/skills/discord-guideline/SKILL.md
@@ -46,7 +46,6 @@ Entity scaffolding is also available via the `/scaffold` slash command in Discor
 Channel structure is defined by the entity's blueprint. For the `software` blueprint:
 - `#general` — entity discussion and coordination
 - `#work-room-1` through `#work-room-3` — feature workspaces
-- `#work-log` — agent activity feed
 - `#alerts` — approvals, blockers, questions
 
 ## discord.js Patterns
@@ -108,7 +107,7 @@ import { ChannelType } from "discord.js";
 ## Naming Conventions
 
 - Categories: `{Entity Name} [{entity-id}]` (e.g. "My SaaS [my-saas]")
-- Channels: lowercase, hyphenated (e.g. `work-room-1`, `work-log`)
+- Channels: lowercase, hyphenated (e.g. `work-room-1`, `alerts`)
 - Global category: `GLOBAL` (uppercase)
 - Webhooks: `LobsterFarm Agent` (shared per channel, agents differentiate via username)
 

--- a/docs/guide/index.html
+++ b/docs/guide/index.html
@@ -1328,8 +1328,6 @@ review: [<span class="str">"review-guideline"</span>]        <span class="cm">//
         <span class="key">id</span>: <span class="str">"..."</span>
       - <span class="key">type</span>: <span class="str">work_room</span>
         <span class="key">id</span>: <span class="str">"..."</span>
-      - <span class="key">type</span>: <span class="str">work_log</span>      <span class="cm"># Activity feed</span>
-        <span class="key">id</span>: <span class="str">"..."</span>
       - <span class="key">type</span>: <span class="str">alerts</span>        <span class="cm"># Approvals, questions</span>
         <span class="key">id</span>: <span class="str">"..."</span>
 
@@ -1344,13 +1342,12 @@ review: [<span class="str">"review-guideline"</span>]        <span class="cm">//
   </details>
 
   <h3>Discord channel structure</h3>
-  <p>Each entity gets a Discord category with five channels:</p>
+  <p>Each entity gets a Discord category with these channels:</p>
   <table>
     <thead><tr><th>Channel</th><th>Type</th><th>Purpose</th></tr></thead>
     <tbody>
       <tr><td><code>#general</code></td><td>general</td><td>Discovery, planning, coordination with the Planner</td></tr>
       <tr><td><code>#work-room-1/2/3</code></td><td>work_room</td><td>Feature workspaces -- one agent at a time, interactive sessions</td></tr>
-      <tr><td><code>#work-log</code></td><td>work_log</td><td>Agent activity feed -- progress updates, session starts/stops</td></tr>
       <tr><td><code>#alerts</code></td><td>alerts</td><td>Approvals, blockers, escalations that need human attention</td></tr>
     </tbody>
   </table>

--- a/docs/lobsterfarm-architecture-v0.3.md
+++ b/docs/lobsterfarm-architecture-v0.3.md
@@ -385,7 +385,6 @@ entity:
       work_room_1: { id: "...", purpose: "Feature workspace", assigned_feature: null }
       work_room_2: { id: "...", purpose: "Feature workspace", assigned_feature: null }
       work_room_3: { id: "...", purpose: "Feature workspace", assigned_feature: null }
-      work_log: { id: "...", purpose: "Agent activity feed" }
       alerts: { id: "...", purpose: "Approvals, blockers, questions" }
 
   agent_mode: "hybrid"  # dedicated | generalist | hybrid
@@ -464,9 +463,6 @@ phases:
           labels: ["planning", "entity:{entity.id}"]
       - assign-work-room:
           entity: "{entity.id}"
-      - notify:
-          channel: work_log
-          message: "Planning started: {feature.title}"
     agent:
       archetype: gary
       dna: [planning-dna]
@@ -489,9 +485,6 @@ phases:
       - create-worktree:
           branch: "feature/{feature.github_issue}-{feature.slug}"
       - compile-context
-      - notify:
-          channel: work_log
-          message: "Design phase started: #{feature.github_issue}"
     agent:
       archetype: pearl
       dna: [design-dna, coding-dna]
@@ -599,22 +592,16 @@ The build phase supports asynchronous collaboration:
 ```
 You (work-room-1, 9:00am): "Build the candlestick chart. Spec in #42."
 
-Agent (work-log): "Starting #42. Reading spec, creating worktree."
-Agent (work-log): "Setting up component structure."
-
-Agent (alerts, 9:15am): "Question on #42: Should indicators be
-  pluggable or fixed set? Affects module architecture."
+Agent (alerts, 9:15am): "Starting #42. Reading spec, creating worktree.
+  Question: Should indicators be pluggable or fixed set? Affects module architecture."
 
 [You respond when available — minutes or hours]
 
 You (alerts, 10:30am): "Pluggable. Register functions that receive
   OHLCV, return overlay data."
 
-Agent (work-log): "Implementing plugin architecture."
-Agent (work-log): "Complete. 12 tests, 94% coverage."
-
-Agent (alerts, 11:00am): "Build done for #42. Preview at localhost:3001.
-  Ready for review?"
+Agent (alerts, 11:00am): "Build done for #42. 12 tests, 94% coverage.
+  Preview at localhost:3001. Ready for review?"
 ```
 
 This works because: worktree persists state, GitHub issue tracks spec, MEMORY.md provides context if session expires, daemon tracks phase and can resume.
@@ -651,7 +638,6 @@ LobsterFarm (Server)
 │   ├── #work-room-1         # Feature workspace (dynamically assigned)
 │   ├── #work-room-2         # Feature workspace
 │   ├── #work-room-3         # Feature workspace
-│   ├── #work-log            # Agent activity feed (all features)
 │   └── #alerts              # Approvals, blockers, questions from agents
 │
 ├── ENTITY: SaaS Product [beta]
@@ -930,7 +916,7 @@ Worktrees:
 - [ ] Test Peekaboo integration (install, permissions, basic automation)
 - [ ] Write context compilation script (entity memory → worktree CLAUDE.md)
 - [ ] Write memory extraction stop hook script
-- [ ] Set up Discord server (entity category + 3 work rooms + work-log + alerts)
+- [ ] Set up Discord server (entity category + 3 work rooms + alerts)
 - [ ] Manual feature lifecycle: plan in Discord → build in worktree → PR → review → merge
 - [ ] Test session resume for feature continuity
 
@@ -1017,7 +1003,6 @@ Worktrees:
 | Model + think config | Tier | opus-high, sonnet-standard |
 | Discord entity channel | General | #general |
 | Discord feature workspace | Work Room | #work-room-1 |
-| Agent activity feed | Work Log | #work-log |
 | Human attention needed | Alerts | #alerts |
 
 ---

--- a/docs/memory/project_design_decisions.md
+++ b/docs/memory/project_design_decisions.md
@@ -69,8 +69,6 @@ Pool bots are assigned/released as features enter/leave rooms.
 
 **#alerts** — notification inbox. Errors, cross-room pings, entity-level notifications. Not for conversation — go to the work room for that.
 
-**#work-log** — read-only activity feed.
-
 ## Feature Lifecycle (Revised)
 
 **Planning happens in Discord, not headless.** The GitHub issue is the OUTPUT of planning, not the input. You riff with Gary in #general or a work room. Gary does socratic discovery, creates the issue when the spec is ready, posts it in the work room. You approve in Discord.


### PR DESCRIPTION
## Summary

- Removed all `#work-log` references from agent-facing documentation files
- The channel was removed from entity scaffolding but docs still directed agents to post there
- Updated the interactive build example in the architecture spec to route messages through `#alerts` instead
- Also caught references in `docs/guide/index.html` and naming convention examples

## Files changed

- `config/claude/CLAUDE.md` -- removed work-log line from Communication section
- `config/claude/skills/discord-guideline/SKILL.md` -- removed from channel list and naming example
- `docs/lobsterfarm-architecture-v0.3.md` -- removed from channel structures, YAML examples, SOP notify steps, interactive build example, TODO checklist, and glossary table
- `docs/memory/project_design_decisions.md` -- removed from channel ownership section
- `docs/guide/index.html` -- removed from config example and channel table
- `~/.lobsterfarm/CLAUDE.md` -- removed from per-entity channel listing (not in repo, edited directly)

## Test plan

- [ ] Verify no remaining `work-log` or `work_log` references in documentation files
- [ ] Confirm source code files (enums, constants, router, actions) were not touched

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)