### PR TITLE
chore: remove (LobsterFarm) suffix from git author names

### DIFF
--- a/packages/daemon/src/commander-process.ts
+++ b/packages/daemon/src/commander-process.ts
@@ -128,16 +128,16 @@ export class CommanderProcess extends EventEmitter {
       "new-session", "-d",
       "-s", TMUX_SESSION,
       "-x", "200", "-y", "50",
-      `DISCORD_STATE_DIR=${sq(this.state_dir())} GIT_AUTHOR_NAME=${sq("Pat (LobsterFarm)")} GIT_AUTHOR_EMAIL=${sq("pat@lobsterfarm.dev")} GIT_COMMITTER_NAME=${sq("Pat (LobsterFarm)")} GIT_COMMITTER_EMAIL=${sq("pat@lobsterfarm.dev")} ${claude_cmd}`,
+      `DISCORD_STATE_DIR=${sq(this.state_dir())} GIT_AUTHOR_NAME=${sq("Pat")} GIT_AUTHOR_EMAIL=${sq("pat@lobsterfarm.dev")} GIT_COMMITTER_NAME=${sq("Pat")} GIT_COMMITTER_EMAIL=${sq("pat@lobsterfarm.dev")} ${claude_cmd}`,
     ], {
       cwd: working_dir,
       stdio: "ignore",
       env: {
         ...process.env,
         DISCORD_STATE_DIR: this.state_dir(),
-        GIT_AUTHOR_NAME: "Pat (LobsterFarm)",
+        GIT_AUTHOR_NAME: "Pat",
         GIT_AUTHOR_EMAIL: "pat@lobsterfarm.dev",
-        GIT_COMMITTER_NAME: "Pat (LobsterFarm)",
+        GIT_COMMITTER_NAME: "Pat",
         GIT_COMMITTER_EMAIL: "pat@lobsterfarm.dev",
       },
     });

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -1503,7 +1503,7 @@ export class BotPool extends EventEmitter {
     // naturally via CLAUDE.md, skills, and entity memory in the working directory.
 
     const display_name = resolve_agent_display_name(archetype, this.config);
-    const git_env = `GIT_AUTHOR_NAME=${sq(`${display_name} (LobsterFarm)`)} GIT_AUTHOR_EMAIL=${sq(`${agent_name}@lobsterfarm.dev`)} GIT_COMMITTER_NAME=${sq(`${display_name} (LobsterFarm)`)} GIT_COMMITTER_EMAIL=${sq(`${agent_name}@lobsterfarm.dev`)}`;
+    const git_env = `GIT_AUTHOR_NAME=${sq(display_name)} GIT_AUTHOR_EMAIL=${sq(`${agent_name}@lobsterfarm.dev`)} GIT_COMMITTER_NAME=${sq(display_name)} GIT_COMMITTER_EMAIL=${sq(`${agent_name}@lobsterfarm.dev`)}`;
 
     // Build extra env var prefix for the tmux command string (e.g., GH_TOKEN=...)
     const extra_env_str = Object.entries(extra_env)
@@ -1526,9 +1526,9 @@ export class BotPool extends EventEmitter {
           ...process.env,
           ...extra_env,
           DISCORD_STATE_DIR: bot.state_dir,
-          GIT_AUTHOR_NAME: `${display_name} (LobsterFarm)`,
+          GIT_AUTHOR_NAME: display_name,
           GIT_AUTHOR_EMAIL: `${agent_name}@lobsterfarm.dev`,
-          GIT_COMMITTER_NAME: `${display_name} (LobsterFarm)`,
+          GIT_COMMITTER_NAME: display_name,
           GIT_COMMITTER_EMAIL: `${agent_name}@lobsterfarm.dev`,
         },
       });


### PR DESCRIPTION
## Summary
- Removes the `(LobsterFarm)` suffix from `GIT_AUTHOR_NAME` and `GIT_COMMITTER_NAME` for pool bots and commander
- Commits will now show as "Gary", "Bob", "Pat" etc. instead of "Gary (LobsterFarm)"
- The `@lobsterfarm.dev` email suffix already identifies the origin

## Files changed
- `packages/daemon/src/pool.ts` — pool bot git env (tmux string + spawn env)
- `packages/daemon/src/commander-process.ts` — Pat's git env

## Test plan
- [ ] Verify build passes
- [ ] Next commit by any agent should show clean name without suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)