### PR TITLE
fix: rebuild channel map on /reload

### DIFF
--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -369,6 +369,9 @@ const handle_scaffold_entity: RouteHandler = async (req, res, ctx) => {
 const handle_reload: RouteHandler = async (_req, res, ctx) => {
   try {
     await ctx.registry.load_all();
+    if (ctx.discord) {
+      ctx.discord.build_channel_map();
+    }
     json_response(res, 200, {
       ok: true,
       entities: ctx.registry.count(),


### PR DESCRIPTION
## Summary
- `/reload` reloads the entity registry but wasn't rebuilding the Discord channel map
- Newly scaffolded entities whose configs get channel IDs written back after scaffold had unmapped channels until daemon restart
- Adds `build_channel_map()` call after `load_all()` in the reload handler — same pattern used in `handle_channel_delete`

Closes #0

## Test plan
- [ ] Scaffold a new entity, update config with channel IDs, call `/reload` — verify channel map includes new entity
- [ ] Send a message in the new entity's #general — verify auto-assignment fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)