### PR TITLE
fix: include pool status in /status endpoint response

### DIFF
--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -83,6 +83,7 @@ const handle_status: RouteHandler = (_req, res, ctx) => {
       })),
     },
     queue: queue_stats,
+    pool: ctx.pool?.get_status() ?? null,
     commander: ctx.commander?.health_check() ?? { state: "not_configured" },
     github_app: ctx.github_app ? "configured" : "not_configured",
   });


### PR DESCRIPTION
## Summary

- Wire `pool.get_status()` into the `/status` endpoint response so operators can see pool bot activity (assigned/free/parked counts and per-bot assignment details) alongside session and queue data.
- The pool data was already available via the dedicated `/pool` endpoint but missing from the unified `/status` view, causing it to report 0 active sessions when only pool bots were running.

Closes #179

## Test plan

- [ ] `curl localhost:7749/status` returns a `pool` field with `total`, `free`, `assigned`, `parked`, and `assignments`
- [ ] When pool is not initialized (e.g., no Discord), `pool` field is `null`
- [ ] Existing pool tests pass (62/62 verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)