### PR TITLE
feat: auto-rebase PRs when squash merge fails due to branch divergence

### DIFF
--- a/packages/daemon/src/__tests__/auto-rebase.test.ts
+++ b/packages/daemon/src/__tests__/auto-rebase.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Tests for attempt_auto_merge() — the auto-rebase merge recovery function.
+ *
+ * Mocks all external commands (gh, git, mktemp) to test the decision logic
+ * without touching real repos or the GitHub API.
+ *
+ * Uses a dynamic import pattern: the mock factory installs a stub execFile
+ * with the custom promisify symbol. Per-test routing is configured via a
+ * module-level variable that the promisified function reads at call time.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Command routing ──
+
+type ExecRoute = (
+  args: string[],
+  opts: Record<string, unknown>,
+) => { stdout: string; stderr?: string } | Error;
+
+/**
+ * Module-level route map, updated per-test via route_exec().
+ * The mock reads this at call time (not at hoist time).
+ */
+const routes: Record<string, ExecRoute> = {};
+
+function find_route_key(
+  cmd: string,
+  args: string[],
+): string | null {
+  const tokens = [cmd, ...args.slice(0, 3)];
+  for (let len = tokens.length; len > 0; len--) {
+    const candidate = tokens.slice(0, len).join(" ");
+    if (routes[candidate] !== undefined) return candidate;
+  }
+  return null;
+}
+
+/**
+ * Set up routing for execFile calls in the current test.
+ * Each key is matched against "cmd args[0] args[1] ..." (progressively shorter).
+ * Handlers return { stdout } on success or an Error on failure.
+ */
+function route_exec(new_routes: Record<string, ExecRoute>): void {
+  // Clear previous routes
+  for (const key of Object.keys(routes)) delete routes[key];
+  Object.assign(routes, new_routes);
+}
+
+// ── Mock node:child_process ──
+//
+// vi.mock is hoisted, so the factory cannot reference variables declared after it.
+// Instead, we rely on the routes object (declared above the factory) and the
+// util.promisify.custom symbol to make promisify(execFile) return our async handler.
+
+vi.mock("node:child_process", async () => {
+  const { promisify } = await import("node:util");
+
+  // The async handler that routes calls through the `routes` map
+  const promisified = async (
+    cmd: string,
+    args: string[],
+    opts: Record<string, unknown> = {},
+  ): Promise<{ stdout: string; stderr: string }> => {
+    const key = find_route_key(cmd, args);
+    if (!key) {
+      throw new Error(`Unmocked command: ${cmd} ${args.join(" ")}`);
+    }
+    const result = routes[key]!(args, opts);
+    if (result instanceof Error) throw result;
+    return { stdout: result.stdout, stderr: result.stderr ?? "" };
+  };
+
+  // Build a callback-style stub with the custom promisify symbol
+  const stub = (..._args: unknown[]) => {
+    // Shouldn't be called directly (review-utils uses promisify), but handle it
+    throw new Error("execFile mock: use promisify, not direct calls");
+  };
+  (stub as unknown as Record<symbol, unknown>)[promisify.custom] = promisified;
+
+  return { execFile: stub };
+});
+
+import { attempt_auto_merge } from "../review-utils.js";
+
+// ── Tests ──
+
+describe("attempt_auto_merge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    // Clear routes — each test must set its own
+    for (const key of Object.keys(routes)) delete routes[key];
+  });
+
+  it("returns merged: true with method 'direct' when first merge succeeds", async () => {
+    route_exec({
+      "gh pr merge": () => ({ stdout: "" }),
+    });
+
+    const result = await attempt_auto_merge(42, "feature/test", "/repo", "gh");
+    expect(result).toEqual({ merged: true, method: "direct" });
+  });
+
+  it("tries update-branch API when direct merge fails", async () => {
+    let update_branch_called = false;
+    let merge_count = 0;
+
+    route_exec({
+      "gh pr merge": () => {
+        merge_count++;
+        if (merge_count === 1) return new Error("Pull request is not mergeable");
+        return { stdout: "" };
+      },
+      "gh repo view": () => ({ stdout: "test-org/test-repo" }),
+      "gh api": (args) => {
+        if (args.some(a => a.includes("update-branch"))) {
+          update_branch_called = true;
+          return { stdout: "" };
+        }
+        return new Error("unknown api call");
+      },
+      "gh pr view": () => ({ stdout: "MERGEABLE" }),
+    });
+
+    const result = await attempt_auto_merge(42, "feature/test", "/repo", "gh");
+
+    expect(update_branch_called).toBe(true);
+    expect(result).toEqual({ merged: true, method: "update-branch" });
+  });
+
+  it("attempts local rebase when update-branch API fails", async () => {
+    let rebase_attempted = false;
+    let merge_count = 0;
+
+    route_exec({
+      "gh pr merge": () => {
+        merge_count++;
+        // First attempt (direct) fails; second attempt (after rebase) succeeds
+        if (merge_count === 1) return new Error("Pull request is not mergeable");
+        return { stdout: "" };
+      },
+      "gh repo view": () => ({ stdout: "test-org/test-repo" }),
+      "gh api": () => new Error("Merge conflict"),
+      "gh pr view": () => ({ stdout: "MERGEABLE" }),
+      "mktemp": () => ({ stdout: "/tmp/test-rebase-dir" }),
+      "git remote": () => ({ stdout: "https://github.com/test/repo.git" }),
+      "git clone": () => ({ stdout: "" }),
+      "git fetch": () => ({ stdout: "" }),
+      "git rebase": (args) => {
+        if (args.includes("--abort")) return { stdout: "" };
+        rebase_attempted = true;
+        return { stdout: "" };
+      },
+      "git push": () => ({ stdout: "" }),
+      "rm": () => ({ stdout: "" }),
+    });
+
+    const result = await attempt_auto_merge(42, "feature/test", "/repo", "gh");
+
+    expect(rebase_attempted).toBe(true);
+    expect(result).toEqual({ merged: true, method: "local-rebase" });
+  });
+
+  it("returns error when rebase has conflicts and aborts cleanly", async () => {
+    let rebase_abort_called = false;
+
+    route_exec({
+      "gh pr merge": () => new Error("Pull request is not mergeable"),
+      "gh repo view": () => ({ stdout: "test-org/test-repo" }),
+      "gh api": () => new Error("Merge conflict"),
+      "gh pr view": () => ({ stdout: "CONFLICTING" }),
+      "mktemp": () => ({ stdout: "/tmp/test-rebase-dir" }),
+      "git remote": () => ({ stdout: "https://github.com/test/repo.git" }),
+      "git clone": () => ({ stdout: "" }),
+      "git fetch": () => ({ stdout: "" }),
+      "git rebase": (args) => {
+        if (args.includes("--abort")) {
+          rebase_abort_called = true;
+          return { stdout: "" };
+        }
+        return new Error("CONFLICT (content): Merge conflict in file.ts");
+      },
+      "rm": () => ({ stdout: "" }),
+    });
+
+    const result = await attempt_auto_merge(42, "feature/test", "/repo", "gh");
+
+    expect(result.merged).toBe(false);
+    expect(result.error).toContain("Rebase conflicts require manual resolution");
+    expect(rebase_abort_called).toBe(true);
+  });
+
+  it("does not attempt update-branch or rebase when direct merge succeeds", async () => {
+    let update_branch_called = false;
+    let rebase_called = false;
+
+    route_exec({
+      "gh pr merge": () => ({ stdout: "" }),
+      "gh api": () => {
+        update_branch_called = true;
+        return { stdout: "" };
+      },
+      "git rebase": () => {
+        rebase_called = true;
+        return { stdout: "" };
+      },
+    });
+
+    const result = await attempt_auto_merge(42, "feature/test", "/repo", "gh");
+
+    expect(result).toEqual({ merged: true, method: "direct" });
+    expect(update_branch_called).toBe(false);
+    expect(rebase_called).toBe(false);
+  });
+
+  it("returns error when repo nwo cannot be determined", async () => {
+    route_exec({
+      "gh pr merge": () => new Error("Pull request is not mergeable"),
+      "gh repo view": () => new Error("not a git repository"),
+    });
+
+    const result = await attempt_auto_merge(42, "feature/test", "/repo", "gh");
+
+    expect(result.merged).toBe(false);
+    expect(result.error).toContain("Could not determine repo owner/name");
+  });
+
+  it("passes gh_token through via env", async () => {
+    let captured_env: Record<string, unknown> | undefined;
+
+    route_exec({
+      "gh pr merge": (_args, opts) => {
+        captured_env = opts.env as Record<string, unknown>;
+        return { stdout: "" };
+      },
+    });
+
+    await attempt_auto_merge(42, "feature/test", "/repo", "gh", "ghs_test_token_123");
+
+    expect(captured_env).toBeDefined();
+    expect(captured_env!["GH_TOKEN"]).toBe("ghs_test_token_123");
+  });
+
+  it("cleans up temp directory even when rebase fails", async () => {
+    let rm_args: string[] | undefined;
+
+    route_exec({
+      "gh pr merge": () => new Error("not mergeable"),
+      "gh repo view": () => ({ stdout: "test-org/test-repo" }),
+      "gh api": () => new Error("Merge conflict"),
+      "gh pr view": () => ({ stdout: "CONFLICTING" }),
+      "git remote": () => ({ stdout: "https://github.com/test/repo.git" }),
+      "mktemp": () => ({ stdout: "/tmp/auto-rebase-test-42" }),
+      "git clone": () => ({ stdout: "" }),
+      "git fetch": () => ({ stdout: "" }),
+      "git rebase": (args) => {
+        if (args.includes("--abort")) return { stdout: "" };
+        return new Error("CONFLICT");
+      },
+      "rm": (args) => {
+        rm_args = args;
+        return { stdout: "" };
+      },
+    });
+
+    await attempt_auto_merge(42, "feature/test", "/repo", "gh");
+
+    expect(rm_args).toBeDefined();
+    expect(rm_args).toContain("/tmp/auto-rebase-test-42");
+  });
+
+  it("falls through to local rebase when update-branch succeeds but merge still fails", async () => {
+    let merge_count = 0;
+    let rebase_attempted = false;
+
+    route_exec({
+      "gh pr merge": () => {
+        merge_count++;
+        if (merge_count <= 2) return new Error("not mergeable");
+        return { stdout: "" };
+      },
+      "gh repo view": () => ({ stdout: "test-org/test-repo" }),
+      "gh api": () => ({ stdout: "" }), // update-branch succeeds
+      "gh pr view": () => ({ stdout: "MERGEABLE" }),
+      "mktemp": () => ({ stdout: "/tmp/test-dir" }),
+      "git remote": () => ({ stdout: "https://github.com/test/repo.git" }),
+      "git clone": () => ({ stdout: "" }),
+      "git fetch": () => ({ stdout: "" }),
+      "git rebase": (args) => {
+        if (args.includes("--abort")) return { stdout: "" };
+        rebase_attempted = true;
+        return { stdout: "" };
+      },
+      "git push": () => ({ stdout: "" }),
+      "rm": () => ({ stdout: "" }),
+    });
+
+    const result = await attempt_auto_merge(42, "feature/test", "/repo", "gh");
+
+    expect(rebase_attempted).toBe(true);
+    expect(result).toEqual({ merged: true, method: "local-rebase" });
+  });
+});

--- a/packages/daemon/src/__tests__/webhook-handler.test.ts
+++ b/packages/daemon/src/__tests__/webhook-handler.test.ts
@@ -33,6 +33,7 @@ vi.mock("../review-utils.js", () => ({
   fetch_review_comments: vi.fn(async () => []),
   build_review_fix_prompt: vi.fn(() => "fix prompt"),
   check_merge_conflicts: vi.fn(async () => false),
+  attempt_auto_merge: vi.fn(async () => ({ merged: true, method: "direct" })),
 }));
 
 // Mock issue-utils — default: no linked issues

--- a/packages/daemon/src/pr-cron.ts
+++ b/packages/daemon/src/pr-cron.ts
@@ -7,7 +7,7 @@ import type { EntityRegistry } from "./registry.js";
 import type { ClaudeSessionManager } from "./session.js";
 import type { DiscordBot } from "./discord.js";
 import type { GitHubAppAuth } from "./github-app.js";
-import { fetch_review_comments, build_review_fix_prompt } from "./review-utils.js";
+import { fetch_review_comments, build_review_fix_prompt, attempt_auto_merge } from "./review-utils.js";
 import { detect_review_outcome } from "./actions.js";
 import { load_pr_reviews, save_pr_reviews } from "./persistence.js";
 import type { PRReviewState } from "./persistence.js";
@@ -391,6 +391,11 @@ export class PRReviewCron {
       `After posting your review:`,
       `- If you approved, merge the PR:`,
       `  gh pr merge ${String(pr.number)} --squash --delete-branch`,
+      `- If the merge command fails (branch behind main):`,
+      `  1. Try: git fetch origin && git checkout ${pr.headRefName} && git rebase origin/main`,
+      `  2. If rebase is clean (no conflicts): git push --force-with-lease origin ${pr.headRefName}`,
+      `  3. Then retry: gh pr merge ${String(pr.number)} --squash --delete-branch`,
+      `  4. If rebase has conflicts: git rebase --abort — do NOT force push conflict markers`,
       `- If you requested changes, do NOT merge.`,
     ];
 
@@ -528,23 +533,41 @@ export class PRReviewCron {
       }
     } else if (review_state === "approved") {
       // Check if the reviewer already merged (they're instructed to merge on approval)
-      const is_merged = await this.check_pr_merged(repo_path, pr.number, gh_token);
+      let is_merged = await this.check_pr_merged(repo_path, pr.number, gh_token);
 
-      // Close linked issues after merge — GitHub Apps don't trigger auto-close
       if (is_merged) {
+        // Reviewer merged — close linked issues and notify
         await this.close_issues_for_merged_pr(entity_id, repo_path, pr, entity_config);
-      }
 
-      if (is_internal) {
-        await this.notify_alerts(
-          entity_id,
-          `PR #${String(pr.number)}: ${pr.title} — ${is_merged ? "approved and merged to main" : "approved, awaiting merge"}`,
+        if (is_internal) {
+          await this.notify_alerts(
+            entity_id,
+            `PR #${String(pr.number)}: ${pr.title} — approved and merged to main`,
+          );
+        } else {
+          await this.notify_alerts(
+            entity_id,
+            `External PR #${String(pr.number)} from @${pr.author.login}: ${pr.title} — approved and merged to main`,
+          );
+        }
+      } else if (is_internal) {
+        // Internal PR not yet merged — attempt auto-merge with rebase (#166)
+        const result = await attempt_auto_merge(
+          pr.number, pr.headRefName, repo_path, this.gh_bin, gh_token,
         );
-      } else if (is_merged) {
-        await this.notify_alerts(
-          entity_id,
-          `External PR #${String(pr.number)} from @${pr.author.login}: ${pr.title} — approved and merged to main`,
-        );
+
+        if (result.merged) {
+          await this.close_issues_for_merged_pr(entity_id, repo_path, pr, entity_config);
+          await this.notify_alerts(
+            entity_id,
+            `PR #${String(pr.number)}: ${pr.title} — approved, auto-rebased (${result.method}), and merged to main`,
+          );
+        } else {
+          await this.notify_alerts(
+            entity_id,
+            `PR #${String(pr.number)}: ${pr.title} — approved but merge failed after rebase attempt. ${result.error ?? "Manual intervention needed."}`,
+          );
+        }
       } else {
         // External, not yet merged — escalate to human
         await this.notify_alerts(

--- a/packages/daemon/src/review-utils.ts
+++ b/packages/daemon/src/review-utils.ts
@@ -1,10 +1,11 @@
 /**
- * Utility functions for PR review feedback.
+ * Utility functions for PR review feedback and auto-merge with rebase.
  *
  * Used by both webhook-handler.ts and pr-cron.ts to fetch reviewer
  * comments and build fix prompts for the auto-fix loop.
  *
  * Extracted from features.ts during feature lifecycle removal (#100).
+ * Auto-merge with rebase added in #166.
  */
 
 import { execFile } from "node:child_process";
@@ -98,4 +99,265 @@ export function build_review_fix_prompt(
   );
 
   return lines.join("\n");
+}
+
+// ── Auto-merge with rebase (#166) ──
+
+export interface AutoMergeResult {
+  merged: boolean;
+  method?: "direct" | "update-branch" | "local-rebase";
+  error?: string;
+}
+
+/** How long to wait for GitHub to recompute mergeable state after an update. */
+const MERGEABLE_POLL_TIMEOUT_MS = 30_000;
+const MERGEABLE_POLL_INTERVAL_MS = 5_000;
+
+/**
+ * Attempt to merge an approved PR, rebasing if necessary.
+ * Returns { merged: true } if merge succeeded, { merged: false } if manual intervention needed.
+ *
+ * Strategy (in order):
+ * 1. Try direct merge (maybe reviewer hit a transient error)
+ * 2. If that fails: try GitHub's update-branch API (merge-update from base)
+ * 3. If update-branch fails: attempt local git rebase in a temp dir
+ * 4. If rebase has real conflicts: give up, return false
+ */
+export async function attempt_auto_merge(
+  pr_number: number,
+  branch: string,
+  repo_path: string,
+  gh_bin: string = "gh",
+  gh_token?: string,
+): Promise<AutoMergeResult> {
+  const pr = String(pr_number);
+  const env = gh_token
+    ? { ...process.env, GH_TOKEN: gh_token }
+    : process.env;
+  const exec_opts = { cwd: repo_path, env, timeout: 30_000 };
+
+  // Step 1: Direct merge retry
+  try {
+    await exec_async(gh_bin, [
+      "pr", "merge", pr, "--squash", "--delete-branch",
+    ], exec_opts);
+    return { merged: true, method: "direct" };
+  } catch (err) {
+    console.log(
+      `[auto-merge] Direct merge failed for PR #${pr}: ${String(err instanceof Error ? err.message : err)}`,
+    );
+  }
+
+  // Step 2: GitHub API update-branch (merge-update, not rebase)
+  // Derive owner/repo from the git remote
+  const nwo = await get_repo_nwo(repo_path, gh_bin, env);
+  if (!nwo) {
+    return { merged: false, error: "Could not determine repo owner/name from remote" };
+  }
+
+  const update_branch_ok = await try_update_branch(nwo, pr_number, gh_bin, env);
+
+  if (update_branch_ok) {
+    // Wait for GitHub to recompute mergeable state, then retry merge
+    const mergeable = await poll_mergeable(pr_number, repo_path, gh_bin, env);
+    if (mergeable) {
+      try {
+        await exec_async(gh_bin, [
+          "pr", "merge", pr, "--squash", "--delete-branch",
+        ], exec_opts);
+        return { merged: true, method: "update-branch" };
+      } catch (err) {
+        console.log(
+          `[auto-merge] Merge after update-branch failed for PR #${pr}: ${String(err instanceof Error ? err.message : err)}`,
+        );
+      }
+    }
+  }
+
+  // Step 3: Local git rebase fallback
+  const rebase_result = await try_local_rebase(branch, repo_path, env);
+  if (rebase_result.success) {
+    // Wait for GitHub to process the force-push, then merge
+    const mergeable = await poll_mergeable(pr_number, repo_path, gh_bin, env);
+    if (mergeable) {
+      try {
+        await exec_async(gh_bin, [
+          "pr", "merge", pr, "--squash", "--delete-branch",
+        ], exec_opts);
+        return { merged: true, method: "local-rebase" };
+      } catch (err) {
+        return {
+          merged: false,
+          error: `Rebase succeeded but merge still failed: ${String(err instanceof Error ? err.message : err)}`,
+        };
+      }
+    }
+    return { merged: false, error: "Rebase succeeded but PR not mergeable after update" };
+  }
+
+  return { merged: false, error: rebase_result.error };
+}
+
+/**
+ * Get the repo owner/name (e.g. "org/repo") from the git remote.
+ * Tries `gh repo view --json nameWithOwner` first.
+ */
+async function get_repo_nwo(
+  repo_path: string,
+  gh_bin: string,
+  env: NodeJS.ProcessEnv,
+): Promise<string | null> {
+  try {
+    const { stdout } = await exec_async(gh_bin, [
+      "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner",
+    ], { cwd: repo_path, env, timeout: 15_000 });
+    const nwo = stdout.trim();
+    return nwo || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Try the GitHub API update-branch endpoint.
+ * Returns true if the API call succeeded (branch was updated).
+ */
+async function try_update_branch(
+  nwo: string,
+  pr_number: number,
+  gh_bin: string,
+  env: NodeJS.ProcessEnv,
+): Promise<boolean> {
+  try {
+    await exec_async(gh_bin, [
+      "api", `repos/${nwo}/pulls/${String(pr_number)}/update-branch`,
+      "--method", "PUT",
+    ], { cwd: "/tmp", env, timeout: 30_000 });
+    console.log(`[auto-merge] update-branch API succeeded for PR #${String(pr_number)}`);
+    return true;
+  } catch (err) {
+    console.log(
+      `[auto-merge] update-branch API failed for PR #${String(pr_number)}: ${String(err instanceof Error ? err.message : err)}`,
+    );
+    return false;
+  }
+}
+
+/**
+ * Poll the PR's mergeable state until it becomes MERGEABLE or we time out.
+ * Returns true if the PR is mergeable.
+ */
+async function poll_mergeable(
+  pr_number: number,
+  repo_path: string,
+  gh_bin: string,
+  env: NodeJS.ProcessEnv,
+): Promise<boolean> {
+  const deadline = Date.now() + MERGEABLE_POLL_TIMEOUT_MS;
+  const pr = String(pr_number);
+
+  while (Date.now() < deadline) {
+    try {
+      const { stdout } = await exec_async(gh_bin, [
+        "pr", "view", pr,
+        "--json", "mergeable",
+        "--jq", ".mergeable",
+      ], { cwd: repo_path, env, timeout: 15_000 });
+
+      const state = stdout.trim().toUpperCase();
+      if (state === "MERGEABLE") return true;
+      if (state === "CONFLICTING") return false;
+      // UNKNOWN — GitHub still computing, keep polling
+    } catch {
+      // gh CLI error — keep polling
+    }
+
+    await sleep(MERGEABLE_POLL_INTERVAL_MS);
+  }
+
+  console.log(`[auto-merge] Timed out waiting for mergeable state on PR #${pr}`);
+  return false;
+}
+
+/**
+ * Attempt a local git rebase of the branch onto origin/main.
+ * Uses a temp directory with a minimal clone, then force-pushes with lease.
+ */
+async function try_local_rebase(
+  branch: string,
+  repo_path: string,
+  env: NodeJS.ProcessEnv,
+): Promise<{ success: boolean; error?: string }> {
+  // Get the remote URL from the repo
+  let remote_url: string;
+  try {
+    const { stdout } = await exec_async("git", [
+      "remote", "get-url", "origin",
+    ], { cwd: repo_path, env, timeout: 10_000 });
+    remote_url = stdout.trim();
+  } catch {
+    return { success: false, error: "Could not determine remote URL" };
+  }
+
+  // Create temp dir for the rebase
+  let tmp_dir: string;
+  try {
+    const { stdout } = await exec_async("mktemp", ["-d"], { timeout: 5_000 });
+    tmp_dir = stdout.trim();
+  } catch {
+    return { success: false, error: "Could not create temp directory" };
+  }
+
+  try {
+    // Clone the branch (shallow to save time)
+    await exec_async("git", [
+      "clone", "--single-branch", "--branch", branch, remote_url, tmp_dir,
+    ], { env, timeout: 60_000 });
+
+    // Fetch main
+    await exec_async("git", [
+      "fetch", "origin", "main",
+    ], { cwd: tmp_dir, env, timeout: 30_000 });
+
+    // Attempt rebase
+    try {
+      await exec_async("git", [
+        "rebase", "origin/main",
+      ], { cwd: tmp_dir, env, timeout: 60_000 });
+    } catch {
+      // Rebase failed — abort and clean up
+      try {
+        await exec_async("git", [
+          "rebase", "--abort",
+        ], { cwd: tmp_dir, env, timeout: 10_000 });
+      } catch {
+        // Abort failed too — best-effort
+      }
+      return { success: false, error: "Rebase conflicts require manual resolution" };
+    }
+
+    // Rebase succeeded — force-push with lease
+    await exec_async("git", [
+      "push", "--force-with-lease", "origin", branch,
+    ], { cwd: tmp_dir, env, timeout: 30_000 });
+
+    console.log(`[auto-merge] Local rebase succeeded for branch ${branch}`);
+    return { success: true };
+  } catch (err) {
+    return {
+      success: false,
+      error: `Local rebase failed: ${String(err instanceof Error ? err.message : err)}`,
+    };
+  } finally {
+    // Clean up temp dir — best-effort
+    try {
+      await exec_async("rm", ["-rf", tmp_dir], { timeout: 10_000 });
+    } catch {
+      // Ignore cleanup failures
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/packages/daemon/src/webhook-handler.ts
+++ b/packages/daemon/src/webhook-handler.ts
@@ -19,12 +19,13 @@ import type { EntityRegistry } from "./registry.js";
 import type { ClaudeSessionManager, SessionResult } from "./session.js";
 import type { DiscordBot } from "./discord.js";
 import { detect_review_outcome } from "./actions.js";
-import { fetch_review_comments, build_review_fix_prompt } from "./review-utils.js";
+import { fetch_review_comments, build_review_fix_prompt, attempt_auto_merge } from "./review-utils.js";
 import {
   extract_first_linked_issue,
   extract_linked_issues,
   fetch_issue_context,
   close_linked_issues,
+  nwo_from_url,
 } from "./issue-utils.js";
 import { cleanup_after_merge } from "./worktree-cleanup.js";
 import * as sentry from "./sentry.js";
@@ -421,11 +422,35 @@ async function handle_review_completion(
   } else if (outcome === "approved") {
     // Check if reviewer already merged
     const is_merged = await check_pr_merged(repo_path, pr.number, gh_token);
-    await notify_alerts(
-      entity_id,
-      `PR #${String(pr.number)}: ${pr.title} — ${is_merged ? "approved and merged" : "approved"}`,
-      ctx,
-    );
+
+    if (!is_merged) {
+      // Attempt auto-merge with rebase fallback (#166)
+      const result = await attempt_auto_merge(
+        pr.number, pr.head.ref, repo_path, undefined, gh_token,
+      );
+
+      if (result.merged) {
+        // Post-merge cleanup: close linked issues and clean up worktrees
+        await post_auto_merge_cleanup(pr, entity_id, repo_path, ctx, installation_id);
+        await notify_alerts(
+          entity_id,
+          `PR #${String(pr.number)}: ${pr.title} — approved, auto-rebased (${result.method}), and merged`,
+          ctx,
+        );
+      } else {
+        await notify_alerts(
+          entity_id,
+          `PR #${String(pr.number)}: ${pr.title} — approved but merge failed after rebase attempt. ${result.error ?? "Manual intervention needed."}`,
+          ctx,
+        );
+      }
+    } else {
+      await notify_alerts(
+        entity_id,
+        `PR #${String(pr.number)}: ${pr.title} — approved and merged`,
+        ctx,
+      );
+    }
   } else {
     await notify_alerts(
       entity_id,
@@ -546,6 +571,11 @@ function build_reviewer_prompt(
     `After posting your review:`,
     `- If you approved, merge the PR:`,
     `  gh pr merge ${String(pr.number)} --squash --delete-branch`,
+    `- If the merge command fails (branch behind main):`,
+    `  1. Try: git fetch origin && git checkout ${pr.head.ref} && git rebase origin/main`,
+    `  2. If rebase is clean (no conflicts): git push --force-with-lease origin ${pr.head.ref}`,
+    `  3. Then retry: gh pr merge ${String(pr.number)} --squash --delete-branch`,
+    `  4. If rebase has conflicts: git rebase --abort — do NOT force push conflict markers`,
     `- If you requested changes, do NOT merge.`,
   ];
 
@@ -623,6 +653,77 @@ async function handle_pr_merged(
     );
     sentry.captureException(err, {
       tags: { module: "webhook", action: "worktree_cleanup" },
+      contexts: { pr: { number: pr.number, branch: pr.head.ref } },
+    });
+  }
+}
+
+// ── Post auto-merge cleanup ──
+
+/**
+ * After a successful auto-merge, close linked issues and clean up worktrees.
+ * Derives the repo full name from the entity registry rather than the webhook
+ * payload, since this runs outside the `closed` event path.
+ * All operations are best-effort — failures are logged but never thrown.
+ */
+async function post_auto_merge_cleanup(
+  pr: WebhookPR,
+  entity_id: string,
+  repo_path: string,
+  ctx: WebhookContext,
+  installation_id?: string,
+): Promise<void> {
+  // Close linked issues
+  const issue_numbers = extract_linked_issues(pr.body, pr.title);
+  if (issue_numbers.length > 0) {
+    // Derive repo full name from entity registry
+    const entity_config = ctx.registry.get_active().find(
+      (e: { entity: { id: string } }) => e.entity.id === entity_id,
+    );
+    const repo = entity_config?.entity.repos.find(
+      (r: { path: string; url: string }) => {
+        const expanded = expand_home(r.path);
+        return expanded === repo_path;
+      },
+    );
+    const repo_full_name = repo ? nwo_from_url(repo.url) : undefined;
+
+    if (repo_full_name) {
+      try {
+        const gh_token = await resolve_token(ctx.github_app, installation_id);
+        const results = await close_linked_issues(
+          repo_full_name, pr.number, issue_numbers, gh_token,
+        );
+        for (const result of results) {
+          if (!result.success) {
+            sentry.captureException(new Error(result.error ?? "unknown"), {
+              tags: { module: "webhook", action: "auto_merge_close_issue" },
+              contexts: {
+                pr: { number: pr.number, title: pr.title },
+                issue: { number: result.issue_number },
+              },
+            });
+          }
+        }
+      } catch (err) {
+        console.error(`[webhook] Failed to close issues after auto-merge: ${String(err)}`);
+        sentry.captureException(err, {
+          tags: { module: "webhook", action: "auto_merge_close_issues" },
+          contexts: { pr: { number: pr.number, title: pr.title } },
+        });
+      }
+    }
+  }
+
+  // Clean up worktrees
+  try {
+    await cleanup_after_merge(repo_path, pr.head.ref);
+  } catch (err) {
+    console.error(
+      `[webhook] Worktree cleanup failed after auto-merge for branch ${pr.head.ref}: ${String(err)}`,
+    );
+    sentry.captureException(err, {
+      tags: { module: "webhook", action: "auto_merge_worktree_cleanup" },
       contexts: { pr: { number: pr.number, branch: pr.head.ref } },
     });
   }


### PR DESCRIPTION
## Summary

- Add `attempt_auto_merge()` to `review-utils.ts` with a three-step recovery strategy: direct merge retry, GitHub API update-branch, and local git rebase fallback
- Wire auto-merge into both `webhook-handler.ts` (post-review completion) and `pr-cron.ts` (approved-but-not-merged internal PRs)
- Update reviewer prompts in both paths with rebase instructions so the reviewer session can handle it in-session before the daemon fallback kicks in
- Add 9 unit tests covering all paths: direct success, update-branch, local rebase, conflict abort, env passthrough, and temp dir cleanup

## Test plan

- [x] Unit: `attempt_auto_merge()` — direct merge succeeds, no rebase attempted
- [x] Unit: `attempt_auto_merge()` — direct merge fails, update-branch API succeeds, merge retried
- [x] Unit: `attempt_auto_merge()` — update-branch fails, local rebase attempted and succeeds
- [x] Unit: `attempt_auto_merge()` — rebase has conflicts, clean abort and error return
- [x] Unit: `attempt_auto_merge()` — repo nwo not determined, returns error early
- [x] Unit: `attempt_auto_merge()` — gh_token passed through via env
- [x] Unit: `attempt_auto_merge()` — temp directory cleaned up even on rebase failure
- [x] Unit: update-branch succeeds but merge still fails, falls through to local rebase
- [x] Integration: webhook handler mock includes `attempt_auto_merge` (existing tests pass)
- [x] All 658 existing tests pass (40 test files)

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)