### PR TITLE
Remove unused Discord channel topic code

### DIFF
--- a/packages/daemon/src/__tests__/actions.test.ts
+++ b/packages/daemon/src/__tests__/actions.test.ts
@@ -135,7 +135,6 @@ import {
   notify,
   assign_work_room,
   release_work_room,
-  reset_idle_work_room_topics,
   set_discord_bot,
   set_pool,
   type FeatureData,
@@ -196,7 +195,6 @@ function make_mock_discord() {
   return {
     send_to_entity: vi.fn(async () => {}),
     send: vi.fn(async () => {}),
-    set_channel_topic: vi.fn(async () => {}),
     create_channel: vi.fn(async () => "new-channel-123456789012345678"),
     delete_channel: vi.fn(async () => true),
     build_channel_map: vi.fn(),
@@ -775,11 +773,6 @@ describe("assign_work_room", () => {
     const result = await assign_work_room(feature, config);
 
     expect(result).toBe("12345678901234567890");
-    // Should set topic on the assigned channel
-    expect(mock_discord.set_channel_topic).toHaveBeenCalledWith(
-      "12345678901234567890",
-      expect.stringContaining("#42"),
-    );
   });
 
   it("skips rooms with non-snowflake placeholder IDs", async () => {
@@ -901,35 +894,6 @@ describe("assign_work_room", () => {
     expect(result).toBeNull();
   });
 
-  it("truncates long titles in channel topic", async () => {
-    const mock_discord = make_mock_discord();
-    set_discord_bot(mock_discord as any);
-
-    const config = make_entity_config({
-      channels: {
-        category_id: "cat-123",
-        list: [
-          {
-            type: "work_room",
-            id: "12345678901234567890",
-            purpose: "Room 1",
-          } as ChannelMapping,
-        ],
-      },
-    });
-
-    const long_title =
-      "This is a very long feature title that exceeds sixty characters and needs to be truncated";
-    const feature = make_feature({ title: long_title });
-
-    await assign_work_room(feature, config);
-
-    const topic_arg = mock_discord.set_channel_topic.mock.calls[0]?.[1] as string;
-    // Title should be truncated to 57 chars + "..."
-    expect(topic_arg.length).toBeLessThanOrEqual(70);
-    expect(topic_arg).toContain("...");
-  });
-
   it("rebuilds channel map after assignment", async () => {
     const mock_discord = make_mock_discord();
     set_discord_bot(mock_discord as any);
@@ -989,11 +953,6 @@ describe("release_work_room", () => {
 
     await release_work_room(feature, config);
 
-    // Should reset topic
-    expect(mock_discord.set_channel_topic).toHaveBeenCalledWith(
-      "12345678901234567890",
-      expect.stringContaining("Available"),
-    );
     // Should send farewell message
     expect(mock_discord.send).toHaveBeenCalledWith(
       "12345678901234567890",
@@ -1071,120 +1030,3 @@ describe("release_work_room", () => {
   });
 });
 
-describe("reset_idle_work_room_topics", () => {
-  it("no-ops when Discord bot is not set", async () => {
-    set_discord_bot(null);
-
-    const registry = {
-      get_active: vi.fn().mockReturnValue([]),
-    };
-
-    await reset_idle_work_room_topics(registry as any);
-
-    // Should not crash and should not call registry
-    expect(registry.get_active).not.toHaveBeenCalled();
-  });
-
-  it("resets unoccupied work rooms to Available", async () => {
-    const mock_discord = make_mock_discord();
-    set_discord_bot(mock_discord as any);
-
-    const registry = {
-      get_active: vi.fn().mockReturnValue([
-        make_entity_config({
-          channels: {
-            category_id: "cat-123",
-            list: [
-              {
-                type: "work_room",
-                id: "12345678901234567890",
-                purpose: "Room 1",
-              } as ChannelMapping,
-              {
-                type: "work_room",
-                id: "22345678901234567890",
-                purpose: "Room 2",
-              } as ChannelMapping,
-            ],
-          },
-        }),
-      ]),
-    };
-
-    await reset_idle_work_room_topics(registry as any);
-
-    expect(mock_discord.set_channel_topic).toHaveBeenCalledTimes(2);
-    expect(mock_discord.set_channel_topic).toHaveBeenCalledWith(
-      "12345678901234567890",
-      expect.stringContaining("Available"),
-    );
-  });
-
-  it("skips rooms with active pool assignments", async () => {
-    const mock_discord = make_mock_discord();
-    const mock_pool = make_mock_pool();
-    set_discord_bot(mock_discord as any);
-    set_pool(mock_pool as any);
-
-    // Mark first room as occupied
-    mock_pool.set_assignment("12345678901234567890", { bot_id: 1 });
-
-    const registry = {
-      get_active: vi.fn().mockReturnValue([
-        make_entity_config({
-          channels: {
-            category_id: "cat-123",
-            list: [
-              {
-                type: "work_room",
-                id: "12345678901234567890",
-                purpose: "Room 1 (occupied)",
-              } as ChannelMapping,
-              {
-                type: "work_room",
-                id: "22345678901234567890",
-                purpose: "Room 2 (free)",
-              } as ChannelMapping,
-            ],
-          },
-        }),
-      ]),
-    };
-
-    await reset_idle_work_room_topics(registry as any);
-
-    // Only the second (free) room should be reset
-    expect(mock_discord.set_channel_topic).toHaveBeenCalledTimes(1);
-    expect(mock_discord.set_channel_topic).toHaveBeenCalledWith(
-      "22345678901234567890",
-      expect.stringContaining("Available"),
-    );
-  });
-
-  it("skips rooms with non-snowflake placeholder IDs", async () => {
-    const mock_discord = make_mock_discord();
-    set_discord_bot(mock_discord as any);
-
-    const registry = {
-      get_active: vi.fn().mockReturnValue([
-        make_entity_config({
-          channels: {
-            category_id: "cat-123",
-            list: [
-              {
-                type: "work_room",
-                id: "wr-1",
-                purpose: "Placeholder",
-              } as ChannelMapping,
-            ],
-          },
-        }),
-      ]),
-    };
-
-    await reset_idle_work_room_topics(registry as any);
-
-    // Non-snowflake IDs should be skipped
-    expect(mock_discord.set_channel_topic).not.toHaveBeenCalled();
-  });
-});

--- a/packages/daemon/src/__tests__/fix-snowflake-validation.test.ts
+++ b/packages/daemon/src/__tests__/fix-snowflake-validation.test.ts
@@ -264,58 +264,12 @@ function make_mock_discord() {
     send: vi.fn().mockResolvedValue(undefined),
     send_as_agent: vi.fn().mockResolvedValue(undefined),
     send_to_entity: vi.fn().mockResolvedValue(undefined),
-    set_channel_topic: vi.fn().mockResolvedValue(undefined),
     create_channel: vi.fn().mockResolvedValue("10000000000000050"),
     delete_channel: vi.fn().mockResolvedValue(true),
     build_channel_map: vi.fn(),
     is_connected: vi.fn().mockReturnValue(true),
   };
 }
-
-describe("reset_idle_work_room_topics — snowflake guard", () => {
-  let discord: ReturnType<typeof make_mock_discord>;
-
-  beforeEach(() => {
-    discord = make_mock_discord();
-    // @ts-expect-error — mock
-    actions.set_discord_bot(discord);
-    actions.set_pool(null);
-  });
-
-  it("skips work rooms with placeholder IDs", async () => {
-    const entity = make_actions_entity([
-      { type: "general", id: "gen-1" },
-      { type: "work_room", id: "wr-1" },
-      { type: "work_room", id: "wr-2" },
-      { type: "work_room", id: VALID_WR },
-    ]);
-    const registry = { get_active: vi.fn().mockReturnValue([entity]) };
-
-    // @ts-expect-error — mock registry
-    await actions.reset_idle_work_room_topics(registry);
-
-    // Only the valid snowflake channel should have its topic set
-    expect(discord.set_channel_topic).toHaveBeenCalledTimes(1);
-    expect(discord.set_channel_topic).toHaveBeenCalledWith(VALID_WR, "\u{1F7E2} Available");
-    expect(discord.set_channel_topic).not.toHaveBeenCalledWith("wr-1", expect.anything());
-    expect(discord.set_channel_topic).not.toHaveBeenCalledWith("wr-2", expect.anything());
-  });
-
-  it("is a no-op when all work room IDs are placeholders", async () => {
-    const entity = make_actions_entity([
-      { type: "general", id: "gen-1" },
-      { type: "work_room", id: "wr-1" },
-      { type: "work_room", id: "wr-2" },
-      { type: "work_room", id: "wr-3" },
-    ]);
-    const registry = { get_active: vi.fn().mockReturnValue([entity]) };
-
-    // @ts-expect-error — mock registry
-    await actions.reset_idle_work_room_topics(registry);
-
-    expect(discord.set_channel_topic).not.toHaveBeenCalled();
-  });
-});
 
 describe("assign_work_room — snowflake guard", () => {
   let discord: ReturnType<typeof make_mock_discord>;
@@ -357,32 +311,6 @@ describe("assign_work_room — snowflake guard", () => {
   });
 });
 
-describe("update_work_room_topic — snowflake guard", () => {
-  let discord: ReturnType<typeof make_mock_discord>;
-
-  beforeEach(() => {
-    discord = make_mock_discord();
-    // @ts-expect-error — mock
-    actions.set_discord_bot(discord);
-  });
-
-  it("skips topic update when work room ID is a placeholder", async () => {
-    const feature = make_feature({ discordWorkRoom: "wr-1" });
-
-    await actions.update_work_room_topic(feature, "some topic");
-
-    expect(discord.set_channel_topic).not.toHaveBeenCalled();
-  });
-
-  it("updates topic when work room ID is a valid snowflake", async () => {
-    const feature = make_feature({ discordWorkRoom: VALID_WR });
-
-    await actions.update_work_room_topic(feature, "some topic");
-
-    expect(discord.set_channel_topic).toHaveBeenCalledWith(VALID_WR, "some topic");
-  });
-});
-
 describe("release_work_room — snowflake guard", () => {
   let discord: ReturnType<typeof make_mock_discord>;
 
@@ -401,7 +329,6 @@ describe("release_work_room — snowflake guard", () => {
     await actions.release_work_room(feature, entity);
 
     // The entry is found (so assigned_feature is cleared), but no Discord API calls
-    expect(discord.set_channel_topic).not.toHaveBeenCalled();
     expect(discord.send).not.toHaveBeenCalled();
   });
 
@@ -427,7 +354,6 @@ describe("release_work_room — snowflake guard", () => {
 
     await actions.release_work_room(feature, entity);
 
-    expect(discord.set_channel_topic).toHaveBeenCalledWith(VALID_WR, "\u{1F7E2} Available");
     expect(discord.send).toHaveBeenCalled();
   });
 });

--- a/packages/daemon/src/__tests__/work-rooms.test.ts
+++ b/packages/daemon/src/__tests__/work-rooms.test.ts
@@ -80,7 +80,6 @@ function make_mock_discord() {
     send: vi.fn().mockResolvedValue(undefined),
     send_as_agent: vi.fn().mockResolvedValue(undefined),
     send_to_entity: vi.fn().mockResolvedValue(undefined),
-    set_channel_topic: vi.fn().mockResolvedValue(undefined),
     create_channel: vi.fn().mockResolvedValue(DYN_WR),
     delete_channel: vi.fn().mockResolvedValue(true),
     build_channel_map: vi.fn(),
@@ -198,32 +197,6 @@ describe("Work Room Assignment", () => {
       expect(dynamic_entry?.assigned_feature).toBe("alpha-42");
     });
 
-    it("sets channel topic with title on assignment", async () => {
-      const feature = make_feature();
-      const entity = make_entity_config(make_static_work_rooms(3));
-
-      await actions.assign_work_room(feature, entity);
-
-      expect(discord.set_channel_topic).toHaveBeenCalledWith(
-        WR_IDS[0],
-        "\u{1F528} #42: Test Feature",
-      );
-    });
-
-    it("truncates long title in channel topic on assignment", async () => {
-      const long_title = "A".repeat(80);
-      const feature = make_feature({ title: long_title });
-      const entity = make_entity_config(make_static_work_rooms(3));
-
-      await actions.assign_work_room(feature, entity);
-
-      const expected_title = "A".repeat(57) + "...";
-      expect(discord.set_channel_topic).toHaveBeenCalledWith(
-        WR_IDS[0],
-        `\u{1F528} #42: ${expected_title}`,
-      );
-    });
-
     it("rebuilds channel map after assignment", async () => {
       const feature = make_feature();
       const entity = make_entity_config(make_static_work_rooms(3));
@@ -328,17 +301,6 @@ describe("Work Room Assignment", () => {
   });
 
   describe("release_work_room", () => {
-    it("resets static room topic to Available", async () => {
-      const feature = make_feature({ discordWorkRoom: WR_IDS[0] });
-      const channels = make_static_work_rooms(3);
-      channels[1]!.assigned_feature = "alpha-42";
-      const entity = make_entity_config(channels);
-
-      await actions.release_work_room(feature, entity);
-
-      expect(discord.set_channel_topic).toHaveBeenCalledWith(WR_IDS[0], "\u{1F7E2} Available");
-    });
-
     it("clears assigned_feature on static room", async () => {
       const feature = make_feature({ discordWorkRoom: WR_IDS[0] });
       const channels = make_static_work_rooms(3);
@@ -433,7 +395,6 @@ describe("Work Room Assignment", () => {
       await actions.release_work_room(feature, entity);
 
       expect(discord.send).not.toHaveBeenCalled();
-      expect(discord.set_channel_topic).not.toHaveBeenCalled();
       expect(discord.delete_channel).not.toHaveBeenCalled();
     });
 
@@ -448,135 +409,6 @@ describe("Work Room Assignment", () => {
       expect(wr2).toBeDefined();
       expect(wr2?.type).toBe("work_room");
     });
-  });
-});
-
-describe("Channel Topic Updates", () => {
-  let discord: ReturnType<typeof make_mock_discord>;
-
-  beforeEach(() => {
-    discord = make_mock_discord();
-    // @ts-expect-error — mock does not implement full DiscordBot interface
-    actions.set_discord_bot(discord);
-  });
-
-  describe("update_work_room_topic", () => {
-    it("updates topic when work room is assigned", async () => {
-      const feature = make_feature({ discordWorkRoom: WR_IDS[0] });
-
-      await actions.update_work_room_topic(feature, "\u{1F7E3} alpha-42 \u2014 #42 \u2014 In Review");
-
-      expect(discord.set_channel_topic).toHaveBeenCalledWith(
-        WR_IDS[0],
-        "\u{1F7E3} alpha-42 \u2014 #42 \u2014 In Review",
-      );
-    });
-
-    it("is a no-op when no work room is assigned", async () => {
-      const feature = make_feature({ discordWorkRoom: null });
-
-      await actions.update_work_room_topic(feature, "some topic");
-
-      expect(discord.set_channel_topic).not.toHaveBeenCalled();
-    });
-
-    it("is a no-op when no discord bot is available", async () => {
-      actions.set_discord_bot(null);
-      const feature = make_feature({ discordWorkRoom: WR_IDS[0] });
-
-      await actions.update_work_room_topic(feature, "some topic");
-
-      // No error thrown, function returns silently
-    });
-  });
-});
-
-describe("Startup Topic Reset", () => {
-  let discord: ReturnType<typeof make_mock_discord>;
-
-  beforeEach(() => {
-    discord = make_mock_discord();
-    // @ts-expect-error — mock does not implement full DiscordBot interface
-    actions.set_discord_bot(discord);
-    actions.set_pool(null);
-  });
-
-  it("resets all work rooms to Available when no pool assignments", async () => {
-    const entity = make_entity_config(make_static_work_rooms(3));
-    const registry = {
-      get_active: vi.fn().mockReturnValue([entity]),
-    };
-
-    // @ts-expect-error — mock registry
-    await actions.reset_idle_work_room_topics(registry);
-
-    // All 3 work rooms should be reset
-    expect(discord.set_channel_topic).toHaveBeenCalledWith(WR_IDS[0], "\u{1F7E2} Available");
-    expect(discord.set_channel_topic).toHaveBeenCalledWith(WR_IDS[1], "\u{1F7E2} Available");
-    expect(discord.set_channel_topic).toHaveBeenCalledWith(WR_IDS[2], "\u{1F7E2} Available");
-    expect(discord.set_channel_topic).toHaveBeenCalledTimes(3);
-  });
-
-  it("preserves topic on work rooms with active pool assignments", async () => {
-    const entity = make_entity_config(make_static_work_rooms(3));
-    // Pool has a bot assigned to wr-1
-    // @ts-expect-error — mock pool
-    actions.set_pool(make_mock_pool({ [WR_IDS[0]]: { id: 0, archetype: "builder" } }));
-
-    const registry = {
-      get_active: vi.fn().mockReturnValue([entity]),
-    };
-
-    // @ts-expect-error — mock registry
-    await actions.reset_idle_work_room_topics(registry);
-
-    // wr-1 has an active pool assignment — should NOT be reset
-    expect(discord.set_channel_topic).not.toHaveBeenCalledWith(WR_IDS[0], "\u{1F7E2} Available");
-    // wr-2 and wr-3 should be reset
-    expect(discord.set_channel_topic).toHaveBeenCalledWith(WR_IDS[1], "\u{1F7E2} Available");
-    expect(discord.set_channel_topic).toHaveBeenCalledWith(WR_IDS[2], "\u{1F7E2} Available");
-    expect(discord.set_channel_topic).toHaveBeenCalledTimes(2);
-  });
-
-  it("is a no-op when no discord bot is available", async () => {
-    actions.set_discord_bot(null);
-
-    const registry = {
-      get_active: vi.fn().mockReturnValue([]),
-    };
-
-    // Should not throw
-    // @ts-expect-error — mock registry
-    await actions.reset_idle_work_room_topics(registry);
-
-    expect(registry.get_active).not.toHaveBeenCalled();
-  });
-
-  it("only touches work_room channels, not general or alerts", async () => {
-    const entity = make_entity_config(make_static_work_rooms(3));
-    const registry = {
-      get_active: vi.fn().mockReturnValue([entity]),
-    };
-
-    // @ts-expect-error — mock registry
-    await actions.reset_idle_work_room_topics(registry);
-
-    // Should not be called for gen-1 or al-1
-    expect(discord.set_channel_topic).not.toHaveBeenCalledWith(GEN_ID, expect.anything());
-    expect(discord.set_channel_topic).not.toHaveBeenCalledWith(AL_ID, expect.anything());
-  });
-
-  it("is a no-op with 0 static work rooms", async () => {
-    const entity = make_entity_config(make_static_work_rooms(0));
-    const registry = {
-      get_active: vi.fn().mockReturnValue([entity]),
-    };
-
-    // @ts-expect-error — mock registry
-    await actions.reset_idle_work_room_topics(registry);
-
-    // No work rooms -> no topics to reset
-    expect(discord.set_channel_topic).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/daemon/src/actions.ts
+++ b/packages/daemon/src/actions.ts
@@ -24,7 +24,6 @@ import { expand_home, entity_config_path, write_yaml } from "@lobster-farm/share
 import { is_discord_snowflake } from "./discord.js";
 import type { DiscordBot } from "./discord.js";
 import type { BotPool } from "./pool.js";
-import type { EntityRegistry } from "./registry.js";
 import * as sentry from "./sentry.js";
 
 const exec = promisify(execFile);
@@ -310,17 +309,6 @@ export async function assign_work_room(
     await persist_entity_config(entity_config);
   }
 
-  // Set channel topic with truncated title
-  if (_discord && channel_id) {
-    const short_title = feature.title.length > 60
-      ? feature.title.slice(0, 57) + "..."
-      : feature.title;
-    await _discord.set_channel_topic(
-      channel_id,
-      `🔨 #${String(feature.githubIssue)}: ${short_title}`,
-    );
-  }
-
   // Rebuild channel map so Discord bot routes messages correctly
   _discord?.build_channel_map();
 
@@ -351,10 +339,9 @@ export async function release_work_room(
     channels.list = channels.list.filter((c: ChannelMapping) => c.id !== channel_id);
     await persist_entity_config(entity_config);
   } else if (entry) {
-    // Static room — reset topic and clear assignment
+    // Static room — clear assignment
     entry.assigned_feature = null;
     if (_discord && is_discord_snowflake(channel_id)) {
-      await _discord.set_channel_topic(channel_id, "🟢 Available");
       await _discord.send(
         channel_id,
         `Feature ${feature.id} complete. This work room is now available.`,
@@ -422,16 +409,6 @@ export async function detect_review_outcome(
   }
 }
 
-/** Update the topic of a feature's work room. */
-export async function update_work_room_topic(
-  feature: FeatureData,
-  topic: string,
-): Promise<void> {
-  if (!feature.discordWorkRoom || !_discord) return;
-  if (!is_discord_snowflake(feature.discordWorkRoom)) return;
-  await _discord.set_channel_topic(feature.discordWorkRoom, topic);
-}
-
 // ── Merge error classification ──
 
 export type MergeErrorKind = "conflict" | "other";
@@ -459,46 +436,3 @@ export function classify_merge_error(error: string): MergeErrorKind {
   return "other";
 }
 
-// ── Startup cleanup ──
-
-/**
- * Reset topics on unoccupied work rooms to "Available".
- * Called on daemon startup to clear stale topics from previous runs.
- * Rooms with active pool assignments keep their current topic.
- */
-export async function reset_idle_work_room_topics(
-  registry: EntityRegistry,
-): Promise<void> {
-  if (!_discord) return;
-
-  // Collect work rooms with active pool assignments
-  const active_rooms = new Set<string>();
-  if (_pool) {
-    for (const entity_config of registry.get_active()) {
-      for (const channel of entity_config.entity.channels.list) {
-        if (channel.type === "work_room" && _pool.get_assignment(channel.id)) {
-          active_rooms.add(channel.id);
-        }
-      }
-    }
-  }
-
-  // Reset unoccupied work rooms (skip placeholder IDs like "wr-1" from alpha entity)
-  let reset_count = 0;
-  for (const entity_config of registry.get_active()) {
-    for (const channel of entity_config.entity.channels.list) {
-      if (
-        channel.type === "work_room" &&
-        !active_rooms.has(channel.id) &&
-        is_discord_snowflake(channel.id)
-      ) {
-        await _discord.set_channel_topic(channel.id, "\u{1F7E2} Available");
-        reset_count++;
-      }
-    }
-  }
-
-  if (reset_count > 0) {
-    console.log(`[actions] Reset ${String(reset_count)} idle work room topic(s) to Available`);
-  }
-}

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -621,22 +621,6 @@ export class DiscordBot extends EventEmitter {
 
   // ── Channel management ──
 
-  /** Set a channel's topic. No-op if disconnected or channel not found. */
-  async set_channel_topic(channel_id: string, topic: string): Promise<void> {
-    if (!this.connected) return;
-    try {
-      const channel = await this.client.channels.fetch(channel_id);
-      if (channel?.isTextBased() && !channel.isDMBased()) {
-        await (channel as TextChannel).setTopic(topic);
-      }
-    } catch (err) {
-      console.error(`[discord] Failed to set topic for ${channel_id}: ${String(err)}`);
-      sentry.captureException(err, {
-        tags: { module: "discord", action: "set_topic" },
-      });
-    }
-  }
-
   /** Create a text channel under a category. Returns the channel ID, or null on failure. */
   async create_channel(
     category_id: string,

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -5,7 +5,7 @@ import { ClaudeSessionManager } from "./session.js";
 import type { ActiveSession, SessionResult } from "./session.js";
 import { TaskQueue } from "./queue.js";
 import { DiscordBot, resolve_bot_token } from "./discord.js";
-import { set_discord_bot, set_pool, reset_idle_work_room_topics } from "./actions.js";
+import { set_discord_bot, set_pool } from "./actions.js";
 import { start_server } from "./server.js";
 import { write_pid, remove_pid } from "./pid.js";
 import { CommanderProcess } from "./commander-process.js";
@@ -183,11 +183,6 @@ async function main(): Promise<void> {
         tags: { module: "startup", phase: "avatars" },
       });
     }
-  }
-
-  // Reset stale work room topics from previous daemon runs
-  if (discord_connected) {
-    await reset_idle_work_room_topics(registry);
   }
 
   // Proactively resume bots that were assigned before shutdown.


### PR DESCRIPTION
## Summary

- Remove all Discord channel topic-setting code from the daemon. Topics were cosmetic-only — nothing reads them, and they generated unnecessary Discord API calls on every work room assign/release cycle and on every daemon startup.
- Removed `set_channel_topic()` from `DiscordBot`, `update_work_room_topic()` and `reset_idle_work_room_topics()` from actions, and the startup call in `index.ts`.
- Cleaned up 489 lines across source and test files. All 629 remaining tests pass.

Closes #182

## Test plan

- [x] `pnpm run -r build` compiles cleanly
- [x] `pnpm run -r test` — all 629 tests pass (39 test files, 0 failures)
- [x] Verified no remaining references to `set_channel_topic`, `update_work_room_topic`, or `reset_idle_work_room_topics` in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)