### PR TITLE
feat: add user verification gate to planning and coding DNA

### DIFF
--- a/config/claude/skills/coding-dna/SKILL.md
+++ b/config/claude/skills/coding-dna/SKILL.md
@@ -595,6 +595,32 @@ LOCAL = True if os.getcwd().split('/')[1] == 'Users' else False
 
 ---
 
+## PR Workflow
+
+### Check the Spec's Verification Requirement
+
+Before opening a PR, check the GitHub issue spec for the `## Verification` section:
+
+**When `verification: none` (or not specified for non-artifact changes):**
+- Build, commit, push, open PR immediately
+- Current behavior — AutoReviewer handles the rest
+
+**When `verification: user`:**
+1. Build the feature, commit, and push to the branch
+2. Do NOT open a PR
+3. Post to the channel:
+   - What was built (brief summary)
+   - How to test locally: `git pull && git checkout <branch> && <run command>`
+   - What to look for (specific things to verify)
+4. Wait for user response:
+   - "Looks good" / "Ship it" → open the PR with full body and `Closes #<issue>`
+   - Feedback / "Fix X" → fix the issue, push, ask again
+   - No response → do NOT open the PR. The user will come back when ready.
+
+The PR gate is about product correctness, not code quality. Code quality is the AutoReviewer's job. The user gate catches "it compiles but does the wrong thing."
+
+---
+
 ## Frontend Standards
 
 _Brief for now — {{DESIGNER_NAME}} drives the design system. We implement faithfully._

--- a/config/claude/skills/planning-dna/SKILL.md
+++ b/config/claude/skills/planning-dna/SKILL.md
@@ -43,6 +43,15 @@ _Specs are contracts. Scope is the lever. Questions before answers, always._
 - Who's the user? What do they expect?
 - What can we defer without creating tech debt?
 
+### Verification Decision
+
+For every spec, decide whether user verification is needed before the PR is opened:
+
+- **`none`** — correctness is machine-verifiable. Tests pass, types check, code review is sufficient. Examples: refactors, dependency updates, infra config, test coverage, internal tooling.
+- **`user`** — correctness requires human eyes. The feature produces a user-facing artifact (UI, data output, API behavior) that can't be fully validated by automated checks. Examples: new UI components, chart rendering, data pipeline output, API response format changes.
+
+When unsure, default to `user`. It only costs a "looks good" message.
+
 ---
 
 ## Spec Format (GitHub Issue)
@@ -72,6 +81,11 @@ performance considerations, security implications.
 
 ## Out of Scope
 What this feature does NOT include. Prevents scope creep.
+
+## Verification
+Whether this feature requires user testing before PR.
+- `none` — open PR directly (refactors, infra, config, test coverage)
+- `user` — push to branch, request user testing before opening PR
 
 ## Open Questions (if any)
 Things to decide during implementation.


### PR DESCRIPTION
## Summary

- Adds a `## Verification` section to the planning-DNA spec template (`none` / `user` options) so Gary decides per-issue whether user testing is needed before opening a PR
- Adds `### Verification Decision` guidance to the discovery process with clear criteria for when to choose each option (machine-verifiable vs human-eyes-needed)
- Adds a `## PR Workflow` section to coding-DNA that instructs the builder to check the spec's verification field and, when `user`, push to branch without opening a PR until the user confirms

Closes #186

## Test plan

- [ ] Verify planning-DNA spec template code block includes `## Verification` between `## Out of Scope` and `## Open Questions`
- [ ] Verify planning-DNA has `### Verification Decision` subsection with `none` / `user` guidance
- [ ] Verify coding-DNA has `## PR Workflow` section between "Git & Environments" and "Frontend Standards"
- [ ] Verify the `verification: user` flow clearly describes: push, post to channel, wait for response
- [ ] Verify the `verification: none` flow preserves current behavior (build, push, open PR)