### PR TITLE
fix: stop injecting GIT_*_EMAIL into agent sessions

### DIFF
--- a/packages/daemon/src/commander-process.ts
+++ b/packages/daemon/src/commander-process.ts
@@ -128,7 +128,7 @@ export class CommanderProcess extends EventEmitter {
       "new-session", "-d",
       "-s", TMUX_SESSION,
       "-x", "200", "-y", "50",
-      `DISCORD_STATE_DIR=${sq(this.state_dir())} GIT_AUTHOR_NAME=${sq("Pat")} GIT_AUTHOR_EMAIL=${sq("pat@lobsterfarm.dev")} GIT_COMMITTER_NAME=${sq("Pat")} GIT_COMMITTER_EMAIL=${sq("pat@lobsterfarm.dev")} ${claude_cmd}`,
+      `DISCORD_STATE_DIR=${sq(this.state_dir())} GIT_AUTHOR_NAME=${sq("Pat")} GIT_COMMITTER_NAME=${sq("Pat")} ${claude_cmd}`,
     ], {
       cwd: working_dir,
       stdio: "ignore",
@@ -136,9 +136,7 @@ export class CommanderProcess extends EventEmitter {
         ...process.env,
         DISCORD_STATE_DIR: this.state_dir(),
         GIT_AUTHOR_NAME: "Pat",
-        GIT_AUTHOR_EMAIL: "pat@lobsterfarm.dev",
         GIT_COMMITTER_NAME: "Pat",
-        GIT_COMMITTER_EMAIL: "pat@lobsterfarm.dev",
       },
     });
 

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -1562,7 +1562,7 @@ export class BotPool extends EventEmitter {
     // naturally via CLAUDE.md, skills, and entity memory in the working directory.
 
     const display_name = resolve_agent_display_name(archetype, this.config);
-    const git_env = `GIT_AUTHOR_NAME=${sq(display_name)} GIT_AUTHOR_EMAIL=${sq(`${agent_name}@lobsterfarm.dev`)} GIT_COMMITTER_NAME=${sq(display_name)} GIT_COMMITTER_EMAIL=${sq(`${agent_name}@lobsterfarm.dev`)}`;
+    const git_env = `GIT_AUTHOR_NAME=${sq(display_name)} GIT_COMMITTER_NAME=${sq(display_name)}`;
 
     // Build extra env var prefix for the tmux command string (e.g., GH_TOKEN=...)
     const extra_env_str = Object.entries(extra_env)
@@ -1586,9 +1586,7 @@ export class BotPool extends EventEmitter {
           ...extra_env,
           DISCORD_STATE_DIR: bot.state_dir,
           GIT_AUTHOR_NAME: display_name,
-          GIT_AUTHOR_EMAIL: `${agent_name}@lobsterfarm.dev`,
           GIT_COMMITTER_NAME: display_name,
-          GIT_COMMITTER_EMAIL: `${agent_name}@lobsterfarm.dev`,
         },
       });
 


### PR DESCRIPTION
## Summary

- Remove `GIT_AUTHOR_EMAIL` and `GIT_COMMITTER_EMAIL` from both the tmux command string and the spawn `env` object in `pool.ts` and `commander-process.ts`
- `GIT_AUTHOR_NAME` and `GIT_COMMITTER_NAME` are preserved so agent names still appear on commits
- Repos already have the correct GitHub noreply emails configured via `git config user.email` — this change lets those take effect instead of being overridden by `@lobsterfarm.dev` addresses that Vercel doesn't recognize

## Test plan

- [x] All 696 existing daemon tests pass
- [ ] Deploy a branch from an agent session and verify Vercel recognizes the commit author

Closes #N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)