### PR TITLE
fix: expand tilde in task queue worktree_path to prevent ENOENT

### DIFF
--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -9,7 +9,7 @@ import type { CommanderProcess } from "./commander-process.js";
 import { is_discord_snowflake } from "./discord.js";
 import type { DiscordBot } from "./discord.js";
 import type { BotPool } from "./pool.js";
-import type { ArchetypeRole } from "@lobster-farm/shared";
+import { type ArchetypeRole, expand_home } from "@lobster-farm/shared";
 import { persist_entity_config } from "./actions.js";
 import type { GitHubAppAuth } from "./github-app.js";
 import { handle_github_webhook, type WebhookContext } from "./webhook-handler.js";
@@ -277,7 +277,7 @@ const handle_submit_task: RouteHandler = async (req, res, ctx) => {
   if (!submission.worktree_path) {
     const entity = ctx.registry.get(submission.entity_id);
     if (entity) {
-      submission.worktree_path = entity.entity.repos[0]?.path;
+      submission.worktree_path = expand_home(entity.entity.repos[0]?.path ?? "");
     } else {
       json_response(res, 404, {
         error: `Entity "${submission.entity_id}" not found`,

--- a/packages/daemon/src/session.ts
+++ b/packages/daemon/src/session.ts
@@ -9,6 +9,7 @@ import type {
 import * as sentry from "./sentry.js";
 import { readdir } from "node:fs/promises";
 import {
+  expand_home,
   entity_memory_path,
   entity_daily_dir,
   entity_context_dir,
@@ -250,7 +251,7 @@ export class ClaudeSessionManager extends EventEmitter implements SessionManager
 
     // Spawn the process — prompt is piped via stdin
     const proc = spawn(command, args, {
-      cwd: options.worktree_path,
+      cwd: expand_home(options.worktree_path),
       stdio: ["pipe", "pipe", "pipe"],
       env: { ...process.env, ...options.env },
     });


### PR DESCRIPTION
## Summary

- Task queue submissions failed with `spawn claude ENOENT` because entity configs store repo paths with `~` (e.g., `~/.lobsterfarm/entities/...`). The webhook handler calls `expand_home()` before spawning, but `handle_submit_task()` in server.ts passed the raw tilde path. Node.js `spawn()` doesn't expand `~`, so the `cwd` was invalid.
- Added `expand_home()` in server.ts (primary fix) and defensively in session.ts `spawn()` (belt-and-suspenders for any future callers).

## Test plan

- [ ] Submit a task via `POST /tasks` with `worktree_path: ""` (defaults from entity config) — should succeed instead of ENOENT
- [ ] Existing webhook-spawned sessions (reviewers, builders) continue working
- [ ] Build passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)