### PR TITLE
chore: install script and README refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The wizard checks for prerequisites (Claude Code, 1Password, sudo), configures y
 git clone https://github.com/ultim88888888/lobster-farm.git ~/.lobsterfarm/src
 cd ~/.lobsterfarm/src
 pnpm install && pnpm build
+chmod +x $(pwd)/packages/cli/dist/index.js
 ln -sf $(pwd)/packages/cli/dist/index.js ~/.local/bin/lf
 lf init
 ```

--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,7 @@ NODE_MAJOR=$(node -e "console.log(process.versions.node.split('.')[0])")
 
 command -v pnpm >/dev/null 2>&1 || {
   warn "pnpm not found — installing via corepack..."
-  corepack enable && corepack prepare pnpm@latest --activate
+  corepack enable && corepack prepare pnpm@9 --activate
 }
 
 command -v claude >/dev/null 2>&1 || warn "Claude Code CLI not found. Install it before running 'lf init'."
@@ -50,6 +50,7 @@ info "Installing dependencies and building..."
 cd "$INSTALL_DIR"
 pnpm install --frozen-lockfile 2>/dev/null || pnpm install
 pnpm build
+chmod +x "$INSTALL_DIR/packages/cli/dist/index.js"
 
 # ── Symlink CLI ──
 


### PR DESCRIPTION
## Summary

- Cleaned up `install.sh` — symlink to `~/.local/bin` instead of `npm link` (no sudo), Node.js 22+ version check, `gh` CLI support for private repos, prerequisite warnings for Claude Code and 1Password
- Refreshed README — one-liner install command, manual install steps, removed stale slash commands from stripped feature lifecycle (`/plan`, `/features`, `/advance`), updated architecture diagram

## Test plan

- [ ] `curl -fsSL .../install.sh | bash` works on a clean machine
- [ ] README accurately reflects current CLI commands and slash commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)