### PR TITLE
fix: silence session restored messages on daemon restart

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -189,9 +189,11 @@ async function main(): Promise<void> {
   // Must happen after Discord connects so we can send "back online" notifications.
   // Listen for bot:resumed events and notify each channel via the daemon bot.
   pool.on("bot:resumed", ({ channel_id }: { channel_id: string }) => {
-    if (discord_connected) {
-      void discord.send(channel_id, "Session restored after daemon restart.");
-    }
+    // Disabled: too noisy — every daemon restart floods all channels.
+    // if (discord_connected) {
+    //   void discord.send(channel_id, "Session restored after daemon restart.");
+    // }
+    void channel_id; // suppress unused warning
   });
 
   if (discord_connected) {


### PR DESCRIPTION
## Summary
- Comments out the Discord notification sent to every channel when pool bots are resumed after a daemon restart
- The resume nudge (via tmux send-keys) still works — bots know they were restarted without spamming Discord
- Every restart was sending "Session restored after daemon restart" to 14+ channels

## Test plan
- [ ] Restart daemon, confirm no "Session restored" messages appear in Discord channels
- [ ] Confirm pool bots still resume and function correctly after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)