### PR TITLE
feat: auto-triage deploy failures on main via Gary

### DIFF
--- a/packages/daemon/src/__tests__/ci-gating.test.ts
+++ b/packages/daemon/src/__tests__/ci-gating.test.ts
@@ -87,10 +87,12 @@ vi.mock("../issue-utils.js", () => ({
   nwo_from_url: vi.fn(() => "test-org/lobster-farm"),
 }));
 
-// Mock persistence — the CI fix loop uses load/save_pr_reviews (#196)
+// Mock persistence — CI fix loop uses pr_reviews, deploy triage uses deploy_triage (#196, #199)
 vi.mock("../persistence.js", () => ({
   load_pr_reviews: vi.fn(async () => ({})),
   save_pr_reviews: vi.fn(async () => {}),
+  load_deploy_triage: vi.fn(async () => ({})),
+  save_deploy_triage: vi.fn(async () => {}),
 }));
 
 import type { DiscordBot } from "../discord.js";
@@ -352,16 +354,29 @@ describe("webhook handler — workflow_run events", () => {
   });
 
   it("sends alert when workflow_run fails on main from a push event", async () => {
+    // Route commands needed by spawn_deploy_triage (log fetching)
+    route_exec({
+      "gh run list": () => ({
+        stdout: JSON.stringify([{ databaseId: 123, name: "Deploy Backend" }]),
+      }),
+      "gh run view": () => ({
+        stdout: "Error: deploy failed\n",
+      }),
+    });
+
     const payload = JSON.stringify({
       action: "completed",
       workflow_run: {
+        id: 123,
         name: "Deploy Backend",
         conclusion: "failure",
         event: "push",
         head_branch: "main",
+        head_sha: "abc123",
         html_url: "https://github.com/test-org/lobster-farm/actions/runs/123",
       },
       repository: { full_name: "test-org/lobster-farm" },
+      installation: { id: 12345 },
     });
 
     const ctx = make_context();
@@ -374,20 +389,21 @@ describe("webhook handler — workflow_run events", () => {
     await handle_github_webhook(req, res, ctx);
 
     // Wait for async route_event to process
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await new Promise((resolve) => setTimeout(resolve, 150));
 
     expect(res._status).toBe(200);
     const discord = ctx.discord as unknown as { send_to_entity: ReturnType<typeof vi.fn> };
+    // Updated in #199: alert now mentions Gary triaging instead of a raw failure message
     expect(discord.send_to_entity).toHaveBeenCalledWith(
       "test-entity",
       "alerts",
-      expect.stringContaining("Deploy Backend"),
+      expect.stringContaining("Deploy failed on main"),
       "reviewer",
     );
     expect(discord.send_to_entity).toHaveBeenCalledWith(
       "test-entity",
       "alerts",
-      expect.stringContaining("failed on main"),
+      expect.stringContaining("Gary triaging"),
       "reviewer",
     );
   });

--- a/packages/daemon/src/__tests__/deploy-triage.test.ts
+++ b/packages/daemon/src/__tests__/deploy-triage.test.ts
@@ -1,0 +1,635 @@
+/**
+ * Tests for the deploy triage loop (#199).
+ *
+ * Covers:
+ * - build_deploy_triage_prompt() — prompt construction for Gary
+ * - Retry cap: stops after MAX_DEPLOY_FIX_ATTEMPTS (2)
+ * - Safety valve: 4+ attempts in 24h pauses auto-triage
+ * - Dedup: same run ID at cap doesn't spawn again
+ * - Token failure: does not consume a retry slot
+ *
+ * Uses the same command-routing mock pattern as ci-fix-loop.test.ts.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createHmac } from "node:crypto";
+import { EventEmitter } from "node:events";
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+// ── Command routing ──
+
+type ExecRoute = (
+  args: string[],
+  opts: Record<string, unknown>,
+) => { stdout: string; stderr?: string } | Error;
+
+const routes: Record<string, ExecRoute> = {};
+
+function find_route_key(cmd: string, args: string[]): string | null {
+  const tokens = [cmd, ...args.slice(0, 3)];
+  for (let len = tokens.length; len > 0; len--) {
+    const candidate = tokens.slice(0, len).join(" ");
+    if (routes[candidate] !== undefined) return candidate;
+  }
+  return null;
+}
+
+function route_exec(new_routes: Record<string, ExecRoute>): void {
+  for (const key of Object.keys(routes)) delete routes[key];
+  Object.assign(routes, new_routes);
+}
+
+// ── Mock node:child_process ──
+
+vi.mock("node:child_process", async () => {
+  const { promisify } = await import("node:util");
+
+  const promisified = async (
+    cmd: string,
+    args: string[],
+    opts: Record<string, unknown> = {},
+  ): Promise<{ stdout: string; stderr: string }> => {
+    const key = find_route_key(cmd, args);
+    if (!key) {
+      throw new Error(`Unmocked command: ${cmd} ${args.join(" ")}`);
+    }
+    const result = routes[key]!(args, opts);
+    if (result instanceof Error) throw result;
+    return { stdout: result.stdout, stderr: result.stderr ?? "" };
+  };
+
+  const stub = (..._args: unknown[]) => {
+    throw new Error("execFile mock: use promisify, not direct calls");
+  };
+  (stub as unknown as Record<symbol, unknown>)[promisify.custom] = promisified;
+
+  return { execFile: stub };
+});
+
+// ── Mocks for webhook handler deps ──
+
+vi.mock("../worktree-cleanup.js", () => ({
+  cleanup_after_merge: vi.fn(async () => {}),
+}));
+
+vi.mock("../sentry.js", () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  addBreadcrumb: vi.fn(),
+}));
+
+vi.mock("../actions.js", () => ({
+  detect_review_outcome: vi.fn(async () => "approved"),
+}));
+
+vi.mock("../issue-utils.js", () => ({
+  extract_first_linked_issue: vi.fn(() => null),
+  extract_linked_issues: vi.fn(() => []),
+  fetch_issue_context: vi.fn(async () => ""),
+  close_linked_issues: vi.fn(async () => []),
+  nwo_from_url: vi.fn(() => "test-org/lobster-farm"),
+}));
+
+// Mock persistence — keep in-memory stores for both PR and deploy triage state
+let mock_pr_state: Record<string, unknown> = {};
+let mock_deploy_state: Record<string, unknown> = {};
+vi.mock("../persistence.js", () => ({
+  load_pr_reviews: vi.fn(async () => mock_pr_state),
+  save_pr_reviews: vi.fn(async (state: Record<string, unknown>) => {
+    mock_pr_state = { ...state };
+  }),
+  load_deploy_triage: vi.fn(async () => mock_deploy_state),
+  save_deploy_triage: vi.fn(async (state: Record<string, unknown>) => {
+    mock_deploy_state = { ...state };
+  }),
+}));
+
+// Import after mocks are registered
+import {
+  build_deploy_triage_prompt,
+  MAX_DEPLOY_FIX_ATTEMPTS,
+  type CIFailureLog,
+} from "../review-utils.js";
+import {
+  handle_github_webhook,
+  type WebhookContext,
+} from "../webhook-handler.js";
+import type { GitHubAppAuth } from "../github-app.js";
+import type { EntityRegistry } from "../registry.js";
+import type { ClaudeSessionManager } from "../session.js";
+import type { DiscordBot } from "../discord.js";
+
+// ── build_deploy_triage_prompt tests ──
+
+describe("build_deploy_triage_prompt", () => {
+  it("includes workflow name, URL, run ID, and repo path", () => {
+    const prompt = build_deploy_triage_prompt(
+      "Deploy", "https://github.com/org/repo/actions/runs/123",
+      123, "/tmp/repo", [], 1, 2,
+    );
+
+    expect(prompt).toContain('Deploy');
+    expect(prompt).toContain("https://github.com/org/repo/actions/runs/123");
+    expect(prompt).toContain("123");
+    expect(prompt).toContain("/tmp/repo");
+  });
+
+  it("includes attempt counter", () => {
+    const prompt = build_deploy_triage_prompt(
+      "Deploy", "https://example.com", 1, "/tmp/repo", [], 2, 2,
+    );
+
+    expect(prompt).toContain("Attempt: 2/2");
+  });
+
+  it("includes failure logs when provided", () => {
+    const logs: CIFailureLog[] = [
+      { check_name: "deploy", log_output: "ResourceInitializationError: missing key" },
+    ];
+    const prompt = build_deploy_triage_prompt(
+      "Deploy", "https://example.com", 1, "/tmp/repo", logs, 1, 2,
+    );
+
+    expect(prompt).toContain("## Failure Logs");
+    expect(prompt).toContain("### deploy");
+    expect(prompt).toContain("ResourceInitializationError");
+  });
+
+  it("shows fallback message when no logs available", () => {
+    const prompt = build_deploy_triage_prompt(
+      "Deploy", "https://example.com", 42, "/tmp/repo", [], 1, 2,
+    );
+
+    expect(prompt).toContain("No failure logs could be fetched");
+    expect(prompt).toContain("gh run view 42 --log-failed");
+  });
+
+  it("includes triage instructions", () => {
+    const prompt = build_deploy_triage_prompt(
+      "Deploy", "https://example.com", 1, "/tmp/repo", [], 1, 2,
+    );
+
+    expect(prompt).toContain("Diagnose");
+    expect(prompt).toContain("Classify");
+    expect(prompt).toContain("Do NOT push directly to main");
+  });
+});
+
+// ── Integration tests: webhook handler spawns deploy triage ──
+
+const WEBHOOK_SECRET = "test-secret-for-deploy-triage";
+
+function sign_payload(payload: string): string {
+  const hmac = createHmac("sha256", WEBHOOK_SECRET).update(payload).digest("hex");
+  return `sha256=${hmac}`;
+}
+
+function make_request(
+  body: string,
+  headers: Record<string, string> = {},
+): IncomingMessage {
+  const emitter = new EventEmitter();
+  const req = emitter as unknown as IncomingMessage;
+  req.headers = { ...headers };
+
+  process.nextTick(() => {
+    emitter.emit("data", Buffer.from(body));
+    emitter.emit("end");
+  });
+
+  return req;
+}
+
+function make_response(): ServerResponse & { _status: number; _body: string } {
+  const res = {
+    _status: 0,
+    _body: "",
+    writeHead(s: number, _headers: Record<string, string>) {
+      res._status = s;
+    },
+    end(data: string) {
+      res._body = data;
+    },
+    headersSent: false,
+  } as unknown as ServerResponse & { _status: number; _body: string };
+  return res;
+}
+
+function make_github_app(): GitHubAppAuth {
+  return {
+    verify_signature: vi.fn((payload: string, sig: string) => {
+      const expected = createHmac("sha256", WEBHOOK_SECRET).update(payload).digest("hex");
+      return sig === `sha256=${expected}`;
+    }),
+    get_token: vi.fn().mockResolvedValue("ghs_mock_token"),
+    get_token_for_installation: vi.fn().mockImplementation(
+      (id: string) => Promise.resolve(`ghs_install_${id}`),
+    ),
+  } as unknown as GitHubAppAuth;
+}
+
+function make_registry(): EntityRegistry {
+  return {
+    get_active: vi.fn().mockReturnValue([
+      {
+        entity: {
+          id: "test-entity",
+          repos: [
+            {
+              name: "lobster-farm",
+              url: "https://github.com/test-org/lobster-farm.git",
+              path: "/tmp/test-repo",
+            },
+          ],
+        },
+      },
+    ]),
+  } as unknown as EntityRegistry;
+}
+
+function make_discord(): DiscordBot {
+  return {
+    send_to_entity: vi.fn().mockResolvedValue(undefined),
+  } as unknown as DiscordBot;
+}
+
+function make_session_manager(): ClaudeSessionManager {
+  const emitter = new EventEmitter();
+  const manager = Object.assign(emitter, {
+    spawn: vi.fn().mockResolvedValue({
+      session_id: "test-session-deploy",
+      entity_id: "test-entity",
+      feature_id: "deploy-triage-99999",
+      archetype: "planner",
+      started_at: new Date(),
+      pid: 12345,
+    }),
+    get_active: vi.fn().mockReturnValue([]),
+  });
+  return manager as unknown as ClaudeSessionManager;
+}
+
+function make_context(overrides: Partial<WebhookContext> = {}): WebhookContext {
+  return {
+    github_app: make_github_app(),
+    session_manager: make_session_manager(),
+    registry: make_registry(),
+    discord: make_discord(),
+    config: { paths: { lobsterfarm_dir: "/tmp/test-lf", projects_dir: "/tmp" } } as WebhookContext["config"],
+    pool: null,
+    pr_watches: null,
+    ...overrides,
+  };
+}
+
+function make_workflow_run_payload(run_id: number = 99999): string {
+  return JSON.stringify({
+    action: "completed",
+    workflow_run: {
+      id: run_id,
+      name: "Deploy",
+      conclusion: "failure",
+      event: "push",
+      head_branch: "main",
+      head_sha: "abc123def456",
+      html_url: `https://github.com/test-org/lobster-farm/actions/runs/${String(run_id)}`,
+    },
+    repository: { full_name: "test-org/lobster-farm" },
+    installation: { id: 12345 },
+  });
+}
+
+async function send_workflow_run_webhook(
+  ctx: WebhookContext,
+  run_id: number = 99999,
+): Promise<void> {
+  route_exec({
+    "gh run list": () => ({
+      stdout: JSON.stringify([
+        { databaseId: run_id, name: "Deploy" },
+      ]),
+    }),
+    "gh run view": () => ({
+      stdout: "Error: ResourceInitializationError\n  task definition revision mismatch\n",
+    }),
+  });
+
+  const payload = make_workflow_run_payload(run_id);
+  const req = make_request(payload, {
+    "x-hub-signature-256": sign_payload(payload),
+    "x-github-event": "workflow_run",
+  });
+  const res = make_response();
+
+  await handle_github_webhook(req, res, ctx);
+
+  // Wait for async processing
+  await new Promise((resolve) => setTimeout(resolve, 150));
+}
+
+describe("webhook handler — deploy triage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    mock_pr_state = {};
+    mock_deploy_state = {};
+  });
+
+  it("spawns Gary when a deploy workflow fails on main", async () => {
+    const ctx = make_context();
+    await send_workflow_run_webhook(ctx);
+
+    const sm = ctx.session_manager as unknown as { spawn: ReturnType<typeof vi.fn> };
+    const spawn_calls = sm.spawn.mock.calls;
+    const triage_spawn = spawn_calls.find(
+      (call: unknown[]) => (call[0] as { feature_id: string }).feature_id === "deploy-triage-99999",
+    );
+
+    expect(triage_spawn).toBeDefined();
+    expect((triage_spawn![0] as { archetype: string }).archetype).toBe("planner");
+    expect((triage_spawn![0] as { dna: string[] }).dna).toEqual(["planning-dna"]);
+    expect((triage_spawn![0] as { model: { model: string; think: string } }).model).toEqual({
+      model: "opus",
+      think: "high",
+    });
+  });
+
+  it("posts triage alert to #alerts", async () => {
+    const ctx = make_context();
+    await send_workflow_run_webhook(ctx);
+
+    const discord = ctx.discord as unknown as { send_to_entity: ReturnType<typeof vi.fn> };
+    expect(discord.send_to_entity).toHaveBeenCalledWith(
+      "test-entity",
+      "alerts",
+      expect.stringContaining("Gary triaging"),
+      "reviewer",
+    );
+    expect(discord.send_to_entity).toHaveBeenCalledWith(
+      "test-entity",
+      "alerts",
+      expect.stringContaining("attempt 1/2"),
+      "reviewer",
+    );
+  });
+
+  it("increments fix_attempts counter in deploy triage state", async () => {
+    const ctx = make_context();
+    await send_workflow_run_webhook(ctx);
+
+    const entry = mock_deploy_state["test-entity:99999"] as {
+      fix_attempts?: number;
+      entity_id?: string;
+      workflow_run_id?: number;
+    } | undefined;
+    expect(entry).toBeDefined();
+    expect(entry!.fix_attempts).toBe(1);
+    expect(entry!.entity_id).toBe("test-entity");
+    expect(entry!.workflow_run_id).toBe(99999);
+  });
+
+  it("stops after MAX_DEPLOY_FIX_ATTEMPTS (2) and alerts exhaustion", async () => {
+    // Pre-set the counter to the cap
+    mock_deploy_state = {
+      "test-entity:99999": {
+        entity_id: "test-entity",
+        workflow_run_id: 99999,
+        workflow_name: "Deploy",
+        workflow_url: "https://example.com",
+        head_sha: "abc123",
+        first_seen_at: new Date().toISOString(),
+        fix_attempts: MAX_DEPLOY_FIX_ATTEMPTS, // at cap
+        last_attempt_at: new Date().toISOString(),
+        resolved: false,
+      },
+    };
+
+    const ctx = make_context();
+    await send_workflow_run_webhook(ctx);
+
+    // Should NOT spawn Gary
+    const sm = ctx.session_manager as unknown as { spawn: ReturnType<typeof vi.fn> };
+    expect(sm.spawn).not.toHaveBeenCalled();
+
+    // Should alert about exhaustion
+    const discord = ctx.discord as unknown as { send_to_entity: ReturnType<typeof vi.fn> };
+    expect(discord.send_to_entity).toHaveBeenCalledWith(
+      "test-entity",
+      "alerts",
+      expect.stringContaining("Manual intervention needed"),
+      "reviewer",
+    );
+    expect(discord.send_to_entity).toHaveBeenCalledWith(
+      "test-entity",
+      "alerts",
+      expect.stringContaining("fix loop exhausted"),
+      "reviewer",
+    );
+  });
+
+  it("triggers safety valve when entity has 4+ attempts in 24h", async () => {
+    // Pre-set state with multiple runs accumulating 4 attempts
+    const recent = new Date().toISOString();
+    mock_deploy_state = {
+      "test-entity:11111": {
+        entity_id: "test-entity",
+        workflow_run_id: 11111,
+        workflow_name: "Deploy",
+        workflow_url: "https://example.com/1",
+        head_sha: "aaa",
+        first_seen_at: recent,
+        fix_attempts: 2,
+        last_attempt_at: recent,
+        resolved: false,
+      },
+      "test-entity:22222": {
+        entity_id: "test-entity",
+        workflow_run_id: 22222,
+        workflow_name: "Deploy",
+        workflow_url: "https://example.com/2",
+        head_sha: "bbb",
+        first_seen_at: recent,
+        fix_attempts: 2,
+        last_attempt_at: recent,
+        resolved: false,
+      },
+    };
+
+    const ctx = make_context();
+    // Send a new workflow run (different run ID, same entity)
+    await send_workflow_run_webhook(ctx, 33333);
+
+    // Should NOT spawn Gary
+    const sm = ctx.session_manager as unknown as { spawn: ReturnType<typeof vi.fn> };
+    expect(sm.spawn).not.toHaveBeenCalled();
+
+    // Should alert about safety valve
+    const discord = ctx.discord as unknown as { send_to_entity: ReturnType<typeof vi.fn> };
+    expect(discord.send_to_entity).toHaveBeenCalledWith(
+      "test-entity",
+      "alerts",
+      expect.stringContaining("safety valve"),
+      "reviewer",
+    );
+  });
+
+  it("does not trigger safety valve for old attempts (>24h)", async () => {
+    // Pre-set state with attempts from 48 hours ago (should not count)
+    const old_time = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+    mock_deploy_state = {
+      "test-entity:11111": {
+        entity_id: "test-entity",
+        workflow_run_id: 11111,
+        workflow_name: "Deploy",
+        workflow_url: "https://example.com/1",
+        head_sha: "aaa",
+        first_seen_at: old_time,
+        fix_attempts: 2,
+        last_attempt_at: old_time,
+        resolved: false,
+      },
+      "test-entity:22222": {
+        entity_id: "test-entity",
+        workflow_run_id: 22222,
+        workflow_name: "Deploy",
+        workflow_url: "https://example.com/2",
+        head_sha: "bbb",
+        first_seen_at: old_time,
+        fix_attempts: 2,
+        last_attempt_at: old_time,
+        resolved: false,
+      },
+    };
+
+    const ctx = make_context();
+    await send_workflow_run_webhook(ctx, 33333);
+
+    // Should spawn Gary — old attempts don't count
+    const sm = ctx.session_manager as unknown as { spawn: ReturnType<typeof vi.fn> };
+    const triage_spawn = sm.spawn.mock.calls.find(
+      (call: unknown[]) => (call[0] as { feature_id: string }).feature_id === "deploy-triage-33333",
+    );
+    expect(triage_spawn).toBeDefined();
+  });
+
+  it("does not consume retry slot on token resolution failure", async () => {
+    const ctx = make_context();
+
+    // Make token resolution fail
+    const github_app = ctx.github_app as unknown as {
+      get_token_for_installation: ReturnType<typeof vi.fn>;
+    };
+    github_app.get_token_for_installation = vi.fn().mockRejectedValue(
+      new Error("Certificate expired"),
+    );
+
+    route_exec({
+      "gh run list": () => ({
+        stdout: JSON.stringify([{ databaseId: 99999, name: "Deploy" }]),
+      }),
+      "gh run view": () => ({
+        stdout: "Error: deploy failed\n",
+      }),
+    });
+
+    const payload = make_workflow_run_payload();
+    const req = make_request(payload, {
+      "x-hub-signature-256": sign_payload(payload),
+      "x-github-event": "workflow_run",
+    });
+    const res = make_response();
+
+    await handle_github_webhook(req, res, ctx);
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    // fix_attempts should NOT have been incremented
+    const entry = mock_deploy_state["test-entity:99999"] as {
+      fix_attempts?: number;
+    } | undefined;
+    // Entry should not exist or have 0 attempts
+    expect(entry?.fix_attempts ?? 0).toBe(0);
+
+    // Should NOT have spawned Gary
+    const sm = ctx.session_manager as unknown as { spawn: ReturnType<typeof vi.fn> };
+    expect(sm.spawn).not.toHaveBeenCalled();
+  });
+
+  it("ignores workflow_run events that are not failures on main", async () => {
+    const ctx = make_context();
+
+    // Success event — should be ignored
+    const payload = JSON.stringify({
+      action: "completed",
+      workflow_run: {
+        id: 99999,
+        name: "Deploy",
+        conclusion: "success",
+        event: "push",
+        head_branch: "main",
+        head_sha: "abc123",
+        html_url: "https://example.com",
+      },
+      repository: { full_name: "test-org/lobster-farm" },
+      installation: { id: 12345 },
+    });
+
+    const req = make_request(payload, {
+      "x-hub-signature-256": sign_payload(payload),
+      "x-github-event": "workflow_run",
+    });
+    const res = make_response();
+
+    await handle_github_webhook(req, res, ctx);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const sm = ctx.session_manager as unknown as { spawn: ReturnType<typeof vi.fn> };
+    expect(sm.spawn).not.toHaveBeenCalled();
+  });
+
+  it("ignores workflow_run failures on non-main branches", async () => {
+    const ctx = make_context();
+
+    const payload = JSON.stringify({
+      action: "completed",
+      workflow_run: {
+        id: 99999,
+        name: "CI",
+        conclusion: "failure",
+        event: "push",
+        head_branch: "feature/test",
+        head_sha: "abc123",
+        html_url: "https://example.com",
+      },
+      repository: { full_name: "test-org/lobster-farm" },
+      installation: { id: 12345 },
+    });
+
+    const req = make_request(payload, {
+      "x-hub-signature-256": sign_payload(payload),
+      "x-github-event": "workflow_run",
+    });
+    const res = make_response();
+
+    await handle_github_webhook(req, res, ctx);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const sm = ctx.session_manager as unknown as { spawn: ReturnType<typeof vi.fn> };
+    expect(sm.spawn).not.toHaveBeenCalled();
+  });
+
+  it("passes GH_TOKEN to spawned Gary session", async () => {
+    const ctx = make_context();
+    await send_workflow_run_webhook(ctx);
+
+    const sm = ctx.session_manager as unknown as { spawn: ReturnType<typeof vi.fn> };
+    const triage_spawn = sm.spawn.mock.calls.find(
+      (call: unknown[]) => (call[0] as { feature_id: string }).feature_id === "deploy-triage-99999",
+    );
+
+    expect(triage_spawn).toBeDefined();
+    expect((triage_spawn![0] as { env: Record<string, string> }).env).toEqual({
+      GH_TOKEN: "ghs_install_12345",
+    });
+  });
+});

--- a/packages/daemon/src/persistence.ts
+++ b/packages/daemon/src/persistence.ts
@@ -8,6 +8,7 @@ const STATE_DIR = "state";
 const PR_REVIEWS_FILE = "pr-reviews.json";
 const POOL_STATE_FILE = "pool-state.json";
 const PR_WATCHES_FILE = "pr-watches.json";
+const DEPLOY_TRIAGE_FILE = "deploy-triage.json";
 
 function state_dir(config: LobsterFarmConfig): string {
   return join(lobsterfarm_dir(config.paths), STATE_DIR);
@@ -23,6 +24,10 @@ function pool_state_path(config: LobsterFarmConfig): string {
 
 function pr_watches_path(config: LobsterFarmConfig): string {
   return join(state_dir(config), PR_WATCHES_FILE);
+}
+
+function deploy_triage_path(config: LobsterFarmConfig): string {
+  return join(state_dir(config), DEPLOY_TRIAGE_FILE);
 }
 
 // ── PR Review State ──
@@ -303,6 +308,50 @@ export async function load_pr_watches(config: LobsterFarmConfig): Promise<PRWatc
     const data: unknown = JSON.parse(content);
     if (typeof data !== "object" || data === null || Array.isArray(data)) return {};
     return data as PRWatchState;
+  } catch {
+    return {};
+  }
+}
+
+// ── Deploy Triage State (#199) ──
+
+export interface DeployTriageEntry {
+  entity_id: string;
+  workflow_run_id: number;
+  workflow_name: string;
+  workflow_url: string;
+  head_sha: string;              // commit that triggered the deploy
+  first_seen_at: string;         // ISO timestamp
+  fix_attempts: number;          // incremented on each Gary spawn
+  last_attempt_at: string;       // ISO timestamp
+  resolved: boolean;
+}
+
+/** Keyed by "entity_id:workflow_run_id" */
+export type DeployTriageState = Record<string, DeployTriageEntry>;
+
+/** Save deploy triage state to disk. Uses atomic write-to-temp-then-rename. */
+export async function save_deploy_triage(
+  state: DeployTriageState,
+  config: LobsterFarmConfig,
+): Promise<void> {
+  const path = deploy_triage_path(config);
+  const tmp_path = `${path}.${randomUUID().slice(0, 8)}.tmp`;
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(tmp_path, JSON.stringify(state, null, 2), "utf-8");
+  await rename(tmp_path, path);
+}
+
+/** Load deploy triage state from disk. Returns empty object if file doesn't exist. */
+export async function load_deploy_triage(
+  config: LobsterFarmConfig,
+): Promise<DeployTriageState> {
+  const path = deploy_triage_path(config);
+  try {
+    const content = await readFile(path, "utf-8");
+    const data: unknown = JSON.parse(content);
+    if (typeof data !== "object" || data === null || Array.isArray(data)) return {};
+    return data as DeployTriageState;
   } catch {
     return {};
   }

--- a/packages/daemon/src/review-utils.ts
+++ b/packages/daemon/src/review-utils.ts
@@ -443,6 +443,10 @@ export async function check_ci_status(
 /** Maximum number of CI fix attempts before escalating to a human (#196). */
 export const MAX_CI_FIX_ATTEMPTS = 3;
 
+/** Maximum number of deploy triage attempts before escalating to a human (#199).
+ * Lower than CI fix cap — deploy failures on main are higher stakes. */
+export const MAX_DEPLOY_FIX_ATTEMPTS = 2;
+
 // ── CI failure log fetching (#196) ──
 
 /** Max number of lines to keep per failed job's log output. */
@@ -579,6 +583,76 @@ export function build_ci_fix_prompt(
     "",
     "Keep changes minimal and targeted — only fix what CI is complaining about.",
     "Do NOT merge the PR.",
+  );
+
+  return lines.join("\n");
+}
+
+// ── Deploy triage prompt (#199) ──
+
+/**
+ * Build the prompt given to Gary (planner) when triaging a deploy failure on main.
+ *
+ * Gary will diagnose the failure, classify it, and decide whether to fix forward
+ * (open a hotfix PR), recommend rollback, or escalate to a human.
+ */
+export function build_deploy_triage_prompt(
+  workflow_name: string,
+  workflow_url: string,
+  run_id: number,
+  repo_path: string,
+  failure_logs: CIFailureLog[],
+  attempt: number,
+  max_attempts: number,
+): string {
+  const lines = [
+    `## Deploy Failure Triage`,
+    ``,
+    `Workflow "${workflow_name}" failed on main.`,
+    `Run: ${workflow_url}`,
+    `Run ID: ${String(run_id)}`,
+    `Repository: ${repo_path}`,
+    `Attempt: ${String(attempt)}/${String(max_attempts)}`,
+    ``,
+  ];
+
+  if (failure_logs.length > 0) {
+    lines.push(`## Failure Logs`, ``);
+
+    for (const log of failure_logs) {
+      lines.push(
+        `### ${log.check_name}`,
+        ``,
+        "```",
+        log.log_output,
+        "```",
+        ``,
+      );
+    }
+  } else {
+    lines.push(
+      `(No failure logs could be fetched from GitHub Actions.`,
+      `Run \`gh run view ${String(run_id)} --log-failed\` manually, or check CloudWatch.)`,
+      ``,
+    );
+  }
+
+  lines.push(
+    `## Instructions`,
+    ``,
+    `1. **Diagnose** — read the failure logs above. Identify the failing step and root cause.`,
+    `2. **Classify** — is this a code issue, infra/config issue, or external dependency failure?`,
+    `3. **Decide** — fix forward (hotfix branch + PR), recommend rollback, or escalate to human.`,
+    `4. **Act**:`,
+    `   - For code fixes: create a hotfix branch, fix the issue, open a PR with \`Closes\` link if applicable.`,
+    `   - For infra/config: post diagnosis and recommended fix to #alerts and escalate.`,
+    `   - If unclear: post full diagnosis to #alerts and escalate.`,
+    ``,
+    `Rules:`,
+    `- Do NOT push directly to main. All fixes go through PRs.`,
+    `- Do NOT attempt rollbacks (git revert on main) without human approval.`,
+    `- If GitHub Actions logs are insufficient, note this and recommend checking CloudWatch.`,
+    `- Keep fixes minimal and targeted.`,
   );
 
   return lines.join("\n");

--- a/packages/daemon/src/webhook-handler.ts
+++ b/packages/daemon/src/webhook-handler.ts
@@ -25,14 +25,17 @@ import {
   fetch_issue_context,
   nwo_from_url,
 } from "./issue-utils.js";
-import { load_pr_reviews, save_pr_reviews } from "./persistence.js";
+import { load_pr_reviews, save_pr_reviews, load_deploy_triage, save_deploy_triage } from "./persistence.js";
+import type { DeployTriageEntry } from "./persistence.js";
 import type { BotPool } from "./pool.js";
 import type { PRWatchStore } from "./pr-watches.js";
 import type { EntityRegistry } from "./registry.js";
 import {
   MAX_CI_FIX_ATTEMPTS,
+  MAX_DEPLOY_FIX_ATTEMPTS,
   attempt_auto_merge,
   build_ci_fix_prompt,
+  build_deploy_triage_prompt,
   build_review_fix_prompt,
   check_ci_status,
   fetch_ci_failure_logs,
@@ -68,10 +71,12 @@ interface WebhookPR {
 
 /** Minimal workflow_run shape from webhook payload. */
 interface WebhookWorkflowRun {
+  id: number;
   name: string;
   conclusion: string | null;
   event: string;
   head_branch: string;
+  head_sha: string;
   html_url: string;
 }
 
@@ -771,6 +776,155 @@ async function spawn_ci_fixer(
   }
 }
 
+// ── Deploy triage spawning (#199) ──
+
+/** Safety valve: max total deploy fix attempts across all runs for one entity in 24h. */
+const DEPLOY_SAFETY_VALVE = 4;
+
+/**
+ * Spawn a Gary (planner) session to triage a deploy failure on main.
+ *
+ * Modeled on spawn_ci_fixer() but routes through the planner archetype
+ * since deploy failures span a wider problem space (code, infra, config).
+ *
+ * Dedup: keyed by "entity_id:workflow_run_id". Same run ID won't spawn twice.
+ * Retry cap: MAX_DEPLOY_FIX_ATTEMPTS (2) per workflow run.
+ * Safety valve: 4+ total attempts for one entity in 24h pauses auto-triage.
+ * Token failure: does NOT consume a retry slot (same pattern as CI fix loop).
+ */
+async function spawn_deploy_triage(
+  entity_id: string,
+  repo_path: string,
+  workflow: WebhookWorkflowRun,
+  ctx: WebhookContext,
+  installation_id?: string,
+): Promise<void> {
+  const triage_key = `${entity_id}:${String(workflow.id)}`;
+  const state = await load_deploy_triage(ctx.config);
+
+  // Dedup + retry cap: if we already have an entry at or above the cap, stop.
+  const existing = state[triage_key];
+  if (existing && existing.fix_attempts >= MAX_DEPLOY_FIX_ATTEMPTS) {
+    console.log(
+      `[webhook] Deploy triage exhausted for ${triage_key} ` +
+      `(${String(existing.fix_attempts)}/${String(MAX_DEPLOY_FIX_ATTEMPTS)}) — skipping`,
+    );
+    await notify_alerts(
+      entity_id,
+      `Deploy fix loop exhausted for workflow "${workflow.name}" ` +
+      `(${String(MAX_DEPLOY_FIX_ATTEMPTS)} attempts). Manual intervention needed. ${workflow.html_url}`,
+      ctx,
+    );
+    return;
+  }
+
+  // Safety valve: count total deploy fix attempts for this entity in the last 24h.
+  const twenty_four_hours_ago = Date.now() - 24 * 60 * 60 * 1000;
+  let entity_attempts_24h = 0;
+  for (const entry of Object.values(state)) {
+    if (
+      entry.entity_id === entity_id &&
+      new Date(entry.last_attempt_at).getTime() > twenty_four_hours_ago
+    ) {
+      entity_attempts_24h += entry.fix_attempts;
+    }
+  }
+  if (entity_attempts_24h >= DEPLOY_SAFETY_VALVE) {
+    console.log(
+      `[webhook] Deploy safety valve triggered for ${entity_id} ` +
+      `(${String(entity_attempts_24h)} attempts in 24h) — skipping`,
+    );
+    await notify_alerts(
+      entity_id,
+      `Deploy auto-triage paused for ${entity_id}: ${String(entity_attempts_24h)} fix attempts ` +
+      `in 24h (safety valve = ${String(DEPLOY_SAFETY_VALVE)}). Manual intervention needed.`,
+      ctx,
+    );
+    return;
+  }
+
+  // Resolve token BEFORE incrementing attempt counter — transient token
+  // errors (cert issues, rate limits) shouldn't consume retry slots.
+  let gh_token: string;
+  try {
+    gh_token = await resolve_token(ctx.github_app, installation_id);
+  } catch (err) {
+    console.error(`[webhook] Failed to get token for deploy triage: ${String(err)}`);
+    sentry.captureException(err, {
+      tags: { module: "webhook", entity: entity_id, action: "deploy_triage_token" },
+      contexts: { workflow: { name: workflow.name, run_id: workflow.id } },
+    });
+    return;
+  }
+
+  // Increment attempt counter and save state
+  const now = new Date().toISOString();
+  const attempt = (existing?.fix_attempts ?? 0) + 1;
+  const entry: DeployTriageEntry = {
+    entity_id,
+    workflow_run_id: workflow.id,
+    workflow_name: workflow.name,
+    workflow_url: workflow.html_url,
+    head_sha: workflow.head_sha,
+    first_seen_at: existing?.first_seen_at ?? now,
+    fix_attempts: attempt,
+    last_attempt_at: now,
+    resolved: false,
+  };
+  state[triage_key] = entry;
+  await save_deploy_triage(state, ctx.config);
+
+  // Fetch failure logs from GitHub Actions
+  const failure_logs = await fetch_ci_failure_logs(
+    "main", repo_path, gh_token,
+  );
+
+  // Build prompt for Gary
+  const prompt = build_deploy_triage_prompt(
+    workflow.name,
+    workflow.html_url,
+    workflow.id,
+    repo_path,
+    failure_logs,
+    attempt,
+    MAX_DEPLOY_FIX_ATTEMPTS,
+  );
+
+  console.log(
+    `[webhook] Spawning Gary for deploy triage in ${entity_id} ` +
+    `(run ${String(workflow.id)}, attempt ${String(attempt)}/${String(MAX_DEPLOY_FIX_ATTEMPTS)})`,
+  );
+
+  await notify_alerts(
+    entity_id,
+    `\u26a0\ufe0f Deploy failed on main — Gary triaging ` +
+    `(attempt ${String(attempt)}/${String(MAX_DEPLOY_FIX_ATTEMPTS)}). ${workflow.html_url}`,
+    ctx,
+  );
+
+  try {
+    await ctx.session_manager.spawn({
+      entity_id,
+      feature_id: `deploy-triage-${String(workflow.id)}`,
+      archetype: "planner" as ArchetypeRole,
+      dna: ["planning-dna"],
+      model: { model: "opus", think: "high" },
+      worktree_path: repo_path,
+      prompt,
+      interactive: false,
+      env: { GH_TOKEN: gh_token },
+    });
+  } catch (err) {
+    console.error(
+      `[webhook] Failed to spawn deploy triage for run ${String(workflow.id)}: ${String(err)}`,
+    );
+    sentry.captureException(err, {
+      tags: { module: "webhook", entity: entity_id, action: "spawn_deploy_triage" },
+      contexts: { workflow: { name: workflow.name, run_id: workflow.id } },
+    });
+  }
+}
+
 // ── Prompt building ──
 
 function build_reviewer_prompt(pr: WebhookPR, repo_path: string, issue_context: string): string {
@@ -1000,14 +1154,16 @@ async function handle_workflow_run(payload: WebhookPayload, ctx: WebhookContext)
     return;
   }
 
+  const installation_id = payload.installation?.id != null
+    ? String(payload.installation.id)
+    : undefined;
+
   console.log(
     `[webhook] Workflow "${workflow.name}" failed on main in ${match.entity_id} (${repo_full_name})`,
   );
 
-  await notify_alerts(
-    match.entity_id,
-    `\u26a0\ufe0f Workflow "${workflow.name}" failed on main (${workflow.html_url})`,
-    ctx,
+  await spawn_deploy_triage(
+    match.entity_id, match.repo_path, workflow, ctx, installation_id,
   );
 }
 


### PR DESCRIPTION
## Summary

- When a deploy workflow fails on main, the daemon now spawns a Gary (planner) session to diagnose the failure, classify it (code vs infra vs config), and either fix forward via a hotfix PR or escalate to #alerts
- Modeled on the CI fix loop pattern (`spawn_ci_fixer`) with a lower retry cap (2 attempts per workflow run) and a 24h safety valve (4+ total attempts per entity pauses auto-triage)
- Token resolution failures do not consume retry slots, matching the CI fix loop's graceful handling

### Files changed

- **`persistence.ts`** -- `DeployTriageEntry` interface, `DeployTriageState` type, `save_deploy_triage()`, `load_deploy_triage()` with atomic writes
- **`review-utils.ts`** -- `MAX_DEPLOY_FIX_ATTEMPTS = 2` constant, `build_deploy_triage_prompt()` function
- **`webhook-handler.ts`** -- `id`/`head_sha` added to `WebhookWorkflowRun`, `spawn_deploy_triage()` function, `handle_workflow_run()` updated to spawn triage
- **`ci-gating.test.ts`** -- Updated existing workflow_run test for new alert wording and payload shape, added deploy triage persistence mock
- **`deploy-triage.test.ts`** -- 15 new unit tests covering retry cap, safety valve, dedup, token failure, prompt construction, and event filtering

## Test plan

- [x] All 15 deploy-triage tests pass (retry cap, safety valve, dedup, token failure, prompt construction)
- [x] All 16 ci-gating tests pass (including updated workflow_run alert test)
- [x] All 18 ci-fix-loop tests pass (no regression)
- [x] Full test suite passes (724 tests across 45 files)

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)