### PR TITLE
feat: add CI pipeline for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
+        with:
+          version: 9
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` — runs on every PR to `main`
- Steps: checkout → pnpm setup → Node 22 → install → build → lint → typecheck → test
- Build runs first because workspace packages (`@lobster-farm/shared`) must be compiled before lint/typecheck/test can resolve imports
- Single job keeps it simple for a small monorepo

The daemon's CI gating infrastructure (check_ci_status, ci-fix-loop, retry_approved_unmerged) is already in place — this workflow activates it.

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)