### PR TITLE
fix: suppress noExplicitAny lint warnings in test files

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -29,6 +29,18 @@
       }
     }
   },
+  "overrides": [
+    {
+      "include": ["**/__tests__/**", "**/*.test.ts", "**/*.spec.ts"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noExplicitAny": "off"
+          }
+        }
+      }
+    }
+  ],
   "files": {
     "ignore": ["dist/", "node_modules/", ".claude/", "worktrees/", "coverage/"]
   }


### PR DESCRIPTION
## Summary
- Adds Biome override to disable `noExplicitAny` in test files (`__tests__/`, `*.test.ts`, `*.spec.ts`)
- Test mocks legitimately need `as any` casts — 49 warnings eliminated
- Production code still warns on explicit `any`

## Test plan
- [x] `pnpm lint` exits 0 with zero warnings
- [ ] CI passes (lint + typecheck + test)

Closes #N/A — housekeeping fix for Biome setup (#211)

🤖 Generated with [Claude Code](https://claude.com/claude-code)