### PR TITLE
docs: update operator-dna to reference Biome instead of ESLint

### DIFF
--- a/config/claude/skills/operator-dna/SKILL.md
+++ b/config/claude/skills/operator-dna/SKILL.md
@@ -34,7 +34,7 @@ Every repo with production code must have CI workflows. No exceptions.
 
 | Language | Checks | Tools |
 |----------|--------|-------|
-| TypeScript / JavaScript | Lint, Type-check, Build | ESLint, `tsc --noEmit`, `next build` or `vite build` |
+| TypeScript / JavaScript | Lint, Type-check, Build | Biome, `tsc --noEmit`, `next build` or `vite build` |
 | Python | Lint, Type-check | Ruff, mypy |
 
 ### Workflow Structure


### PR DESCRIPTION
## Summary
- Updates the CI pipeline standards table in operator-dna to list Biome instead of ESLint as the TS/JS linter
- Biome is now our standard (PR #215)

## Test plan
- [x] Verified the change is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)