### PR TITLE
chore: add draft PR workflow and validation checklist to coding DNA

### DIFF
--- a/config/claude/skills/coding-dna/SKILL.md
+++ b/config/claude/skills/coding-dna/SKILL.md
@@ -746,11 +746,17 @@ Before marking a PR as ready, verify:
 # Open draft PR at the start of work
 gh pr create --draft --title "feat: add token market cap backfill" --body "WIP"
 
-# Keep iterating...
-git add -A && git commit -m "fix: handle API rate limits"
+# Keep iterating — stage specific files, not -A
+git add src/api/rate-limit.ts && git commit -m "fix: handle API rate limits"
 git push
 
-# When validated, mark ready (triggers auto-review → auto-merge)
+# When validated, update PR body with full description and issue link
+gh pr edit --body "## Summary
+- Added rate limit handling for external API calls
+
+Closes #123"
+
+# Then mark ready (triggers auto-review → auto-merge)
 gh pr ready
 ```
 

--- a/config/claude/skills/coding-dna/SKILL.md
+++ b/config/claude/skills/coding-dna/SKILL.md
@@ -726,6 +726,34 @@ The code never knows or cares that 1Password is involved. It just reads env vars
 
 Git workflow (branching rules, PR process, merge policy) is defined per-project in each repo's `CLAUDE.md`. Read it before starting work.
 
+### Pull Requests — Draft vs. Ready
+
+**Open a draft PR when you start a feature branch.** This gives visibility (the branch and diff are trackable) without triggering review or auto-merge. Keep pushing commits as you iterate.
+
+**Only convert to "Ready for Review" when the implementation is validated end-to-end.** The auto-reviewer will pick it up, review, and merge automatically. There is no going back — once it's ready, it's in the merge pipeline.
+
+Before marking a PR as ready, verify:
+- [ ] The feature works end-to-end, not just "code compiles"
+- [ ] For backend changes: the server starts, routes respond correctly
+- [ ] For database changes: migrations run cleanly (up and down)
+- [ ] For infra/deploy changes: the build succeeds, the deploy works
+- [ ] For data pipelines: the pipeline has run successfully against real data at least once
+- [ ] For frontend changes: the page renders, interactions work, no console errors
+
+**The goal is one PR per feature, not one PR per attempt.** If you find issues after pushing, fix them on the same branch and push again — don't merge and open a new PR.
+
+```bash
+# Open draft PR at the start of work
+gh pr create --draft --title "feat: add token market cap backfill" --body "WIP"
+
+# Keep iterating...
+git add -A && git commit -m "fix: handle API rate limits"
+git push
+
+# When validated, mark ready (triggers auto-review → auto-merge)
+gh pr ready
+```
+
 ### Commits
 
 **Conventional commits:**
@@ -1054,6 +1082,7 @@ Loggers are configurable per-environment. In prod you want structured logs. In d
 | `asyncio.run()` inside library code | Async-native functions + sync wrappers |
 | One massive `utils.py` | Split by domain: `time_utils`, `text`, `pandas_utils` |
 | `inplace=True` parameter pattern | Always return new objects. Immutability is clarity. |
+| Opening a ready PR before validating | Open as draft, iterate, mark ready when it works |
 
 ---
 

--- a/config/claude/skills/coding-dna/SKILL.md
+++ b/config/claude/skills/coding-dna/SKILL.md
@@ -760,6 +760,8 @@ Closes #123"
 gh pr ready
 ```
 
+> **See also:** [PR Workflow](#pr-workflow) below for verification requirements (`none` vs `user` gate) and watch registration.
+
 ### Commits
 
 **Conventional commits:**
@@ -802,6 +804,8 @@ LOCAL = True if os.getcwd().split('/')[1] == 'Users' else False
 ---
 
 ## PR Workflow
+
+> **See also:** [Pull Requests — Draft vs. Ready](#pull-requests--draft-vs-ready) above for the draft → ready lifecycle and validation checklist.
 
 ### Check the Spec's Verification Requirement
 


### PR DESCRIPTION
## Summary

- Adds a "Pull Requests — Draft vs. Ready" subsection to the coding DNA under Git & Environments, between "Branching" and "Commits"
- Includes a validation checklist builders must verify before marking a PR as ready for review (backend, database, infra, pipeline, frontend)
- Includes `gh pr create --draft` / `gh pr ready` command examples
- Adds "Opening a ready PR before validating" to the anti-patterns table

Paired with #224 (auto-reviewer skips draft PRs). Together they create the gate: builders iterate on drafts, only mark ready when validated, and the auto-reviewer enforces the boundary.

The deployed copy at `~/.claude/skills/coding-dna/SKILL.md` has also been updated to match.

Closes #225

## Test plan

- [x] New subsection appears after "Branching" and before "Commits" in Git & Environments
- [x] Validation checklist is present with all six categories
- [x] Bash code block with `gh pr create --draft` / `gh pr ready` examples is present
- [x] Anti-patterns table has the new row
- [x] No other sections of coding DNA are modified (diff is additive only, 29 lines)
- [x] Both files updated: repo template and deployed copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)