### PR TITLE
fix: status embed idle detection always returning true

### DIFF
--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -639,6 +639,12 @@ export class DiscordBot extends EventEmitter {
     // Fire immediately, then repeat
     void this.send_typing(channel_id);
 
+    // Track consecutive idle checks to avoid premature finalization.
+    // The MCP plugin needs time to deliver the message to the bot — if we
+    // check idle on the very first tick the bot may not have started yet.
+    let consecutive_idle = 0;
+    const IDLE_THRESHOLD = 2; // require 2 consecutive idle checks (~8s) before finalizing
+
     // NOTE: is_bot_idle() calls execFileSync("tmux", ...) — synchronous and blocking.
     // Fine at current scale (sub-ms per call), but if pool utilization grows this
     // should be replaced with an async tmux check or a dedicated idle-state event.
@@ -650,17 +656,28 @@ export class DiscordBot extends EventEmitter {
       }
 
       const bot = this._pool.get_assignment(channel_id);
-      if (!bot || this._pool.is_bot_idle(bot)) {
+      if (!bot) {
         this.stop_typing_loop(channel_id);
         void this.finalize_status_embed(channel_id);
         return;
+      }
+
+      if (this._pool.is_bot_idle(bot)) {
+        consecutive_idle++;
+        if (consecutive_idle >= IDLE_THRESHOLD) {
+          this.stop_typing_loop(channel_id);
+          void this.finalize_status_embed(channel_id);
+          return;
+        }
+      } else {
+        consecutive_idle = 0;
       }
 
       void this.send_typing(channel_id);
 
       // Parse tmux output and update the status embed if activity changed
       void this.update_status_embed_from_tmux(channel_id, bot);
-    }, 8000);
+    }, 4000);
 
     this.typing_loops.set(channel_id, interval);
   }

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -1028,8 +1028,15 @@ export class BotPool extends EventEmitter {
       });
       const lines = output.trim().split("\n");
       const last_line = lines[lines.length - 1] ?? "";
-      // "bypass permissions" matches the Claude Code workspace trust dialog text.
-      // This is UI-text dependent and may break if Claude Code changes the dialog wording.
+
+      // Claude Code's status bar always shows "bypass permissions on (shift+tab to cycle)"
+      // at the bottom of the pane. When actively processing, it ALSO shows
+      // "esc to interrupt" — that's the reliable indicator the bot is working.
+      if (last_line.includes("esc to interrupt")) return false;
+
+      // If no "esc to interrupt", check for idle indicators:
+      // - ❯ prompt visible (waiting for input)
+      // - "bypass permissions" in status bar without "esc to interrupt" (idle at prompt)
       return last_line.includes("❯") || last_line.includes("bypass permissions");
     } catch {
       return true; // Can't check — assume idle (fail-open for eviction)


### PR DESCRIPTION
## Summary
- **Root cause**: `is_bot_idle()` checked for `"bypass permissions"` in the last tmux line, but that text is **always present** in Claude Code's status bar — whether idle or processing. So every bot was always detected as idle, causing the embed to finalize after one 8-second poll cycle.
- **Fix**: Check for `"esc to interrupt"` first — that text only appears during active processing. If present, the bot is NOT idle.
- Reduced polling interval from 8s → 4s for more responsive activity updates in the embed
- Added consecutive idle threshold (2 checks = ~8s) before finalizing, preventing premature "Done" when message delivery is still in-flight

## Test plan
- [ ] Send a message in an entity channel, verify the embed shows live activity (e.g. "Reading files", "Running commands") and updates every ~4s
- [ ] Verify embed shows "Done" only after the bot actually finishes responding
- [ ] Verify idle eviction still works correctly (bot pool cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)