### PR TITLE
feat: status embeds + session resume for Commander (Pat)

### DIFF
--- a/packages/daemon/src/commander-process.ts
+++ b/packages/daemon/src/commander-process.ts
@@ -19,7 +19,7 @@ export interface CommanderHealth {
   tmux_session: string;
 }
 
-const TMUX_SESSION = "pat";
+export const PAT_TMUX_SESSION = "pat";
 const BACKOFF_SCHEDULE = [0, 5_000, 15_000, 60_000, 300_000];
 const BACKOFF_RESET_MS = 10 * 60 * 1000; // 10 min stable → reset counter
 const MAX_RESTARTS = 5;
@@ -82,7 +82,7 @@ export class CommanderProcess extends EventEmitter {
   /** Check if the tmux session is alive. */
   private is_tmux_alive(): boolean {
     try {
-      execFileSync("tmux", ["has-session", "-t", TMUX_SESSION], {
+      execFileSync("tmux", ["has-session", "-t", PAT_TMUX_SESSION], {
         stdio: "ignore",
       });
       return true;
@@ -94,9 +94,13 @@ export class CommanderProcess extends EventEmitter {
   /** Get the PID of the main process inside the tmux session. */
   private get_tmux_pid(): number | null {
     try {
-      const out = execFileSync("tmux", ["list-panes", "-t", TMUX_SESSION, "-F", "#{pane_pid}"], {
-        encoding: "utf-8",
-      }).trim();
+      const out = execFileSync(
+        "tmux",
+        ["list-panes", "-t", PAT_TMUX_SESSION, "-F", "#{pane_pid}"],
+        {
+          encoding: "utf-8",
+        },
+      ).trim();
       const pid = Number.parseInt(out, 10);
       return Number.isNaN(pid) ? null : pid;
     } catch {
@@ -119,7 +123,7 @@ export class CommanderProcess extends EventEmitter {
     // Kill any stale tmux session
     if (this.is_tmux_alive()) {
       try {
-        execFileSync("tmux", ["kill-session", "-t", TMUX_SESSION], {
+        execFileSync("tmux", ["kill-session", "-t", PAT_TMUX_SESSION], {
           stdio: "ignore",
         });
       } catch {
@@ -165,7 +169,7 @@ export class CommanderProcess extends EventEmitter {
 
     const claude_cmd = claude_args.join(" ");
 
-    console.log(`[commander] Starting ${agent_name} in tmux session "${TMUX_SESSION}"...`);
+    console.log(`[commander] Starting ${agent_name} in tmux session "${PAT_TMUX_SESSION}"...`);
 
     // Create a detached tmux session running Claude Code.
     // DISCORD_STATE_DIR is set so the channel plugin reads from the right dir.
@@ -175,7 +179,7 @@ export class CommanderProcess extends EventEmitter {
         "new-session",
         "-d",
         "-s",
-        TMUX_SESSION,
+        PAT_TMUX_SESSION,
         "-x",
         "200",
         "-y",
@@ -214,7 +218,7 @@ export class CommanderProcess extends EventEmitter {
         // Auto-accept it after a brief delay for the UI to render.
         setTimeout(() => {
           try {
-            execFileSync("tmux", ["send-keys", "-t", TMUX_SESSION, "Enter"], {
+            execFileSync("tmux", ["send-keys", "-t", PAT_TMUX_SESSION, "Enter"], {
               stdio: "ignore",
             });
           } catch {
@@ -333,7 +337,7 @@ export class CommanderProcess extends EventEmitter {
     if (this.is_tmux_alive()) {
       console.log("[commander] Stopping tmux session...");
       try {
-        execFileSync("tmux", ["kill-session", "-t", TMUX_SESSION], {
+        execFileSync("tmux", ["kill-session", "-t", PAT_TMUX_SESSION], {
           stdio: "ignore",
         });
       } catch {
@@ -358,7 +362,7 @@ export class CommanderProcess extends EventEmitter {
           : null,
       restart_count: this.restart_count,
       last_started_at: this.last_started_at?.toISOString() ?? null,
-      tmux_session: TMUX_SESSION,
+      tmux_session: PAT_TMUX_SESSION,
     };
   }
 }

--- a/packages/daemon/src/commander-process.ts
+++ b/packages/daemon/src/commander-process.ts
@@ -1,7 +1,7 @@
 import { execFileSync, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { LobsterFarmConfig } from "@lobster-farm/shared";
@@ -66,6 +66,15 @@ export class CommanderProcess extends EventEmitter {
   /** Persist the session_id so future restarts can resume. */
   private async write_session_id(session_id: string): Promise<void> {
     await writeFile(this.session_state_path(), JSON.stringify({ session_id }, null, 2), "utf-8");
+  }
+
+  /** Clear persisted session state so the next startup begins fresh. */
+  private async clear_session_id(): Promise<void> {
+    try {
+      await unlink(this.session_state_path());
+    } catch {
+      /* ignore — file may not exist */
+    }
   }
 
   /** Check if Pat's bot token is configured. */
@@ -306,6 +315,9 @@ export class CommanderProcess extends EventEmitter {
           tags: { module: "commander" },
         },
       );
+      // Clear persisted session so the next daemon startup gets a fresh session
+      // instead of re-entering a resume loop on an expired session ID.
+      void this.clear_session_id().catch(() => {});
       this.emit("gave_up", this.restart_count);
       return;
     }

--- a/packages/daemon/src/commander-process.ts
+++ b/packages/daemon/src/commander-process.ts
@@ -1,6 +1,7 @@
 import { execFileSync, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { LobsterFarmConfig } from "@lobster-farm/shared";
@@ -44,6 +45,27 @@ export class CommanderProcess extends EventEmitter {
   /** State directory for Pat's Discord channel plugin. */
   private state_dir(): string {
     return join(lobsterfarm_dir(this.config.paths), "channels", "pat");
+  }
+
+  /** Path to the session state file (persists session_id across restarts). */
+  private session_state_path(): string {
+    return join(this.state_dir(), "session-state.json");
+  }
+
+  /** Read the persisted session_id, if any. Returns null on missing or corrupt file. */
+  private async read_session_id(): Promise<string | null> {
+    try {
+      const content = await readFile(this.session_state_path(), "utf-8");
+      const state = JSON.parse(content) as { session_id?: string };
+      return state.session_id ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Persist the session_id so future restarts can resume. */
+  private async write_session_id(session_id: string): Promise<void> {
+    await writeFile(this.session_state_path(), JSON.stringify({ session_id }, null, 2), "utf-8");
   }
 
   /** Check if Pat's bot token is configured. */
@@ -110,7 +132,14 @@ export class CommanderProcess extends EventEmitter {
     const agent_name = this.config.agents.commander.name.toLowerCase();
     const working_dir = lobsterfarm_dir(this.config.paths);
 
-    const claude_cmd = [
+    // Resolve session ID for resume support. If we have a persisted session_id
+    // from a previous run, use --resume to restore conversation context.
+    // Otherwise generate a fresh ID and use --session-id to establish it.
+    const existing_session_id = await this.read_session_id();
+    const is_resume = existing_session_id !== null;
+    const session_id = existing_session_id ?? randomUUID();
+
+    const claude_args = [
       sq(claude_bin),
       "--channels",
       "plugin:discord@claude-plugins-official",
@@ -124,7 +153,17 @@ export class CommanderProcess extends EventEmitter {
       sq(working_dir),
       "--add-dir",
       sq(homedir()),
-    ].join(" ");
+    ];
+
+    if (is_resume) {
+      claude_args.push("--resume", sq(session_id));
+      console.log(`[commander] Resuming session ${session_id.slice(0, 8)}...`);
+    } else {
+      claude_args.push("--session-id", sq(session_id));
+      console.log(`[commander] Starting fresh session ${session_id.slice(0, 8)}...`);
+    }
+
+    const claude_cmd = claude_args.join(" ");
 
     console.log(`[commander] Starting ${agent_name} in tmux session "${TMUX_SESSION}"...`);
 
@@ -188,6 +227,11 @@ export class CommanderProcess extends EventEmitter {
         const pid = this.get_tmux_pid();
         console.log(`[commander] ${agent_name} running in tmux (pane pid: ${String(pid)})`);
         this.emit("started", pid);
+
+        // Persist session_id so future restarts can resume the conversation
+        void this.write_session_id(session_id).catch((err) => {
+          console.error(`[commander] Failed to persist session_id: ${String(err)}`);
+        });
 
         // Start health check polling
         this.start_health_polling();

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -32,6 +32,7 @@ import {
   type TextChannel,
   type Webhook,
 } from "discord.js";
+import { is_tmux_session_idle } from "./pool.js";
 import type { BotPool, PoolBot } from "./pool.js";
 import type { TaskQueue } from "./queue.js";
 import type { EntityRegistry } from "./registry.js";
@@ -477,6 +478,8 @@ export class DiscordBot extends EventEmitter {
       agent_name: string;
     }
   >();
+  /** Cached #command-center channel ID (resolved lazily from the GLOBAL category). */
+  private command_center_channel_id: string | null = null;
 
   constructor(
     private config: LobsterFarmConfig,
@@ -504,6 +507,14 @@ export class DiscordBot extends EventEmitter {
 
         // Register guild-specific slash commands (instant, no propagation delay)
         void this.register_slash_commands();
+
+        // Eagerly resolve #command-center channel ID so handle_message()
+        // can detect user messages there and show typing + status embeds.
+        void this.find_command_center_channel().then((id) => {
+          if (id) {
+            console.log(`[discord] Command center channel resolved: ${id}`);
+          }
+        });
 
         this.emit("connected");
         resolve();
@@ -592,6 +603,27 @@ export class DiscordBot extends EventEmitter {
     return channel?.id ?? null;
   }
 
+  /** Find the #command-center channel by name under the GLOBAL category. Caches the result. */
+  async find_command_center_channel(): Promise<string | null> {
+    if (this.command_center_channel_id) return this.command_center_channel_id;
+
+    const guild = await this.get_guild();
+    if (!guild) return null;
+
+    const category = guild.channels.cache.find(
+      (c) => c.name === "GLOBAL" && c.type === DiscordChannelType.GuildCategory,
+    );
+    if (!category) return null;
+
+    const channel = guild.channels.cache.find(
+      (c) => c.name === "command-center" && c.parentId === category.id,
+    );
+    if (channel) {
+      this.command_center_channel_id = channel.id;
+    }
+    return this.command_center_channel_id;
+  }
+
   /** Send a plain message to a channel (from the bot itself). */
   async send(channel_id: string, content: string): Promise<void> {
     if (!this.connected) {
@@ -659,7 +691,7 @@ export class DiscordBot extends EventEmitter {
       void this.send_typing(channel_id);
 
       // Parse tmux output and update the status embed if activity changed
-      void this.update_status_embed_from_tmux(channel_id, bot);
+      void this.update_status_embed_from_tmux(channel_id, bot.tmux_session);
     }, 8000);
 
     this.typing_loops.set(channel_id, interval);
@@ -683,6 +715,47 @@ export class DiscordBot extends EventEmitter {
       finalizations.push(this.finalize_status_embed(channel_id));
     }
     await Promise.allSettled(finalizations);
+  }
+
+  /**
+   * Start a typing indicator loop for the Commander (Pat) in #command-center.
+   * Uses Pat's fixed tmux session ("pat") for idle detection and activity parsing,
+   * independent of the bot pool.
+   */
+  start_commander_typing_loop(channel_id: string): void {
+    // Don't stack loops for the same channel
+    if (this.typing_loops.has(channel_id)) return;
+
+    const TMUX_SESSION = "pat";
+
+    // Fire immediately, then repeat
+    void this.send_typing(channel_id);
+
+    // Track consecutive idle checks to avoid premature finalization.
+    // Pat's channel plugin needs time to deliver the message — if we
+    // check idle on the very first tick, the bot may not have started yet.
+    let consecutive_idle = 0;
+    const IDLE_THRESHOLD = 2; // require 2 consecutive idle checks before finalizing
+
+    const interval = setInterval(() => {
+      if (is_tmux_session_idle(TMUX_SESSION)) {
+        consecutive_idle++;
+        if (consecutive_idle >= IDLE_THRESHOLD) {
+          this.stop_typing_loop(channel_id);
+          void this.finalize_status_embed(channel_id);
+          return;
+        }
+      } else {
+        consecutive_idle = 0;
+      }
+
+      void this.send_typing(channel_id);
+
+      // Parse tmux output and update the status embed if activity changed
+      void this.update_status_embed_from_tmux(channel_id, TMUX_SESSION);
+    }, 4000);
+
+    this.typing_loops.set(channel_id, interval);
   }
 
   // ── Status embeds ──
@@ -809,15 +882,19 @@ export class DiscordBot extends EventEmitter {
   }
 
   /**
-   * Parse tmux output from a bot and update the status embed if activity changed.
-   * Called from the typing loop every 8 seconds.
+   * Parse tmux output from a session and update the status embed if activity changed.
+   * Called from the typing loop every tick. Accepts a tmux session name directly
+   * so it works for both pool bots and the commander (Pat).
    */
-  private async update_status_embed_from_tmux(channel_id: string, bot: PoolBot): Promise<void> {
+  private async update_status_embed_from_tmux(
+    channel_id: string,
+    tmux_session: string,
+  ): Promise<void> {
     const entry = this.status_embeds.get(channel_id);
     if (!entry?.message_id) return; // not yet sent or already finalized
 
     try {
-      const output = execFileSync("tmux", ["capture-pane", "-t", bot.tmux_session, "-p"], {
+      const output = execFileSync("tmux", ["capture-pane", "-t", tmux_session, "-p"], {
         encoding: "utf-8",
         timeout: 2000,
       });
@@ -1479,8 +1556,16 @@ export class DiscordBot extends EventEmitter {
     // Look up channel in entity map
     const entry = this.channel_map.get(message.channelId);
 
-    // Unmapped channels: ignore everything.
     // Commander (Pat) handles #command-center via its own Discord bot.
+    // The daemon's bot sees user messages there too — start typing + status
+    // embeds so the user gets visual feedback while Pat processes.
+    if (!entry && this.command_center_channel_id === message.channelId) {
+      this.start_commander_typing_loop(message.channelId);
+      void this.send_status_embed(message.channelId, "commander");
+      return;
+    }
+
+    // Unmapped channels: ignore everything.
     if (!entry) return;
 
     // Ignore legacy !lf text commands — all commands are now slash commands.

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -1560,7 +1560,10 @@ export class DiscordBot extends EventEmitter {
     // Commander (Pat) handles #command-center via its own Discord bot.
     // The daemon's bot sees user messages there too — start typing + status
     // embeds so the user gets visual feedback while Pat processes.
-    if (!entry && this.command_center_channel_id === message.channelId) {
+    // Lazily resolve the channel ID if it hasn't been cached yet (covers the
+    // narrow window between bot ready and the async find_command_center_channel).
+    const cc_id = this.command_center_channel_id ?? (await this.find_command_center_channel());
+    if (!entry && cc_id === message.channelId) {
       this.start_commander_typing_loop(message.channelId);
       void this.send_status_embed(message.channelId, "commander");
       return;

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -32,6 +32,7 @@ import {
   type TextChannel,
   type Webhook,
 } from "discord.js";
+import { PAT_TMUX_SESSION } from "./commander-process.js";
 import { is_tmux_session_idle } from "./pool.js";
 import type { BotPool, PoolBot } from "./pool.js";
 import type { TaskQueue } from "./queue.js";
@@ -726,7 +727,7 @@ export class DiscordBot extends EventEmitter {
     // Don't stack loops for the same channel
     if (this.typing_loops.has(channel_id)) return;
 
-    const TMUX_SESSION = "pat";
+    const TMUX_SESSION = PAT_TMUX_SESSION;
 
     // Fire immediately, then repeat
     void this.send_typing(channel_id);

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -69,6 +69,31 @@ export interface PoolStatus {
 /** Activity state computed on demand from observable signals (tmux pane, timestamps). */
 export type ActivityState = "idle" | "working" | "waiting_for_human" | "active_conversation";
 
+// ── Tmux idle detection ──
+
+/**
+ * Check whether a tmux session is idle (showing a prompt, not actively processing).
+ * Reads the last line of the tmux pane and looks for prompt or permission dialog indicators.
+ *
+ * Fails open (returns true) when the pane can't be read — safe default for eviction
+ * and typing-loop termination.
+ */
+export function is_tmux_session_idle(tmux_session: string): boolean {
+  try {
+    const output = execFileSync("tmux", ["capture-pane", "-t", tmux_session, "-p"], {
+      encoding: "utf-8",
+      timeout: 2000,
+    });
+    const lines = output.trim().split("\n");
+    const last_line = lines[lines.length - 1] ?? "";
+    // "bypass permissions" matches the Claude Code workspace trust dialog text.
+    // This is UI-text dependent and may break if Claude Code changes the dialog wording.
+    return last_line.includes("❯") || last_line.includes("bypass permissions");
+  } catch {
+    return true; // Can't check — assume idle (fail-open)
+  }
+}
+
 // ── Agent name resolution ──
 
 function resolve_agent_name(archetype: ArchetypeRole, config: LobsterFarmConfig): string {
@@ -1021,19 +1046,7 @@ export class BotPool extends EventEmitter {
    * refuse to evict when the pool is exhausted.
    */
   is_bot_idle(bot: PoolBot): boolean {
-    try {
-      const output = execFileSync("tmux", ["capture-pane", "-t", bot.tmux_session, "-p"], {
-        encoding: "utf-8",
-        timeout: 2000,
-      });
-      const lines = output.trim().split("\n");
-      const last_line = lines[lines.length - 1] ?? "";
-      // "bypass permissions" matches the Claude Code workspace trust dialog text.
-      // This is UI-text dependent and may break if Claude Code changes the dialog wording.
-      return last_line.includes("❯") || last_line.includes("bypass permissions");
-    } catch {
-      return true; // Can't check — assume idle (fail-open for eviction)
-    }
+    return is_tmux_session_idle(bot.tmux_session);
   }
 
   /** Check if any pool bots are actively working (not idle at prompt). */


### PR DESCRIPTION
## Summary

- Adds typing indicators and amber/green status embeds to #command-center when users message Pat, matching the existing pool bot UX
- Adds session resume for Pat via `--resume` flag on daemon restart, persisting the session_id to `channels/pat/session-state.json`
- Extracts `is_tmux_session_idle()` as a standalone exported function from `BotPool.is_bot_idle()` for reuse outside the pool

## Test plan

- [ ] Verify 757/757 tests pass (confirmed locally)
- [ ] Verify type-check passes with `npx tsc --noEmit`
- [ ] Message Pat in #command-center and confirm amber "Working" embed appears with live activity updates
- [ ] Confirm embed transitions to green "Done" when Pat finishes responding
- [ ] Restart the daemon and verify Pat resumes with `--resume` (check logs for "Resuming session" message)
- [ ] Verify `channels/pat/session-state.json` is created after first start


🤖 Generated with [Claude Code](https://claude.com/claude-code)