### PR TITLE
fix(cli): use commander name instead of hardcoded "Pat" in init wizard

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -896,7 +896,7 @@ Always clean up after yourself:
 
       const discord_setup = non_interactive
         ? undefined
-        : await prompt_discord(has_existing_discord_token);
+        : await prompt_discord(has_existing_discord_token, agent_names.commander);
       const github = non_interactive ? { username: "" } : await prompt_github();
 
       // ── Build TemplateVariables ──
@@ -1068,7 +1068,10 @@ Always clean up after yourself:
 
         bot_entries.push({ name: "Daemon", token: discord_setup.daemon_bot_token });
         if (discord_setup.commander_bot_token) {
-          bot_entries.push({ name: "Pat (Commander)", token: discord_setup.commander_bot_token });
+          bot_entries.push({
+            name: `${agent_names.commander} (Commander)`,
+            token: discord_setup.commander_bot_token,
+          });
         }
         for (let i = 0; i < pool_bot_tokens.length; i++) {
           bot_entries.push({ name: `LF-${String(i)}`, token: pool_bot_tokens[i]! });

--- a/packages/cli/src/commands/init/prompts.ts
+++ b/packages/cli/src/commands/init/prompts.ts
@@ -135,7 +135,14 @@ export async function prompt_discord(
   }
 
   p.note(
-    `Step 1: Go to https://discord.com/developers/applications\nStep 2: Click "New Application" → name it "${commander_name}"\nStep 3: In the Installation tab → set Install Link to "None"\nStep 4: In the Bot tab:\n  - Uncheck "Public Bot"\n  - Enable all 3 Privileged Gateway Intents:\n    Presence Intent, Server Members Intent, Message Content Intent\n  - Click "Reset Token" → copy the token`,
+    `Step 1: Go to https://discord.com/developers/applications
+Step 2: Click "New Application" → name it "${commander_name}"
+Step 3: In the Installation tab → set Install Link to "None"
+Step 4: In the Bot tab:
+  - Uncheck "Public Bot"
+  - Enable all 3 Privileged Gateway Intents:
+    Presence Intent, Server Members Intent, Message Content Intent
+  - Click "Reset Token" → copy the token`,
     `Create Commander Bot (${commander_name})`,
   );
 

--- a/packages/cli/src/commands/init/prompts.ts
+++ b/packages/cli/src/commands/init/prompts.ts
@@ -63,7 +63,10 @@ export interface DiscordSetup {
 }
 
 /** Prompt for Discord setup (optional). Returns server ID + bot tokens or undefined. */
-export async function prompt_discord(existing_token?: boolean): Promise<DiscordSetup | undefined> {
+export async function prompt_discord(
+  existing_token?: boolean,
+  commander_name = "Pat",
+): Promise<DiscordSetup | undefined> {
   if (existing_token) {
     const overwrite = await p.confirm({
       message: "Discord bot tokens already configured. Update them?",
@@ -132,19 +135,12 @@ export async function prompt_discord(existing_token?: boolean): Promise<DiscordS
   }
 
   p.note(
-    "Step 1: Go to https://discord.com/developers/applications\n" +
-      'Step 2: Click "New Application" → name it "Pat"\n' +
-      'Step 3: In the Installation tab → set Install Link to "None"\n' +
-      "Step 4: In the Bot tab:\n" +
-      '  - Uncheck "Public Bot"\n' +
-      "  - Enable all 3 Privileged Gateway Intents:\n" +
-      "    Presence Intent, Server Members Intent, Message Content Intent\n" +
-      '  - Click "Reset Token" → copy the token',
-    "Create Commander Bot (Pat)",
+    `Step 1: Go to https://discord.com/developers/applications\nStep 2: Click "New Application" → name it "${commander_name}"\nStep 3: In the Installation tab → set Install Link to "None"\nStep 4: In the Bot tab:\n  - Uncheck "Public Bot"\n  - Enable all 3 Privileged Gateway Intents:\n    Presence Intent, Server Members Intent, Message Content Intent\n  - Click "Reset Token" → copy the token`,
+    `Create Commander Bot (${commander_name})`,
   );
 
   const commander_token = await p.password({
-    message: "Commander bot token (Pat — press Enter to skip):",
+    message: `Commander bot token (${commander_name} — press Enter to skip):`,
   });
   if (p.isCancel(commander_token)) {
     p.cancel("Setup cancelled.");


### PR DESCRIPTION
## Summary
- Thread `agent_names.commander` through `prompt_discord()` so the commander bot setup prompts use the user's chosen name instead of a hardcoded "Pat"
- Update the 1Password entry name to match (`${commander_name} (Commander)`)

## Changes
- `packages/cli/src/commands/init/prompts.ts` — add `commander_name` parameter (default `"Pat"`), interpolate it into the three commander-bot prompts
- `packages/cli/src/commands/init.ts` — pass `agent_names.commander` at the call site; use it for the 1Password bot entry label

## Test plan
- [x] `pnpm run lint` — clean
- [x] `pnpm run typecheck` — clean
- [x] `pnpm -C packages/cli run test` — 33 passing
- [ ] Manual: run `lf init`, choose a non-default commander name, confirm the bot setup instructions use the chosen name

Closes #202