### PR TITLE
feat(sentry): enrich initial alert format

### DIFF
--- a/packages/daemon/src/__tests__/sentry-alert-format.test.ts
+++ b/packages/daemon/src/__tests__/sentry-alert-format.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Tests for Sentry alert formatting + in-memory issue details cache (#259).
+ *
+ * Covers:
+ * - format_sentry_alert(): all fields present → full 5-line layout
+ * - format_sentry_alert(): missing release, missing stack frame, missing culprit
+ * - format_sentry_alert(): level → emoji mapping (fatal/error/warning/other)
+ * - format_sentry_alert(): action prefix for resolved/unresolved events
+ * - format_sentry_alert_minimal(): fallback format when enrichment fails
+ * - relative_time(): formats seconds/minutes/hours/days ago
+ * - extract_top_app_frame(): prefers in-app frames, handles missing data
+ * - get_cached_issue_details(): cache hit within TTL
+ * - get_cached_issue_details(): concurrent callers share one in-flight fetch
+ * - get_cached_issue_details(): TTL expiry triggers refetch
+ * - get_cached_issue_details(): error is not cached
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  _reset_cache_for_test,
+  extract_top_app_frame,
+  format_sentry_alert,
+  format_sentry_alert_minimal,
+  get_cached_issue_details,
+  relative_time,
+} from "../sentry-alert-format.js";
+import type { SentryIssueDetails } from "../sentry-api.js";
+
+// ── Fixture helpers ──
+
+function make_details(overrides: Partial<SentryIssueDetails> = {}): SentryIssueDetails {
+  return {
+    title: "TimeoutError: request timed out",
+    culprit: "asyncpg.pool.close",
+    level: "error",
+    count: "8",
+    first_seen: new Date(Date.now() - 2 * 60 * 1000).toISOString(), // 2 minutes ago
+    last_seen: new Date().toISOString(),
+    platform: "python",
+    short_id: "SONAR-BACKEND-A7K",
+    web_url: "https://ultim8.sentry.io/issues/7409847425/",
+    tags: [
+      { key: "environment", value: "production" },
+      { key: "release", value: "a7b3c9d4e5f6" },
+    ],
+    stack_trace: "TimeoutError: request timed out\n  at cleanup (apps/backend/src/db/pool.py:142)",
+    top_frame: null,
+    contexts: {},
+    ...overrides,
+  };
+}
+
+// ── format_sentry_alert ──
+
+describe("format_sentry_alert", () => {
+  it("renders full 5-line layout when all fields are present", () => {
+    const alert = format_sentry_alert({
+      action: "created",
+      short_id: "SONAR-BACKEND-A7K",
+      project_slug: "sonar-backend",
+      details: make_details(),
+      top_frame: {
+        filename: "apps/backend/src/db/pool.py",
+        lineno: 142,
+        function: "cleanup",
+      },
+    });
+
+    const lines = alert.split("\n");
+    expect(lines[0]).toBe("⚠️ Sentry [error]: TimeoutError: request timed out");
+    expect(lines[1]).toBe("SONAR-BACKEND-A7K · sonar-backend · release a7b3c9d");
+    expect(lines[2]).toMatch(/^asyncpg\.pool\.close {2}\(8 events, first \d+[smhd] ago\)$/);
+    expect(lines[3]).toBe("→ apps/backend/src/db/pool.py:142 cleanup()");
+    expect(lines[4]).toBe("https://ultim8.sentry.io/issues/7409847425/");
+  });
+
+  it("uses 🔥 for fatal, ⚠️ for error, ℹ️ for warning, no emoji otherwise", () => {
+    const base = {
+      action: "created",
+      short_id: "S-1",
+      project_slug: "p",
+      top_frame: null,
+    };
+    expect(
+      format_sentry_alert({ ...base, details: make_details({ level: "fatal" }) }).split("\n")[0],
+    ).toMatch(/^🔥 Sentry \[fatal\]/);
+    expect(
+      format_sentry_alert({ ...base, details: make_details({ level: "error" }) }).split("\n")[0],
+    ).toMatch(/^⚠️ Sentry \[error\]/);
+    expect(
+      format_sentry_alert({ ...base, details: make_details({ level: "warning" }) }).split("\n")[0],
+    ).toMatch(/^ℹ️ Sentry \[warning\]/);
+    expect(
+      format_sentry_alert({ ...base, details: make_details({ level: "info" }) }).split("\n")[0],
+    ).toBe("Sentry [info]: TimeoutError: request timed out");
+  });
+
+  it("omits release token when release tag is missing", () => {
+    const alert = format_sentry_alert({
+      action: "created",
+      short_id: "S-1",
+      project_slug: "sonar-backend",
+      details: make_details({ tags: [{ key: "environment", value: "production" }] }),
+      top_frame: null,
+    });
+    const meta_line = alert.split("\n")[1];
+    expect(meta_line).toBe("S-1 · sonar-backend");
+  });
+
+  it("omits short_id token when shortId is missing", () => {
+    const alert = format_sentry_alert({
+      action: "created",
+      short_id: null,
+      project_slug: "sonar-backend",
+      details: make_details({ tags: [{ key: "release", value: "abc1234567" }] }),
+      top_frame: null,
+    });
+    const meta_line = alert.split("\n")[1];
+    expect(meta_line).toBe("sonar-backend · release abc1234");
+  });
+
+  it("omits stack-frame line when top_frame is null", () => {
+    const alert = format_sentry_alert({
+      action: "created",
+      short_id: "S-1",
+      project_slug: "sonar-backend",
+      details: make_details(),
+      top_frame: null,
+    });
+    const lines = alert.split("\n");
+    expect(lines).toHaveLength(4); // header, meta, culprit, url
+    expect(lines[3]).toBe("https://ultim8.sentry.io/issues/7409847425/");
+  });
+
+  it("omits culprit line entirely when culprit is empty and count is 0", () => {
+    const alert = format_sentry_alert({
+      action: "created",
+      short_id: "S-1",
+      project_slug: "sonar-backend",
+      details: make_details({ culprit: "", count: "0", first_seen: "" }),
+      top_frame: null,
+    });
+    const lines = alert.split("\n");
+    // header, meta, url — no culprit line, no stack line
+    expect(lines).toHaveLength(3);
+    expect(lines[2]).toBe("https://ultim8.sentry.io/issues/7409847425/");
+  });
+
+  it("prefixes 'Resolved' instead of 'Sentry' for resolved action", () => {
+    const alert = format_sentry_alert({
+      action: "resolved",
+      short_id: "S-1",
+      project_slug: "sonar-backend",
+      details: make_details(),
+      top_frame: null,
+    });
+    expect(alert.split("\n")[0]).toMatch(/^⚠️ Resolved \[error\]:/);
+  });
+});
+
+// ── format_sentry_alert_minimal ──
+
+describe("format_sentry_alert_minimal", () => {
+  it("renders the legacy fallback format", () => {
+    const alert = format_sentry_alert_minimal({
+      action: "created",
+      error_title: "TimeoutError",
+      project_slug: "sonar-backend",
+      issue_url: "https://ultim8.sentry.io/issues/1/",
+    });
+    expect(alert).toBe(
+      "Sentry: TimeoutError\nProject: sonar-backend\nhttps://ultim8.sentry.io/issues/1/",
+    );
+  });
+
+  it("uses Resolved prefix and includes action label for unresolved", () => {
+    expect(
+      format_sentry_alert_minimal({
+        action: "resolved",
+        error_title: "T",
+        project_slug: "p",
+        issue_url: "u",
+      }),
+    ).toBe("Resolved: T\nProject: p\nu");
+
+    expect(
+      format_sentry_alert_minimal({
+        action: "unresolved",
+        error_title: "T",
+        project_slug: "p",
+        issue_url: "u",
+      }),
+    ).toBe("Sentry [unresolved]: T\nProject: p\nu");
+  });
+});
+
+// ── relative_time ──
+
+describe("relative_time", () => {
+  const now = new Date("2026-04-15T12:00:00Z").getTime();
+
+  it("formats seconds ago", () => {
+    expect(relative_time(new Date(now - 30_000).toISOString(), now)).toBe("30s");
+  });
+
+  it("formats minutes ago", () => {
+    expect(relative_time(new Date(now - 5 * 60_000).toISOString(), now)).toBe("5m");
+  });
+
+  it("formats hours ago", () => {
+    expect(relative_time(new Date(now - 3 * 3600_000).toISOString(), now)).toBe("3h");
+  });
+
+  it("formats days ago", () => {
+    expect(relative_time(new Date(now - 2 * 86_400_000).toISOString(), now)).toBe("2d");
+  });
+
+  it("returns empty string for invalid input", () => {
+    expect(relative_time("", now)).toBe("");
+    expect(relative_time("not-a-date", now)).toBe("");
+  });
+});
+
+// ── extract_top_app_frame ──
+
+describe("extract_top_app_frame", () => {
+  it("returns the innermost in-app frame from the first exception", () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            type: "TimeoutError",
+            value: "request timed out",
+            stacktrace: {
+              frames: [
+                { filename: "vendor/lib.py", lineNo: 99, function: "vendor_fn", inApp: false },
+                {
+                  filename: "apps/backend/src/db/pool.py",
+                  lineNo: 142,
+                  function: "cleanup",
+                  inApp: true,
+                },
+                // Innermost-last per Sentry convention
+                { filename: "stdlib/socket.py", lineNo: 1, function: "recv", inApp: false },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    const frame = extract_top_app_frame(event);
+    expect(frame).toEqual({
+      filename: "apps/backend/src/db/pool.py",
+      lineno: 142,
+      function: "cleanup",
+    });
+  });
+
+  it("falls back to any frame if no in-app frames are marked", () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            stacktrace: {
+              frames: [{ filename: "a.py", lineNo: 1, function: "f" }],
+            },
+          },
+        ],
+      },
+    };
+    expect(extract_top_app_frame(event)).toEqual({
+      filename: "a.py",
+      lineno: 1,
+      function: "f",
+    });
+  });
+
+  it("returns null when event has no exception frames", () => {
+    expect(extract_top_app_frame({})).toBeNull();
+    expect(extract_top_app_frame({ exception: { values: [] } })).toBeNull();
+    expect(
+      extract_top_app_frame({
+        exception: { values: [{ stacktrace: { frames: [] } }] },
+      }),
+    ).toBeNull();
+  });
+});
+
+// ── get_cached_issue_details ──
+
+describe("get_cached_issue_details", () => {
+  beforeEach(() => {
+    _reset_cache_for_test();
+  });
+
+  afterEach(() => {
+    _reset_cache_for_test();
+  });
+
+  it("caches within TTL — second call does not re-fetch", async () => {
+    const fetcher = vi.fn().mockResolvedValue(make_details());
+
+    const a = await get_cached_issue_details("issue-1", fetcher);
+    const b = await get_cached_issue_details("issue-1", fetcher);
+
+    expect(a).toBe(b);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("deduplicates concurrent callers — both share one in-flight promise", async () => {
+    let resolve_inner: ((v: SentryIssueDetails) => void) | null = null;
+    const fetcher = vi.fn().mockImplementation(
+      () =>
+        new Promise<SentryIssueDetails>((r) => {
+          resolve_inner = r;
+        }),
+    );
+
+    const p1 = get_cached_issue_details("issue-1", fetcher);
+    const p2 = get_cached_issue_details("issue-1", fetcher);
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    resolve_inner?.(make_details());
+    const [a, b] = await Promise.all([p1, p2]);
+    expect(a).toBe(b);
+  });
+
+  it("re-fetches after TTL expiry", async () => {
+    vi.useFakeTimers();
+    const fetcher = vi.fn().mockResolvedValue(make_details());
+
+    await get_cached_issue_details("issue-1", fetcher);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    // Advance beyond the 30s TTL
+    vi.advanceTimersByTime(31_000);
+
+    await get_cached_issue_details("issue-1", fetcher);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
+  });
+
+  it("does not cache a rejected promise", async () => {
+    const fetcher = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("sentry 500"))
+      .mockResolvedValueOnce(make_details());
+
+    await expect(get_cached_issue_details("issue-1", fetcher)).rejects.toThrow("sentry 500");
+    // Failed fetches must not poison the cache — the next call should retry
+    await expect(get_cached_issue_details("issue-1", fetcher)).resolves.toBeDefined();
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/daemon/src/__tests__/sentry-triage.test.ts
+++ b/packages/daemon/src/__tests__/sentry-triage.test.ts
@@ -79,10 +79,12 @@ function make_issue_details(overrides: Partial<SentryIssueDetails> = {}): Sentry
     first_seen: "2026-04-06T10:00:00Z",
     last_seen: "2026-04-07T10:00:00Z",
     platform: "node",
+    short_id: "TEST-1",
     web_url: "https://sentry.io/issues/12345/",
     tags: [{ key: "environment", value: "production" }],
     stack_trace:
       "TypeError: Cannot read property 'foo' of undefined\n  at process_request (src/handler.ts:42:5)",
+    top_frame: null,
     contexts: { runtime: { name: "node", version: "20.0.0" } },
     ...overrides,
   };

--- a/packages/daemon/src/sentry-alert-format.ts
+++ b/packages/daemon/src/sentry-alert-format.ts
@@ -1,0 +1,251 @@
+/**
+ * Sentry alert formatting + short-lived issue-details cache (#259).
+ *
+ * The initial Discord alert posted for a Sentry webhook used to be three
+ * lines (`Sentry: {title}`, `Project: {slug}`, `{url}`). This module
+ * enriches it with metadata fetched from the Sentry API so the alert
+ * stands on its own without waiting for Ray's triage follow-up.
+ *
+ * Format (full, with all fields):
+ *
+ *   ⚠️ Sentry [error]: TimeoutError: request timed out
+ *   SONAR-BACKEND-A7K · sonar-backend · release a7b3c9d
+ *   asyncpg.pool.close  (8 events, first 2m ago)
+ *   → apps/backend/src/db/pool.py:142 cleanup()
+ *   https://ultim8.sentry.io/issues/7409847425/
+ *
+ * Rules:
+ *   - Line 1 emoji by level: 🔥 fatal, ⚠️ error, ℹ️ warning, none otherwise.
+ *   - Line 2: `shortId · project · release {short_sha}` — missing tokens
+ *     are dropped; the ` · ` separator is applied over what remains.
+ *     Environment is intentionally omitted (prod-only by design).
+ *   - Line 3: `culprit  (N events, first Xm/h ago)`. Dropped entirely if
+ *     culprit is empty and count/first_seen are unavailable.
+ *   - Line 4: top in-app stack frame, if available. Dropped otherwise.
+ *   - Line 5: permalink.
+ *
+ * Fallback: `format_sentry_alert_minimal()` is the pre-#259 format and is
+ * used when enrichment fails for any reason — we never drop the alert.
+ *
+ * Cache: `get_cached_issue_details()` wraps the API fetch in a 30-second
+ * in-memory promise cache keyed on Sentry issue id. The webhook handler
+ * (for enrichment) and the triage path (for Ray's prompt) both go through
+ * this cache, so a single event results in at most one API call — even if
+ * the two code paths race.
+ */
+
+import {
+  type SentryIssueDetails,
+  type SentryTopFrame,
+  extract_top_frame_from_event,
+} from "./sentry-api.js";
+
+// ── Types ──
+
+export type TopStackFrame = SentryTopFrame;
+
+/**
+ * Re-export under the original name so tests and callers can import
+ * this helper from the alert-format module alongside the formatter.
+ */
+export const extract_top_app_frame = extract_top_frame_from_event;
+
+export interface FormatSentryAlertInput {
+  action: string | undefined;
+  short_id: string | null;
+  project_slug: string;
+  details: SentryIssueDetails;
+  top_frame: TopStackFrame | null;
+}
+
+export interface FormatSentryAlertMinimalInput {
+  action: string | undefined;
+  error_title: string;
+  project_slug: string;
+  issue_url: string;
+}
+
+// ── Level → emoji ──
+
+function level_emoji(level: string): string {
+  switch (level) {
+    case "fatal":
+      return "🔥";
+    case "error":
+      return "⚠️";
+    case "warning":
+      return "ℹ️";
+    default:
+      return "";
+  }
+}
+
+// ── Action → prefix ──
+
+function action_prefix(action: string | undefined): { prefix: string; tag: string } {
+  if (action === "resolved") return { prefix: "Resolved", tag: "" };
+  if (action === "unresolved") return { prefix: "Sentry", tag: "[unresolved]" };
+  if (action === "regression") return { prefix: "Sentry", tag: "[regression]" };
+  return { prefix: "Sentry", tag: "" };
+}
+
+// ── Relative time formatter ──
+
+/**
+ * Format an ISO timestamp as a compact relative time: "30s", "5m", "3h", "2d".
+ *
+ * `now` is injectable for deterministic tests. Returns "" on invalid input.
+ */
+export function relative_time(iso: string, now: number = Date.now()): string {
+  if (!iso) return "";
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return "";
+
+  const delta_s = Math.max(0, Math.floor((now - then) / 1000));
+  if (delta_s < 60) return `${String(delta_s)}s`;
+
+  const delta_m = Math.floor(delta_s / 60);
+  if (delta_m < 60) return `${String(delta_m)}m`;
+
+  const delta_h = Math.floor(delta_m / 60);
+  if (delta_h < 24) return `${String(delta_h)}h`;
+
+  const delta_d = Math.floor(delta_h / 24);
+  return `${String(delta_d)}d`;
+}
+
+// ── Release tag lookup ──
+
+function find_release(tags: SentryIssueDetails["tags"]): string | null {
+  const tag = tags.find((t) => t.key === "release");
+  if (!tag?.value) return null;
+  // Sentry releases are commonly a full 40-char SHA or a semver string.
+  // For the alert we want 7 chars of a SHA-like value; longer semver/release
+  // names pass through unchanged.
+  const value = tag.value;
+  if (/^[0-9a-f]{8,}$/i.test(value)) return value.slice(0, 7);
+  return value;
+}
+
+// ── Main formatter ──
+
+export function format_sentry_alert(input: FormatSentryAlertInput): string {
+  const { action, short_id, project_slug, details, top_frame } = input;
+
+  const { prefix, tag } = action_prefix(action);
+  const emoji = level_emoji(details.level);
+  const level_bracket = `[${details.level}]`;
+
+  // Header: "<emoji> <prefix> [level]: <title>" (action tag replaces level when set)
+  const header_tag = tag || level_bracket;
+  const emoji_part = emoji ? `${emoji} ` : "";
+  const header = `${emoji_part}${prefix} ${header_tag}: ${details.title}`;
+
+  // Meta line: shortId · project · release (omit missing tokens)
+  const release = find_release(details.tags);
+  const meta_tokens: string[] = [];
+  if (short_id) meta_tokens.push(short_id);
+  meta_tokens.push(project_slug);
+  if (release) meta_tokens.push(`release ${release}`);
+  const meta = meta_tokens.join(" · ");
+
+  // Culprit + count line
+  const count_num = Number.parseInt(details.count, 10);
+  const has_count = Number.isFinite(count_num) && count_num > 0;
+  const rel = relative_time(details.first_seen);
+  let culprit_line: string | null = null;
+  if (details.culprit || has_count) {
+    const count_part =
+      has_count && rel
+        ? `(${String(count_num)} events, first ${rel} ago)`
+        : has_count
+          ? `(${String(count_num)} events)`
+          : "";
+    if (details.culprit && count_part) {
+      culprit_line = `${details.culprit}  ${count_part}`;
+    } else if (details.culprit) {
+      culprit_line = details.culprit;
+    } else if (count_part) {
+      culprit_line = count_part;
+    }
+  }
+
+  // Stack frame line
+  let stack_line: string | null = null;
+  if (top_frame) {
+    const loc =
+      top_frame.lineno != null
+        ? `${top_frame.filename}:${String(top_frame.lineno)}`
+        : top_frame.filename;
+    stack_line = `→ ${loc} ${top_frame.function}()`;
+  }
+
+  const lines = [header, meta];
+  if (culprit_line) lines.push(culprit_line);
+  if (stack_line) lines.push(stack_line);
+  lines.push(details.web_url);
+  return lines.join("\n");
+}
+
+// ── Minimal fallback formatter ──
+
+export function format_sentry_alert_minimal(input: FormatSentryAlertMinimalInput): string {
+  const { action, error_title, project_slug, issue_url } = input;
+  const prefix = action === "resolved" ? "Resolved" : "Sentry";
+  const tag = action && action !== "resolved" && action !== "created" ? ` [${action}]` : "";
+  return `${prefix}${tag}: ${error_title}\nProject: ${project_slug}\n${issue_url}`;
+}
+
+// ── In-memory cache ──
+
+const CACHE_TTL_MS = 30_000;
+
+interface CacheEntry {
+  promise: Promise<SentryIssueDetails>;
+  expires_at: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+/**
+ * Fetch Sentry issue details via `fetcher`, memoizing by issue id for 30s.
+ *
+ * Concurrent callers for the same id share the same in-flight promise, so
+ * the webhook handler and the triage path never double-fetch. A rejected
+ * fetch is removed from the cache immediately so the next call can retry.
+ *
+ * The fetcher is injected (not imported directly) so callers can supply
+ * already-authenticated closures: `() => fetch_sentry_issue_details(id, token, org)`.
+ */
+export function get_cached_issue_details(
+  issue_id: string,
+  fetcher: () => Promise<SentryIssueDetails>,
+): Promise<SentryIssueDetails> {
+  const now = Date.now();
+  const existing = cache.get(issue_id);
+  if (existing && existing.expires_at > now) {
+    return existing.promise;
+  }
+
+  const promise = fetcher();
+  cache.set(issue_id, { promise, expires_at: now + CACHE_TTL_MS });
+
+  // Evict on failure so transient errors do not poison the cache for 30s.
+  promise.catch(() => {
+    const current = cache.get(issue_id);
+    if (current?.promise === promise) {
+      cache.delete(issue_id);
+    }
+  });
+
+  return promise;
+}
+
+// ── Test helpers ──
+
+/**
+ * Reset the in-memory cache between tests. Not for production use.
+ */
+export function _reset_cache_for_test(): void {
+  cache.clear();
+}

--- a/packages/daemon/src/sentry-api.ts
+++ b/packages/daemon/src/sentry-api.ts
@@ -25,6 +25,12 @@ export interface SentryException {
   };
 }
 
+export interface SentryTopFrame {
+  filename: string;
+  lineno: number | null;
+  function: string;
+}
+
 export interface SentryIssueDetails {
   title: string;
   culprit: string;
@@ -33,9 +39,11 @@ export interface SentryIssueDetails {
   first_seen: string;
   last_seen: string;
   platform: string;
+  short_id: string | null;
   web_url: string;
   tags: Array<{ key: string; value: string }>;
   stack_trace: string;
+  top_frame: SentryTopFrame | null;
   contexts: Record<string, unknown>;
   request?: {
     method?: string;
@@ -209,11 +217,52 @@ export async function fetch_sentry_issue_details(
     first_seen: (issue.firstSeen as string) ?? "",
     last_seen: (issue.lastSeen as string) ?? "",
     platform: (issue.platform as string) ?? "",
+    short_id: (issue.shortId as string) ?? null,
     web_url: (issue.permalink as string) ?? (issue.web_url as string) ?? "",
     tags,
     stack_trace: format_stack_trace(latest_event),
+    top_frame: extract_top_frame_from_event(latest_event),
     contexts: (latest_event.contexts as Record<string, unknown>) ?? {},
     request,
     user,
+  };
+}
+
+// ── Top stack frame extraction ──
+
+/**
+ * Pick the innermost in-app stack frame from a Sentry event.
+ *
+ * Sentry frames are ordered bottom-up (caller first, innermost last).
+ * We walk from innermost outward and return the first in-app frame; if
+ * none are marked in-app, we fall back to the innermost frame regardless.
+ * Returns null when the event has no exception frames at all.
+ *
+ * Extracted here (rather than in sentry-alert-format) so SentryIssueDetails
+ * can be populated with `top_frame` at fetch time — callers get the frame
+ * for free without re-parsing the event. Used by the initial Discord alert
+ * enrichment (#259).
+ */
+export function extract_top_frame_from_event(
+  event: Record<string, unknown>,
+): SentryTopFrame | null {
+  const exception_entry = event.exception as Record<string, unknown> | undefined;
+  const values = exception_entry?.values as SentryException[] | undefined;
+  if (!values?.length) return null;
+
+  const first = values[0];
+  const frames = first?.stacktrace?.frames;
+  if (!frames?.length) return null;
+
+  // Walk innermost-first (reverse iteration).
+  const reversed = [...frames].reverse();
+  const in_app = reversed.find((f) => f.inApp === true);
+  const picked = in_app ?? reversed[0];
+  if (!picked) return null;
+
+  return {
+    filename: picked.filename ?? "?",
+    lineno: typeof picked.lineNo === "number" ? picked.lineNo : null,
+    function: picked.function ?? "<anonymous>",
   };
 }

--- a/packages/daemon/src/sentry-triage.ts
+++ b/packages/daemon/src/sentry-triage.ts
@@ -27,6 +27,7 @@ import type { LobsterFarmConfig } from "@lobster-farm/shared";
 import type { DiscordBot } from "./discord.js";
 import type { EntityRegistry } from "./registry.js";
 import { MAX_SENTRY_FIX_ATTEMPTS, build_sentry_fix_prompt } from "./review-utils.js";
+import { get_cached_issue_details } from "./sentry-alert-format.js";
 import { type SentryIssueDetails, fetch_sentry_issue_details } from "./sentry-api.js";
 import * as sentry from "./sentry.js";
 import type { ActiveSession, ClaudeSessionManager, SessionResult } from "./session.js";
@@ -808,7 +809,12 @@ export async function handle_sentry_triage_event(
 
   let issue_details: SentryIssueDetails;
   try {
-    issue_details = await fetch_sentry_issue_details(sentry_issue_id, auth_token, org_slug);
+    // Shared cache with the webhook alert enrichment path (#259) — if the
+    // webhook handler already fetched this issue in the last 30s, we reuse
+    // the result instead of hitting the Sentry API twice for the same event.
+    issue_details = await get_cached_issue_details(sentry_issue_id, () =>
+      fetch_sentry_issue_details(sentry_issue_id, auth_token, org_slug),
+    );
   } catch (err) {
     console.error(
       `[sentry-triage] Failed to fetch Sentry issue ${sentry_issue_id}: ${String(err)}`,

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -14,6 +14,12 @@ import { QueueFullError } from "./queue.js";
 import type { TaskQueue, TaskSubmission } from "./queue.js";
 import type { EntityRegistry } from "./registry.js";
 import {
+  format_sentry_alert,
+  format_sentry_alert_minimal,
+  get_cached_issue_details,
+} from "./sentry-alert-format.js";
+import { fetch_sentry_issue_details } from "./sentry-api.js";
+import {
   type SentryTriageContext,
   handle_sentry_resolved,
   handle_sentry_triage_event,
@@ -260,7 +266,6 @@ async function process_sentry_webhook(
   // assigned / archived   → ignore
 
   const triage_actions = ["created", "regression"];
-  const alert_only_actions = ["resolved", "unresolved"];
   const ignore_actions = ["assigned", "archived"];
 
   if (resource === "issue" && action && ignore_actions.includes(action)) {
@@ -304,13 +309,22 @@ async function process_sentry_webhook(
 
   // ── Alert forwarding ──
   // Always post an alert to Discord for issue events (except ignored ones).
-  // Triage-worthy events get both an alert AND a Ray session.
-  const env = (issue?.environment as string) ?? "";
-  const prefix = action === "resolved" ? "Resolved" : "Sentry";
-  const env_part = env ? ` | Env: ${env}` : "";
-  const action_label =
-    action && !alert_only_actions.includes(action) && action !== "created" ? ` [${action}]` : "";
-  const alert_message = `${prefix}${action_label}: ${error_title}\nProject: ${project_slug}${env_part}\n${issue_url}`;
+  // Triage-worthy events also get a Ray session (spawned above).
+  //
+  // The initial alert is enriched with data fetched from the Sentry API
+  // (#259) so it stands on its own without waiting for Ray's follow-up.
+  // Enrichment is cached for 30s so the triage path does not double-fetch.
+  // Any failure during enrichment falls back to the minimal legacy format —
+  // we never drop the alert.
+  const webhook_short_id = (issue?.shortId as string) ?? null;
+  const alert_message = await build_sentry_alert_message({
+    action,
+    sentry_issue_id,
+    webhook_short_id,
+    project_slug,
+    error_title,
+    issue_url,
+  });
 
   if (ctx.discord) {
     if (target_entity_id) {
@@ -325,6 +339,58 @@ async function process_sentry_webhook(
   }
 
   console.log(`[sentry-webhook] Processed: ${resource}.${action ?? "unknown"} — ${error_title}`);
+}
+
+/**
+ * Build the Discord alert message for a Sentry webhook event.
+ *
+ * Attempts to enrich via `fetch_sentry_issue_details()` (through the shared
+ * cache). On any failure — missing credentials, API error, timeout — falls
+ * back to the minimal legacy format so the alert is never dropped.
+ */
+async function build_sentry_alert_message(opts: {
+  action: string | undefined;
+  sentry_issue_id: string;
+  webhook_short_id: string | null;
+  project_slug: string;
+  error_title: string;
+  issue_url: string;
+}): Promise<string> {
+  const { action, sentry_issue_id, webhook_short_id, project_slug, error_title, issue_url } = opts;
+
+  const auth_token = process.env.SENTRY_AUTH_TOKEN;
+  const org_slug = process.env.SENTRY_ORG;
+
+  // No creds or no issue id → minimal format only, nothing to enrich with.
+  if (!sentry_issue_id || !auth_token || !org_slug) {
+    return format_sentry_alert_minimal({ action, error_title, project_slug, issue_url });
+  }
+
+  try {
+    const details = await get_cached_issue_details(sentry_issue_id, () =>
+      fetch_sentry_issue_details(sentry_issue_id, auth_token, org_slug),
+    );
+
+    return format_sentry_alert({
+      action,
+      short_id: details.short_id ?? webhook_short_id,
+      project_slug,
+      details,
+      top_frame: details.top_frame,
+    });
+  } catch (err) {
+    // Breadcrumb for postmortem; never throw past this point.
+    sentry.addBreadcrumb({
+      category: "sentry-webhook",
+      message: `Alert enrichment failed for issue ${sentry_issue_id}`,
+      level: "warning",
+      data: { error: String(err), project: project_slug },
+    });
+    console.warn(
+      `[sentry-webhook] Enrichment failed for ${sentry_issue_id}, falling back to minimal format: ${String(err)}`,
+    );
+    return format_sentry_alert_minimal({ action, error_title, project_slug, issue_url });
+  }
 }
 
 // ── Hook endpoints ──


### PR DESCRIPTION
## Summary

The initial Discord alert posted for a Sentry webhook was three lines of mostly-useless text. It now stands on its own with level emoji, short id, release, culprit + event count, a top in-app stack frame, and the permalink. Ray's richer triage follow-up is unchanged.

Enrichment goes through a new 30s in-memory promise cache keyed on Sentry issue id — the webhook handler and the triage path both go through it, so a single event results in at most one API call even if they race. Any enrichment failure (missing creds, API error, timeout) falls back to the legacy minimal format — the alert is never dropped.

## Before

```
Sentry: TimeoutError
Project: sonar-backend
https://ultim8.sentry.io/issues/7409847425/
```

## After

```
⚠️ Sentry [error]: TimeoutError: request timed out
SONAR-BACKEND-A7K · sonar-backend · release a7b3c9d
asyncpg.pool.close  (8 events, first 2m ago)
→ apps/backend/src/db/pool.py:142 cleanup()
https://ultim8.sentry.io/issues/7409847425/
```

Rules:
- Emoji by level: `🔥` fatal, `⚠️` error, `ℹ️` warning, none otherwise.
- Line 2: `shortId · project · release {short_sha}` — missing tokens are dropped, `release` is truncated to 7 chars for SHA-like values. Environment is intentionally omitted (Sentry is prod-only).
- Line 3: `culprit  (N events, first Xm/h ago)`. Dropped if culprit + count are both absent.
- Line 4: top in-app stack frame, if available. Dropped otherwise.
- Line 5: permalink.

## Implementation notes

- New module `packages/daemon/src/sentry-alert-format.ts` holds the pure formatter (`format_sentry_alert`, `format_sentry_alert_minimal`), relative-time helper, and the promise cache (`get_cached_issue_details`).
- `SentryIssueDetails` gains two optional fields — `short_id` and `top_frame` — populated at fetch time in `fetch_sentry_issue_details` so both the alert enrichment and Ray's triage prompt benefit without re-parsing the raw event.
- `sentry-triage.ts` switches from calling `fetch_sentry_issue_details` directly to going through `get_cached_issue_details`, sharing the webhook handler's fetch.
- Failed fetches are immediately evicted from the cache so a transient Sentry outage does not poison alerts for 30s.

## Test plan

- [x] `pnpm vitest run sentry-alert-format` — 21 new tests covering every branch (full layout, emoji levels, missing release, missing short_id, missing stack frame, missing culprit, resolved action, minimal fallback, relative_time, top frame extraction, cache hit within TTL, concurrent in-flight dedup, TTL expiry refetch, rejected promise is not cached).
- [x] `pnpm vitest run` (full daemon suite, 48 files / 801 tests) — all green, including the existing sentry-triage tests.
- [x] `pnpm biome check .` — clean.
- [x] `pnpm -r typecheck` — clean across shared + cli + daemon.
- [ ] End-to-end validation happens on the next natural daemon restart (cannot trigger a real Sentry webhook from this session).

Closes #259