### PR TITLE
fix(pool): harden session_id persistence and expand --add-dir defaults

### DIFF
--- a/packages/daemon/src/__tests__/crash-recovery.test.ts
+++ b/packages/daemon/src/__tests__/crash-recovery.test.ts
@@ -4,8 +4,8 @@ import { join } from "node:path";
 import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
 import type { LobsterFarmConfig } from "@lobster-farm/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { BotPool } from "../pool.js";
 import type { PoolBot } from "../pool.js";
+import { BotPoolTestBase } from "./helpers/test-bot-pool-base.js";
 
 // Mock actions.ts — notify is imported by pool.ts for alerting
 vi.mock("../actions.js", () => ({
@@ -64,7 +64,7 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
  * Test-friendly subclass that stubs tmux/filesystem operations and
  * exposes internals needed for crash recovery assertions.
  */
-class TestBotPool extends BotPool {
+class TestBotPool extends BotPoolTestBase {
   inject_bots(bots: PoolBot[]): void {
     (this as unknown as { bots: PoolBot[] }).bots = bots;
   }
@@ -89,18 +89,6 @@ class TestBotPool extends BotPool {
   /** Override is_bot_idle — not relevant for crash recovery tests. */
   protected override is_bot_idle(): boolean {
     return true;
-  }
-
-  /** Default to "JSONL present" in tests so existing pre-#256 expectations hold. */
-  protected override check_session_jsonl_exists_anywhere(): Promise<boolean> {
-    return Promise.resolve(true);
-  }
-  protected override check_session_jsonl_exists(): Promise<boolean> {
-    return Promise.resolve(true);
-  }
-  /** Disable the background JSONL confirmation watcher in tests. */
-  protected override watch_session_confirmation(bot: PoolBot): void {
-    bot.session_confirmed = true;
   }
 }
 

--- a/packages/daemon/src/__tests__/crash-recovery.test.ts
+++ b/packages/daemon/src/__tests__/crash-recovery.test.ts
@@ -47,6 +47,7 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
     archetype: null,
     channel_type: null,
     session_id: null,
+    session_confirmed: true,
     tmux_session: `pool-${String(overrides.id)}`,
     last_active: null,
     assigned_at: null,
@@ -88,6 +89,18 @@ class TestBotPool extends BotPool {
   /** Override is_bot_idle — not relevant for crash recovery tests. */
   protected override is_bot_idle(): boolean {
     return true;
+  }
+
+  /** Default to "JSONL present" in tests so existing pre-#256 expectations hold. */
+  protected override check_session_jsonl_exists_anywhere(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  protected override check_session_jsonl_exists(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  /** Disable the background JSONL confirmation watcher in tests. */
+  protected override watch_session_confirmation(bot: PoolBot): void {
+    bot.session_confirmed = true;
   }
 }
 

--- a/packages/daemon/src/__tests__/fix-resume-persist.test.ts
+++ b/packages/daemon/src/__tests__/fix-resume-persist.test.ts
@@ -4,8 +4,8 @@ import { join } from "node:path";
 import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
 import type { LobsterFarmConfig } from "@lobster-farm/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { BotPool } from "../pool.js";
 import type { PoolBot } from "../pool.js";
+import { BotPoolTestBase } from "./helpers/test-bot-pool-base.js";
 
 let temp_dir: string;
 
@@ -20,7 +20,7 @@ function make_config(): LobsterFarmConfig {
  * Test-friendly subclass that exposes internals and stubs side effects.
  * Tracks persist() and kill_tmux() calls for assertion.
  */
-class TestBotPool extends BotPool {
+class TestBotPool extends BotPoolTestBase {
   persist_calls = 0;
   kill_tmux_calls: string[] = [];
   private persist_order: string[] = [];
@@ -53,18 +53,6 @@ class TestBotPool extends BotPool {
 
   protected override is_bot_idle(/* _bot: PoolBot */): boolean {
     return true;
-  }
-
-  /** Default to "JSONL present" in tests so existing pre-#256 expectations hold. */
-  protected override check_session_jsonl_exists_anywhere(): Promise<boolean> {
-    return Promise.resolve(true);
-  }
-  protected override check_session_jsonl_exists(): Promise<boolean> {
-    return Promise.resolve(true);
-  }
-  /** Disable the background JSONL confirmation watcher in tests. */
-  protected override watch_session_confirmation(bot: PoolBot): void {
-    bot.session_confirmed = true;
   }
 }
 

--- a/packages/daemon/src/__tests__/fix-resume-persist.test.ts
+++ b/packages/daemon/src/__tests__/fix-resume-persist.test.ts
@@ -54,6 +54,18 @@ class TestBotPool extends BotPool {
   protected override is_bot_idle(/* _bot: PoolBot */): boolean {
     return true;
   }
+
+  /** Default to "JSONL present" in tests so existing pre-#256 expectations hold. */
+  protected override check_session_jsonl_exists_anywhere(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  protected override check_session_jsonl_exists(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  /** Disable the background JSONL confirmation watcher in tests. */
+  protected override watch_session_confirmation(bot: PoolBot): void {
+    bot.session_confirmed = true;
+  }
 }
 
 function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
@@ -64,6 +76,7 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
     archetype: null,
     channel_type: null,
     session_id: null,
+    session_confirmed: true,
     tmux_session: `pool-${String(overrides.id)}`,
     last_active: null,
     assigned_at: null,

--- a/packages/daemon/src/__tests__/gh-token-injection.test.ts
+++ b/packages/daemon/src/__tests__/gh-token-injection.test.ts
@@ -120,6 +120,7 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
     archetype: null,
     channel_type: null,
     session_id: null,
+    session_confirmed: true,
     tmux_session: `pool-${String(overrides.id)}`,
     last_active: null,
     assigned_at: null,

--- a/packages/daemon/src/__tests__/helpers/test-bot-pool-base.ts
+++ b/packages/daemon/src/__tests__/helpers/test-bot-pool-base.ts
@@ -1,0 +1,24 @@
+import { BotPool } from "../../pool.js";
+import type { PoolBot } from "../../pool.js";
+
+/**
+ * Shared TestBotPool base for tests that don't need JSONL control.
+ *
+ * Treats all sessions as present on disk and disables the background watcher.
+ * Test files that need custom JSONL behavior (e.g. pool-session-confirmation)
+ * should extend BotPool directly and provide their own overrides.
+ */
+export class BotPoolTestBase extends BotPool {
+  /** Default to "JSONL present" so existing pre-#256 expectations hold. */
+  protected override check_session_jsonl_exists_anywhere(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  protected override check_session_jsonl_exists(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  /** Disable the background JSONL confirmation watcher — its deferred
+   * persist() can race with afterEach teardown and cause ENOTEMPTY on rmdir. */
+  protected override watch_session_confirmation(bot: PoolBot): void {
+    bot.session_confirmed = true;
+  }
+}

--- a/packages/daemon/src/__tests__/lazy-session-resume.test.ts
+++ b/packages/daemon/src/__tests__/lazy-session-resume.test.ts
@@ -4,8 +4,8 @@ import { join } from "node:path";
 import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
 import type { LobsterFarmConfig } from "@lobster-farm/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { BotPool } from "../pool.js";
 import type { PoolBot } from "../pool.js";
+import { BotPoolTestBase } from "./helpers/test-bot-pool-base.js";
 
 // ── Test helpers ──
 
@@ -43,7 +43,7 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
  * Test-friendly BotPool subclass that stubs tmux/filesystem side effects and
  * exposes internals for assertion. Follows the same pattern as existing test files.
  */
-class TestBotPool extends BotPool {
+class TestBotPool extends BotPoolTestBase {
   private tmux_alive_overrides = new Map<string, boolean>();
 
   inject_bots(bots: PoolBot[]): void {
@@ -71,18 +71,6 @@ class TestBotPool extends BotPool {
   /** Expose check_assigned_health for direct invocation in tests. */
   async run_health_check(): Promise<void> {
     await this.check_assigned_health();
-  }
-
-  /** Default to "JSONL present" in tests so existing pre-#256 expectations hold. */
-  protected override check_session_jsonl_exists_anywhere(): Promise<boolean> {
-    return Promise.resolve(true);
-  }
-  protected override check_session_jsonl_exists(): Promise<boolean> {
-    return Promise.resolve(true);
-  }
-  /** Disable the background JSONL confirmation watcher in tests. */
-  protected override watch_session_confirmation(bot: PoolBot): void {
-    bot.session_confirmed = true;
   }
 }
 

--- a/packages/daemon/src/__tests__/lazy-session-resume.test.ts
+++ b/packages/daemon/src/__tests__/lazy-session-resume.test.ts
@@ -26,6 +26,7 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
     archetype: null,
     channel_type: null,
     session_id: null,
+    session_confirmed: true,
     tmux_session: `pool-${String(overrides.id)}`,
     last_active: null,
     assigned_at: null,
@@ -70,6 +71,18 @@ class TestBotPool extends BotPool {
   /** Expose check_assigned_health for direct invocation in tests. */
   async run_health_check(): Promise<void> {
     await this.check_assigned_health();
+  }
+
+  /** Default to "JSONL present" in tests so existing pre-#256 expectations hold. */
+  protected override check_session_jsonl_exists_anywhere(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  protected override check_session_jsonl_exists(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  /** Disable the background JSONL confirmation watcher in tests. */
+  protected override watch_session_confirmation(bot: PoolBot): void {
+    bot.session_confirmed = true;
   }
 }
 

--- a/packages/daemon/src/__tests__/pool-avatars.test.ts
+++ b/packages/daemon/src/__tests__/pool-avatars.test.ts
@@ -4,8 +4,9 @@ import { join } from "node:path";
 import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
 import type { ArchetypeRole, LobsterFarmConfig } from "@lobster-farm/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { AVATAR_COOLDOWN_MS, BotPool } from "../pool.js";
+import { AVATAR_COOLDOWN_MS } from "../pool.js";
 import type { AvatarHandler, PoolBot } from "../pool.js";
+import { BotPoolTestBase } from "./helpers/test-bot-pool-base.js";
 
 let temp_dir: string;
 
@@ -17,7 +18,7 @@ function make_config(): LobsterFarmConfig {
 }
 
 /** Test-friendly subclass that overrides tmux operations. */
-class TestBotPool extends BotPool {
+class TestBotPool extends BotPoolTestBase {
   private idle_overrides = new Map<number, boolean>();
 
   inject_bots(bots: PoolBot[]): void {
@@ -26,18 +27,6 @@ class TestBotPool extends BotPool {
 
   protected override is_bot_idle(bot: PoolBot): boolean {
     return this.idle_overrides.get(bot.id) ?? true;
-  }
-
-  /** Default to "JSONL present" in tests so existing pre-#256 expectations hold. */
-  protected override check_session_jsonl_exists_anywhere(): Promise<boolean> {
-    return Promise.resolve(true);
-  }
-  protected override check_session_jsonl_exists(): Promise<boolean> {
-    return Promise.resolve(true);
-  }
-  /** Disable the background JSONL confirmation watcher in tests. */
-  protected override watch_session_confirmation(bot: PoolBot): void {
-    bot.session_confirmed = true;
   }
 }
 

--- a/packages/daemon/src/__tests__/pool-avatars.test.ts
+++ b/packages/daemon/src/__tests__/pool-avatars.test.ts
@@ -27,6 +27,18 @@ class TestBotPool extends BotPool {
   protected override is_bot_idle(bot: PoolBot): boolean {
     return this.idle_overrides.get(bot.id) ?? true;
   }
+
+  /** Default to "JSONL present" in tests so existing pre-#256 expectations hold. */
+  protected override check_session_jsonl_exists_anywhere(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  protected override check_session_jsonl_exists(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  /** Disable the background JSONL confirmation watcher in tests. */
+  protected override watch_session_confirmation(bot: PoolBot): void {
+    bot.session_confirmed = true;
+  }
 }
 
 function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
@@ -37,6 +49,7 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
     archetype: null,
     channel_type: null,
     session_id: null,
+    session_confirmed: true,
     tmux_session: `pool-${String(overrides.id)}`,
     last_active: null,
     assigned_at: null,

--- a/packages/daemon/src/__tests__/pool-persistence.test.ts
+++ b/packages/daemon/src/__tests__/pool-persistence.test.ts
@@ -11,9 +11,9 @@ import {
   save_pr_reviews,
 } from "../persistence.js";
 import type { PersistedPoolBot } from "../persistence.js";
-import { BotPool } from "../pool.js";
 import type { PoolBot } from "../pool.js";
 import type { EntityRegistry } from "../registry.js";
+import { BotPoolTestBase } from "./helpers/test-bot-pool-base.js";
 
 // ── Test helpers ──
 
@@ -47,7 +47,7 @@ function make_persisted_bot(
  * Test-friendly subclass that stubs tmux/filesystem/persistence side effects.
  * Mirrors TestBotPool from pool.test.ts but adds persistence visibility.
  */
-class TestBotPool extends BotPool {
+class TestBotPool extends BotPoolTestBase {
   private idle_overrides = new Map<number, boolean>();
 
   /** Track persist() calls for assertions. */
@@ -71,18 +71,6 @@ class TestBotPool extends BotPool {
 
   protected override is_bot_idle(bot: PoolBot): boolean {
     return this.idle_overrides.get(bot.id) ?? true;
-  }
-
-  /** Default to "JSONL present" in tests so existing pre-#256 expectations hold. */
-  protected override check_session_jsonl_exists_anywhere(): Promise<boolean> {
-    return Promise.resolve(true);
-  }
-  protected override check_session_jsonl_exists(): Promise<boolean> {
-    return Promise.resolve(true);
-  }
-  /** Disable the background JSONL confirmation watcher in tests. */
-  protected override watch_session_confirmation(bot: PoolBot): void {
-    bot.session_confirmed = true;
   }
 }
 

--- a/packages/daemon/src/__tests__/pool-persistence.test.ts
+++ b/packages/daemon/src/__tests__/pool-persistence.test.ts
@@ -72,6 +72,18 @@ class TestBotPool extends BotPool {
   protected override is_bot_idle(bot: PoolBot): boolean {
     return this.idle_overrides.get(bot.id) ?? true;
   }
+
+  /** Default to "JSONL present" in tests so existing pre-#256 expectations hold. */
+  protected override check_session_jsonl_exists_anywhere(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  protected override check_session_jsonl_exists(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  /** Disable the background JSONL confirmation watcher in tests. */
+  protected override watch_session_confirmation(bot: PoolBot): void {
+    bot.session_confirmed = true;
+  }
 }
 
 function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
@@ -82,6 +94,7 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
     archetype: null,
     channel_type: null,
     session_id: null,
+    session_confirmed: true,
     tmux_session: `pool-${String(overrides.id)}`,
     last_active: null,
     assigned_at: null,

--- a/packages/daemon/src/__tests__/pool-session-confirmation.test.ts
+++ b/packages/daemon/src/__tests__/pool-session-confirmation.test.ts
@@ -458,3 +458,174 @@ describe("start_tmux --add-dir defaults (#260)", () => {
     await rm(temp_dir, { recursive: true, force: true });
   });
 });
+
+// ── watch_session_confirmation timer loop ──
+// These tests exercise the REAL watcher (no override) with fake timers
+// to verify the poll loop's branching: confirmation, exhaustion, and
+// mid-poll reassignment.
+
+describe("watch_session_confirmation timer loop", () => {
+  /**
+   * Subclass that runs the REAL watch_session_confirmation — only the JSONL
+   * check is overridden, returning results from a test-controlled Set.
+   */
+  class RealWatcherTestPool extends BotPool {
+    public existing_sessions = new Set<string>();
+
+    /** Hook fired inside check_session_jsonl_exists — lets tests simulate
+     * side effects during the async suspension window (e.g. bot reassignment). */
+    public on_check_hook: (() => void) | null = null;
+
+    inject_bots(bots: PoolBot[]): void {
+      (this as unknown as { bots: PoolBot[] }).bots = bots;
+    }
+
+    get_bots(): PoolBot[] {
+      return (this as unknown as { bots: PoolBot[] }).bots;
+    }
+
+    protected override is_bot_idle(): boolean {
+      return true;
+    }
+
+    protected override check_session_jsonl_exists_anywhere(session_id: string): Promise<boolean> {
+      return Promise.resolve(this.existing_sessions.has(session_id));
+    }
+
+    protected override async check_session_jsonl_exists(
+      _working_dir: string,
+      session_id: string,
+    ): Promise<boolean> {
+      // Fire the hook before returning — simulates work happening during
+      // the async suspension in the real watcher tick.
+      this.on_check_hook?.();
+      return this.existing_sessions.has(session_id);
+    }
+  }
+
+  let pool: RealWatcherTestPool;
+
+  function make_watcher_bot(overrides?: Partial<PoolBot>): PoolBot {
+    return {
+      id: 1,
+      state: "assigned",
+      channel_id: "ch-1",
+      entity_id: "e1",
+      archetype: "builder",
+      channel_type: "general",
+      session_id: "sess-watch-test",
+      session_confirmed: false,
+      tmux_session: "pool-1",
+      last_active: null,
+      assigned_at: null,
+      state_dir: "/tmp/pool-1",
+      model: null,
+      effort: null,
+      last_avatar_archetype: null,
+      last_avatar_set_at: null,
+      ...overrides,
+    };
+  }
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    temp_dir = await mkdtemp(join(tmpdir(), "pool-watcher-test-"));
+    const config = make_config();
+    pool = new RealWatcherTestPool(config);
+  });
+
+  afterEach(async () => {
+    // Cancel any in-flight watchers so timers don't leak into other tests
+    await (pool as unknown as { shutdown: () => Promise<void> }).shutdown();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    await rm(temp_dir, { recursive: true, force: true });
+  });
+
+  it("promotes session_confirmed and calls persist when JSONL appears on tick 3", async () => {
+    const bot = make_watcher_bot();
+    pool.inject_bots([bot]);
+    const persist_spy = vi
+      .spyOn(pool as unknown as { persist: () => Promise<void> }, "persist" as never)
+      .mockResolvedValue(undefined as never);
+    const log_spy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    // Start the real watcher
+    (
+      pool as unknown as {
+        watch_session_confirmation: (b: PoolBot, wd: string, sid: string) => void;
+      }
+    ).watch_session_confirmation(bot, "/tmp/work", "sess-watch-test");
+
+    // Tick 1 (t=0): JSONL not found
+    await vi.advanceTimersByTimeAsync(0);
+    expect(bot.session_confirmed).toBe(false);
+
+    // Tick 2 (t=500): JSONL still not found
+    await vi.advanceTimersByTimeAsync(500);
+    expect(bot.session_confirmed).toBe(false);
+
+    // JSONL appears before tick 3
+    pool.existing_sessions.add("sess-watch-test");
+
+    // Tick 3 (t=1000): JSONL found → confirmed
+    await vi.advanceTimersByTimeAsync(500);
+    expect(bot.session_confirmed).toBe(true);
+    expect(persist_spy).toHaveBeenCalledOnce();
+    expect(log_spy).toHaveBeenCalledWith(expect.stringContaining("confirmed"));
+  });
+
+  it("gives up after max_attempts without setting session_confirmed", async () => {
+    const bot = make_watcher_bot();
+    pool.inject_bots([bot]);
+    const persist_spy = vi
+      .spyOn(pool as unknown as { persist: () => Promise<void> }, "persist" as never)
+      .mockResolvedValue(undefined as never);
+    const warn_spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    (
+      pool as unknown as {
+        watch_session_confirmation: (b: PoolBot, wd: string, sid: string) => void;
+      }
+    ).watch_session_confirmation(bot, "/tmp/work", "sess-watch-test");
+
+    // Advance past all 120 attempts: first tick at 0ms, then 119 * 500ms = 59500ms
+    // Use 61000ms to ensure we're past the full window.
+    await vi.advanceTimersByTimeAsync(61_000);
+
+    expect(bot.session_confirmed).toBe(false);
+    expect(persist_spy).not.toHaveBeenCalled();
+    expect(warn_spy).toHaveBeenCalledWith(expect.stringContaining("unconfirmed"));
+  });
+
+  it("aborts when bot is reassigned during the async check_session_jsonl_exists call", async () => {
+    const bot = make_watcher_bot();
+    pool.inject_bots([bot]);
+    const persist_spy = vi
+      .spyOn(pool as unknown as { persist: () => Promise<void> }, "persist" as never)
+      .mockResolvedValue(undefined as never);
+
+    // During the JSONL check, reassign the bot to a different session —
+    // simulates a message arriving while the filesystem call is in flight.
+    pool.on_check_hook = () => {
+      bot.session_id = "sess-different";
+    };
+
+    // Make the JSONL exist for the original session — the watcher should
+    // still abort because the bot was reassigned mid-check.
+    pool.existing_sessions.add("sess-watch-test");
+
+    (
+      pool as unknown as {
+        watch_session_confirmation: (b: PoolBot, wd: string, sid: string) => void;
+      }
+    ).watch_session_confirmation(bot, "/tmp/work", "sess-watch-test");
+
+    // First tick fires and hits the post-await re-check guard
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Bot should NOT be confirmed — the session_id changed mid-tick
+    expect(bot.session_confirmed).toBe(false);
+    expect(persist_spy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/daemon/src/__tests__/pool-session-confirmation.test.ts
+++ b/packages/daemon/src/__tests__/pool-session-confirmation.test.ts
@@ -1,0 +1,460 @@
+import { EventEmitter } from "node:events";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
+import type { LobsterFarmConfig } from "@lobster-farm/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock node:child_process BEFORE importing the module under test so the
+// spawn() used inside pool.ts routes through our stub. We capture every call
+// on a module-level array and assert against it in the #260 test below.
+const spawn_calls: unknown[][] = [];
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    spawn: (...args: unknown[]) => {
+      spawn_calls.push(args);
+      const fake = new EventEmitter() as EventEmitter & { unref: () => void; kill: () => void };
+      fake.unref = () => {};
+      fake.kill = () => {};
+      setImmediate(() => fake.emit("close", 0));
+      return fake as unknown as ReturnType<typeof actual.spawn>;
+    },
+  };
+});
+
+import { save_pool_state } from "../persistence.js";
+import type { PersistedPoolBot } from "../persistence.js";
+import { BotPool, encode_project_slug } from "../pool.js";
+import type { PoolBot } from "../pool.js";
+
+// ── Test helpers ──
+
+let temp_dir: string;
+
+function make_config(): LobsterFarmConfig {
+  return LobsterFarmConfigSchema.parse({
+    user: { name: "Test" },
+    paths: { lobsterfarm_dir: temp_dir },
+  });
+}
+
+async function seed_pool_dir(id: number): Promise<void> {
+  const dir = join(temp_dir, "channels", `pool-${String(id)}`);
+  await mkdir(dir, { recursive: true });
+  // bot_user_id_from_token() parses a Discord token as base64. Use a
+  // syntactically valid fake — the first segment decodes to "12345".
+  await writeFile(join(dir, ".env"), "DISCORD_BOT_TOKEN=MTIzNDU.abc.def", "utf-8");
+}
+
+function make_persisted(overrides: Partial<PersistedPoolBot> & { id: number }): PersistedPoolBot {
+  return {
+    state: "assigned",
+    channel_id: "ch-100",
+    entity_id: "test-entity",
+    archetype: "builder",
+    channel_type: null,
+    session_id: null,
+    last_active: null,
+    ...overrides,
+  };
+}
+
+/**
+ * TestBotPool variant for session-confirmation tests.
+ *
+ * Unlike the helpers in other test files, this subclass exposes the JSONL
+ * existence check so individual tests can control whether a session is
+ * considered "real" or "phantom". Watch timer is disabled to avoid bleeding
+ * into afterEach teardown.
+ */
+class TestBotPool extends BotPool {
+  /** Set of session_ids that tests should treat as having a JSONL on disk. */
+  public existing_sessions = new Set<string>();
+
+  inject_bots(bots: PoolBot[]): void {
+    (this as unknown as { bots: PoolBot[] }).bots = bots;
+  }
+
+  get_bots(): PoolBot[] {
+    return (this as unknown as { bots: PoolBot[] }).bots;
+  }
+
+  get_session_history(): Map<string, string> {
+    return (this as unknown as { session_history: Map<string, string> }).session_history;
+  }
+
+  /** Spy-ready accessor for the crash_history map. */
+  get_crash_history(): Map<number, number[]> {
+    return (this as unknown as { crash_history: Map<number, number[]> }).crash_history;
+  }
+
+  protected override is_bot_idle(): boolean {
+    return true;
+  }
+
+  protected override check_session_jsonl_exists_anywhere(session_id: string): Promise<boolean> {
+    return Promise.resolve(this.existing_sessions.has(session_id));
+  }
+
+  protected override check_session_jsonl_exists(
+    _working_dir: string,
+    session_id: string,
+  ): Promise<boolean> {
+    return Promise.resolve(this.existing_sessions.has(session_id));
+  }
+
+  /** Disable real watcher — its deferred persist races with rm on teardown. */
+  protected override watch_session_confirmation(bot: PoolBot): void {
+    bot.session_confirmed = true;
+  }
+}
+
+// ── #256: session_id persistence hardening ──
+
+describe("pool session confirmation hardening (#256)", () => {
+  let config: LobsterFarmConfig;
+  let pool: TestBotPool;
+
+  beforeEach(async () => {
+    temp_dir = await mkdtemp(join(tmpdir(), "pool-confirm-test-"));
+    config = make_config();
+    pool = new TestBotPool(config);
+
+    // Stub all side effects that would otherwise touch tmux/FS.
+    vi.spyOn(pool as unknown as Record<string, unknown>, "kill_tmux" as never).mockImplementation(
+      () => {},
+    );
+    vi.spyOn(
+      pool as unknown as Record<string, unknown>,
+      "write_access_json" as never,
+    ).mockResolvedValue(undefined);
+    vi.spyOn(
+      pool as unknown as Record<string, unknown>,
+      "set_bot_nickname" as never,
+    ).mockResolvedValue(undefined);
+    vi.spyOn(
+      pool as unknown as Record<string, unknown>,
+      "set_bot_avatar" as never,
+    ).mockResolvedValue(undefined);
+    vi.spyOn(pool as unknown as Record<string, unknown>, "start_tmux" as never).mockResolvedValue(
+      undefined,
+    );
+    vi.spyOn(pool as unknown as Record<string, unknown>, "is_tmux_alive" as never).mockReturnValue(
+      false,
+    );
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(temp_dir, { recursive: true, force: true });
+  });
+
+  describe("initialize() phantom filtering", () => {
+    it("drops persisted session_id when its JSONL does not exist on disk", async () => {
+      await seed_pool_dir(1);
+      await save_pool_state(
+        [
+          make_persisted({
+            id: 1,
+            state: "parked",
+            session_id: "sess-phantom-abc",
+            channel_id: "ch-1",
+          }),
+        ],
+        config,
+      );
+
+      const fresh = new TestBotPool(config);
+      vi.spyOn(
+        fresh as unknown as Record<string, unknown>,
+        "is_tmux_alive" as never,
+      ).mockReturnValue(false);
+      // existing_sessions is empty — phantom should be dropped
+      await fresh.initialize();
+
+      const bots = fresh.get_bots();
+      expect(bots).toHaveLength(1);
+      expect(bots[0]!.session_id).toBeNull();
+      expect(bots[0]!.session_confirmed).toBe(false);
+    });
+
+    it("keeps persisted session_id when its JSONL is on disk", async () => {
+      await seed_pool_dir(1);
+      await save_pool_state(
+        [
+          make_persisted({
+            id: 1,
+            state: "parked",
+            session_id: "sess-real-xyz",
+            channel_id: "ch-1",
+          }),
+        ],
+        config,
+      );
+
+      const fresh = new TestBotPool(config);
+      fresh.existing_sessions.add("sess-real-xyz");
+      vi.spyOn(
+        fresh as unknown as Record<string, unknown>,
+        "is_tmux_alive" as never,
+      ).mockReturnValue(false);
+      await fresh.initialize();
+
+      const bots = fresh.get_bots();
+      expect(bots).toHaveLength(1);
+      expect(bots[0]!.session_id).toBe("sess-real-xyz");
+      expect(bots[0]!.session_confirmed).toBe(true);
+    });
+
+    it("drops phantom session_history entries", async () => {
+      await seed_pool_dir(1);
+      await save_pool_state([], config, {
+        "e1:ch-dead": "sess-dead",
+        "e1:ch-alive": "sess-alive",
+      });
+
+      const fresh = new TestBotPool(config);
+      fresh.existing_sessions.add("sess-alive");
+      await fresh.initialize();
+
+      const history = fresh.get_session_history();
+      expect(history.get("e1:ch-dead")).toBeUndefined();
+      expect(history.get("e1:ch-alive")).toBe("sess-alive");
+    });
+  });
+
+  describe("persist() gate", () => {
+    it("writes null for unconfirmed session_id to avoid planting phantoms", async () => {
+      pool.inject_bots([
+        {
+          id: 1,
+          state: "assigned",
+          channel_id: "ch-1",
+          entity_id: "e1",
+          archetype: "builder",
+          channel_type: "general",
+          session_id: "sess-fresh-unconfirmed",
+          session_confirmed: false,
+          tmux_session: "pool-1",
+          last_active: null,
+          assigned_at: null,
+          state_dir: "/tmp/pool-1",
+          model: null,
+          effort: null,
+          last_avatar_archetype: null,
+          last_avatar_set_at: null,
+        },
+      ]);
+
+      // Use the private persist() method via bracket notation
+      await (pool as unknown as { persist: () => Promise<void> }).persist();
+
+      const { load_pool_state } = await import("../persistence.js");
+      const state = await load_pool_state(config);
+      expect(state.bots).toHaveLength(1);
+      expect(state.bots[0]!.session_id).toBeNull();
+    });
+
+    it("writes real session_id for confirmed bots", async () => {
+      pool.inject_bots([
+        {
+          id: 1,
+          state: "assigned",
+          channel_id: "ch-1",
+          entity_id: "e1",
+          archetype: "builder",
+          channel_type: "general",
+          session_id: "sess-confirmed",
+          session_confirmed: true,
+          tmux_session: "pool-1",
+          last_active: null,
+          assigned_at: null,
+          state_dir: "/tmp/pool-1",
+          model: null,
+          effort: null,
+          last_avatar_archetype: null,
+          last_avatar_set_at: null,
+        },
+      ]);
+
+      await (pool as unknown as { persist: () => Promise<void> }).persist();
+
+      const { load_pool_state } = await import("../persistence.js");
+      const state = await load_pool_state(config);
+      expect(state.bots[0]!.session_id).toBe("sess-confirmed");
+    });
+  });
+
+  describe("handle_crash_loop() phantom guard", () => {
+    it("does not stash an unconfirmed session into session_history", async () => {
+      pool.inject_bots([
+        {
+          id: 1,
+          state: "assigned",
+          channel_id: "ch-1",
+          entity_id: "e1",
+          archetype: "builder",
+          channel_type: "general",
+          session_id: "sess-unconfirmed",
+          session_confirmed: false,
+          tmux_session: "pool-1",
+          last_active: null,
+          assigned_at: null,
+          state_dir: "/tmp/pool-1",
+          model: null,
+          effort: null,
+          last_avatar_archetype: null,
+          last_avatar_set_at: null,
+        },
+      ]);
+
+      await (
+        pool as unknown as { handle_crash_loop: (b: PoolBot) => Promise<void> }
+      ).handle_crash_loop(pool.get_bots()[0]!);
+
+      expect(pool.get_session_history().get("e1:ch-1")).toBeUndefined();
+    });
+
+    it("does not stash a confirmed-but-missing-JSONL session into session_history", async () => {
+      pool.inject_bots([
+        {
+          id: 1,
+          state: "assigned",
+          channel_id: "ch-1",
+          entity_id: "e1",
+          archetype: "builder",
+          channel_type: "general",
+          session_id: "sess-was-confirmed",
+          session_confirmed: true,
+          tmux_session: "pool-1",
+          last_active: null,
+          assigned_at: null,
+          state_dir: "/tmp/pool-1",
+          model: null,
+          effort: null,
+          last_avatar_archetype: null,
+          last_avatar_set_at: null,
+        },
+      ]);
+      // existing_sessions is empty → JSONL missing
+      await (
+        pool as unknown as { handle_crash_loop: (b: PoolBot) => Promise<void> }
+      ).handle_crash_loop(pool.get_bots()[0]!);
+
+      expect(pool.get_session_history().get("e1:ch-1")).toBeUndefined();
+    });
+
+    it("stashes a confirmed session whose JSONL is still on disk", async () => {
+      pool.existing_sessions.add("sess-real");
+      pool.inject_bots([
+        {
+          id: 1,
+          state: "assigned",
+          channel_id: "ch-1",
+          entity_id: "e1",
+          archetype: "builder",
+          channel_type: "general",
+          session_id: "sess-real",
+          session_confirmed: true,
+          tmux_session: "pool-1",
+          last_active: null,
+          assigned_at: null,
+          state_dir: "/tmp/pool-1",
+          model: null,
+          effort: null,
+          last_avatar_archetype: null,
+          last_avatar_set_at: null,
+        },
+      ]);
+
+      await (
+        pool as unknown as { handle_crash_loop: (b: PoolBot) => Promise<void> }
+      ).handle_crash_loop(pool.get_bots()[0]!);
+
+      expect(pool.get_session_history().get("e1:ch-1")).toBe("sess-real");
+    });
+  });
+});
+
+// ── encode_project_slug helper (#256) ──
+
+describe("encode_project_slug", () => {
+  it("replaces slashes and dots with dashes", () => {
+    expect(encode_project_slug("/Users/me/.lobsterfarm/entities/foo")).toBe(
+      "-Users-me--lobsterfarm-entities-foo",
+    );
+  });
+});
+
+// ── #260: --add-dir defaults ──
+// spawn() is mocked at the top of the file to capture tmux invocations.
+
+describe("start_tmux --add-dir defaults (#260)", () => {
+  it("includes ~/.claude and /tmp in the trusted directory set", async () => {
+    spawn_calls.length = 0;
+    temp_dir = await mkdtemp(join(tmpdir(), "pool-adddir-test-"));
+    const config = make_config();
+    const pool = new TestBotPool(config);
+
+    // is_tmux_alive → false so start_tmux short-circuits after spawn resolves
+    // (it only does the trust-dialog send-keys if tmux_alive returns true).
+    vi.spyOn(pool as unknown as Record<string, unknown>, "is_tmux_alive" as never).mockReturnValue(
+      false,
+    );
+
+    const start_tmux = (
+      pool as unknown as {
+        start_tmux: (
+          bot: PoolBot,
+          archetype: string,
+          entity_id: string,
+          working_dir: string,
+          session_id: string,
+          is_resume?: boolean,
+        ) => Promise<void>;
+      }
+    ).start_tmux.bind(pool);
+
+    const bot: PoolBot = {
+      id: 0,
+      state: "free",
+      channel_id: "ch-1",
+      entity_id: "e1",
+      archetype: "builder",
+      channel_type: "general",
+      session_id: null,
+      session_confirmed: false,
+      tmux_session: "pool-0",
+      last_active: null,
+      assigned_at: null,
+      state_dir: join(temp_dir, "pool-0"),
+      model: null,
+      effort: null,
+      last_avatar_archetype: null,
+      last_avatar_set_at: null,
+    };
+
+    try {
+      await start_tmux(bot, "builder", "e1", join(temp_dir, "work"), "sess-test", false);
+    } catch {
+      // start_tmux throws when is_tmux_alive returns false — but spawn_spy
+      // has already captured the command string we care about.
+    }
+
+    // Find the tmux spawn call (there may also be an unrelated spawn earlier).
+    const tmux_call = spawn_calls.find((c) => c[0] === "tmux");
+    expect(tmux_call).toBeDefined();
+    const argv = tmux_call![1] as string[];
+    // The last element is the DISCORD_STATE_DIR=... <git_env> <claude_cmd> string.
+    const claude_cmd = argv[argv.length - 1]!;
+    expect(claude_cmd).toContain("--add-dir");
+    // ~/.claude should be expanded to an absolute path containing ".claude"
+    expect(claude_cmd).toMatch(/--add-dir\s+'[^']*\.claude'/);
+    expect(claude_cmd).toContain("--add-dir '/tmp'");
+
+    await rm(temp_dir, { recursive: true, force: true });
+  });
+});

--- a/packages/daemon/src/__tests__/pool.test.ts
+++ b/packages/daemon/src/__tests__/pool.test.ts
@@ -4,8 +4,8 @@ import { join } from "node:path";
 import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
 import type { LobsterFarmConfig } from "@lobster-farm/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { BotPool } from "../pool.js";
 import type { PoolBot } from "../pool.js";
+import { BotPoolTestBase } from "./helpers/test-bot-pool-base.js";
 
 let temp_dir: string;
 
@@ -20,7 +20,7 @@ function make_config(): LobsterFarmConfig {
  * Test-friendly subclass of BotPool that exposes internals for unit testing.
  * Overrides tmux/filesystem operations to avoid real side effects.
  */
-class TestBotPool extends BotPool {
+class TestBotPool extends BotPoolTestBase {
   // Override the tmux-dependent methods to make tests deterministic.
   // The real pool checks tmux pane output; we control what is_bot_idle returns
   // by mapping bot IDs to idle status.
@@ -44,19 +44,6 @@ class TestBotPool extends BotPool {
    */
   protected override is_bot_idle(bot: PoolBot): boolean {
     return this.idle_overrides.get(bot.id) ?? true;
-  }
-
-  /** Default to "JSONL present" in tests so existing pre-#256 expectations hold. */
-  protected override check_session_jsonl_exists_anywhere(): Promise<boolean> {
-    return Promise.resolve(true);
-  }
-  protected override check_session_jsonl_exists(): Promise<boolean> {
-    return Promise.resolve(true);
-  }
-  /** Disable the background JSONL confirmation watcher in tests — its deferred
-   * persist() can race with afterEach teardown and cause ENOTEMPTY on rmdir. */
-  protected override watch_session_confirmation(bot: PoolBot): void {
-    bot.session_confirmed = true;
   }
 }
 

--- a/packages/daemon/src/__tests__/pool.test.ts
+++ b/packages/daemon/src/__tests__/pool.test.ts
@@ -45,6 +45,19 @@ class TestBotPool extends BotPool {
   protected override is_bot_idle(bot: PoolBot): boolean {
     return this.idle_overrides.get(bot.id) ?? true;
   }
+
+  /** Default to "JSONL present" in tests so existing pre-#256 expectations hold. */
+  protected override check_session_jsonl_exists_anywhere(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  protected override check_session_jsonl_exists(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  /** Disable the background JSONL confirmation watcher in tests — its deferred
+   * persist() can race with afterEach teardown and cause ENOTEMPTY on rmdir. */
+  protected override watch_session_confirmation(bot: PoolBot): void {
+    bot.session_confirmed = true;
+  }
 }
 
 /** Create a PoolBot with sensible defaults for testing. */
@@ -56,6 +69,7 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
     archetype: null,
     channel_type: null,
     session_id: null,
+    session_confirmed: true,
     tmux_session: `pool-${String(overrides.id)}`,
     last_active: null,
     assigned_at: null,

--- a/packages/daemon/src/__tests__/resume-nudge.test.ts
+++ b/packages/daemon/src/__tests__/resume-nudge.test.ts
@@ -57,6 +57,7 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
     archetype: null,
     channel_type: null,
     session_id: null,
+    session_confirmed: true,
     tmux_session: `pool-${String(overrides.id)}`,
     last_active: null,
     assigned_at: null,
@@ -88,6 +89,18 @@ class TestBotPool extends BotPool {
 
   protected override is_bot_idle(): boolean {
     return true;
+  }
+
+  /** Default to "JSONL present" in tests so existing pre-#256 expectations hold. */
+  protected override check_session_jsonl_exists_anywhere(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  protected override check_session_jsonl_exists(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  /** Disable the background JSONL confirmation watcher in tests. */
+  protected override watch_session_confirmation(bot: PoolBot): void {
+    bot.session_confirmed = true;
   }
 }
 

--- a/packages/daemon/src/__tests__/resume-nudge.test.ts
+++ b/packages/daemon/src/__tests__/resume-nudge.test.ts
@@ -4,8 +4,8 @@ import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
 import type { LobsterFarmConfig } from "@lobster-farm/shared";
 import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PersistedPoolBot } from "../persistence.js";
-import { BotPool } from "../pool.js";
 import type { PoolBot } from "../pool.js";
+import { BotPoolTestBase } from "./helpers/test-bot-pool-base.js";
 
 // ── Mocks ──
 
@@ -74,7 +74,7 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
  * Test-friendly BotPool subclass. Stubs tmux/filesystem side effects
  * and exposes internals for resume_parked_bots testing.
  */
-class TestBotPool extends BotPool {
+class TestBotPool extends BotPoolTestBase {
   inject_bots(bots: PoolBot[]): void {
     (this as unknown as { bots: PoolBot[] }).bots = bots;
   }
@@ -89,18 +89,6 @@ class TestBotPool extends BotPool {
 
   protected override is_bot_idle(): boolean {
     return true;
-  }
-
-  /** Default to "JSONL present" in tests so existing pre-#256 expectations hold. */
-  protected override check_session_jsonl_exists_anywhere(): Promise<boolean> {
-    return Promise.resolve(true);
-  }
-  protected override check_session_jsonl_exists(): Promise<boolean> {
-    return Promise.resolve(true);
-  }
-  /** Disable the background JSONL confirmation watcher in tests. */
-  protected override watch_session_confirmation(bot: PoolBot): void {
-    bot.session_confirmed = true;
   }
 }
 

--- a/packages/daemon/src/__tests__/session-history.test.ts
+++ b/packages/daemon/src/__tests__/session-history.test.ts
@@ -6,8 +6,8 @@ import type { EntityConfig, LobsterFarmConfig } from "@lobster-farm/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { load_pool_state } from "../persistence.js";
 import type { PersistedPoolBot } from "../persistence.js";
-import { BotPool } from "../pool.js";
 import type { PoolBot } from "../pool.js";
+import { BotPoolTestBase } from "./helpers/test-bot-pool-base.js";
 
 // ── Test helpers ──
 
@@ -83,7 +83,7 @@ function make_entity_config(entity_id: string, channel_ids: string[]): EntityCon
 /**
  * Test-friendly BotPool subclass that stubs tmux/filesystem/persistence side effects.
  */
-class TestBotPool extends BotPool {
+class TestBotPool extends BotPoolTestBase {
   private idle_overrides = new Map<number, boolean>();
 
   inject_bots(bots: PoolBot[]): void {
@@ -104,18 +104,6 @@ class TestBotPool extends BotPool {
 
   protected override is_bot_idle(bot: PoolBot): boolean {
     return this.idle_overrides.get(bot.id) ?? true;
-  }
-
-  /** Default to "JSONL present" in tests so existing pre-#256 expectations hold. */
-  protected override check_session_jsonl_exists_anywhere(): Promise<boolean> {
-    return Promise.resolve(true);
-  }
-  protected override check_session_jsonl_exists(): Promise<boolean> {
-    return Promise.resolve(true);
-  }
-  /** Disable the background JSONL confirmation watcher in tests. */
-  protected override watch_session_confirmation(bot: PoolBot): void {
-    bot.session_confirmed = true;
   }
 }
 

--- a/packages/daemon/src/__tests__/session-history.test.ts
+++ b/packages/daemon/src/__tests__/session-history.test.ts
@@ -45,6 +45,7 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
     archetype: null,
     channel_type: null,
     session_id: null,
+    session_confirmed: true,
     tmux_session: `pool-${String(overrides.id)}`,
     last_active: null,
     assigned_at: null,
@@ -103,6 +104,18 @@ class TestBotPool extends BotPool {
 
   protected override is_bot_idle(bot: PoolBot): boolean {
     return this.idle_overrides.get(bot.id) ?? true;
+  }
+
+  /** Default to "JSONL present" in tests so existing pre-#256 expectations hold. */
+  protected override check_session_jsonl_exists_anywhere(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  protected override check_session_jsonl_exists(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  /** Disable the background JSONL confirmation watcher in tests. */
+  protected override watch_session_confirmation(bot: PoolBot): void {
+    bot.session_confirmed = true;
   }
 }
 

--- a/packages/daemon/src/__tests__/stale-oauth-restart.test.ts
+++ b/packages/daemon/src/__tests__/stale-oauth-restart.test.ts
@@ -4,8 +4,8 @@ import { join } from "node:path";
 import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
 import type { LobsterFarmConfig } from "@lobster-farm/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { BotPool } from "../pool.js";
 import type { PoolBot } from "../pool.js";
+import { BotPoolTestBase } from "./helpers/test-bot-pool-base.js";
 
 // ── Test helpers ──
 
@@ -43,7 +43,7 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
  * Test-friendly BotPool subclass that stubs tmux/filesystem side effects.
  * Adds control over stale OAuth detection via pane_stale_overrides.
  */
-class TestBotPool extends BotPool {
+class TestBotPool extends BotPoolTestBase {
   private tmux_alive_overrides = new Map<string, boolean>();
   private pane_stale_overrides = new Map<string, boolean>();
 
@@ -77,18 +77,6 @@ class TestBotPool extends BotPool {
   /** Override is_pane_stale_oauth to use test-controlled map instead of tmux. */
   protected override is_pane_stale_oauth(session_name: string): boolean {
     return this.pane_stale_overrides.get(session_name) ?? false;
-  }
-
-  /** Default to "JSONL present" in tests so existing pre-#256 expectations hold. */
-  protected override check_session_jsonl_exists_anywhere(): Promise<boolean> {
-    return Promise.resolve(true);
-  }
-  protected override check_session_jsonl_exists(): Promise<boolean> {
-    return Promise.resolve(true);
-  }
-  /** Disable the background JSONL confirmation watcher in tests. */
-  protected override watch_session_confirmation(bot: PoolBot): void {
-    bot.session_confirmed = true;
   }
 }
 

--- a/packages/daemon/src/__tests__/stale-oauth-restart.test.ts
+++ b/packages/daemon/src/__tests__/stale-oauth-restart.test.ts
@@ -26,6 +26,7 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
     archetype: null,
     channel_type: null,
     session_id: null,
+    session_confirmed: true,
     tmux_session: `pool-${String(overrides.id)}`,
     last_active: null,
     assigned_at: null,
@@ -76,6 +77,18 @@ class TestBotPool extends BotPool {
   /** Override is_pane_stale_oauth to use test-controlled map instead of tmux. */
   protected override is_pane_stale_oauth(session_name: string): boolean {
     return this.pane_stale_overrides.get(session_name) ?? false;
+  }
+
+  /** Default to "JSONL present" in tests so existing pre-#256 expectations hold. */
+  protected override check_session_jsonl_exists_anywhere(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  protected override check_session_jsonl_exists(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  /** Disable the background JSONL confirmation watcher in tests. */
+  protected override watch_session_confirmation(bot: PoolBot): void {
+    bot.session_confirmed = true;
   }
 }
 

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -1757,7 +1757,7 @@ export class BotPool extends EventEmitter {
 
   /** Cancel any pending session-confirmation watcher for a bot. Safe to call
    * when no watcher exists. */
-  protected cancel_session_watcher(bot_id: number): void {
+  private cancel_session_watcher(bot_id: number): void {
     const timer = this.session_watchers.get(bot_id);
     if (timer) {
       clearTimeout(timer);
@@ -1932,6 +1932,11 @@ export class BotPool extends EventEmitter {
     //     trigger an interactive approval modal. See issue #260.
     //   - /tmp       — standard scratch dir. Lets bots stage intermediate
     //     artifacts without polluting the entity worktree's git status.
+    //     Security note: /tmp is world-writable. We accept this because pool
+    //     bots already run under bypassPermissions for the entity worktree —
+    //     the threat model assumes a trusted single-user environment. If
+    //     multi-tenant isolation is ever required, replace with a per-entity
+    //     temp dir.
     // Both paths are already world-accessible to this user — adding them to
     // the trusted set doesn't widen the blast radius, it just stops the
     // modal stalls. We resolve ~ via homedir() because tmux command-string

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -1,7 +1,7 @@
 import { execFileSync, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
-import { readFile, stat, unlink, writeFile } from "node:fs/promises";
+import { access, readFile, stat, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { ArchetypeRole, LobsterFarmConfig } from "@lobster-farm/shared";
@@ -26,6 +26,11 @@ export interface PoolBot {
   archetype: ArchetypeRole | null;
   channel_type: ChannelType | null;
   session_id: string | null;
+  /** True once the Claude Code JSONL transcript for `session_id` has been observed
+   * on disk — only confirmed sessions are persisted to pool-state.json, so a
+   * daemon restart during the pre-confirmation window will never try to
+   * `--resume` a phantom session that Claude never materialized. See issue #256. */
+  session_confirmed: boolean;
   tmux_session: string;
   last_active: Date | null;
   /** When this bot was assigned to its current channel. Used for uptime calculation. */
@@ -107,6 +112,78 @@ export function is_tmux_session_idle(tmux_session: string): boolean {
   } catch {
     return true; // Can't check — assume idle (fail-open)
   }
+}
+
+// ── Claude Code JSONL session tracking ──
+
+/**
+ * Encode an absolute filesystem path into Claude Code's project-slug format.
+ *
+ * Claude Code stores each session's JSONL transcript at
+ * `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`. The encoding replaces
+ * every `/` and `.` in the absolute path with `-`.
+ *
+ * Example:
+ *   /Users/farm/.lobsterfarm/entities/lobster-farm/repos/lobster-farm
+ *   → -Users-farm--lobsterfarm-entities-lobster-farm-repos-lobster-farm
+ */
+export function encode_project_slug(abs_path: string): string {
+  return abs_path.replace(/[/.]/g, "-");
+}
+
+/** Absolute path to the JSONL transcript Claude Code will write for this session. */
+export function claude_session_jsonl_path(working_dir: string, session_id: string): string {
+  return join(
+    homedir(),
+    ".claude",
+    "projects",
+    encode_project_slug(working_dir),
+    `${session_id}.jsonl`,
+  );
+}
+
+/** Returns true iff the session's JSONL transcript exists on disk under the
+ * project slug that corresponds to `working_dir`. Claude Code only creates
+ * the JSONL on the session's first write, so this is how we distinguish a
+ * "real" session from one that never committed anything.
+ *
+ * This is the targeted check used during confirmation — we know the cwd of
+ * the tmux session we spawned, so we look in exactly that project slug. */
+export async function session_jsonl_exists(
+  working_dir: string,
+  session_id: string,
+): Promise<boolean> {
+  try {
+    await access(claude_session_jsonl_path(working_dir, session_id));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Returns true iff a JSONL transcript for `session_id` exists under *any*
+ * project slug in `~/.claude/projects/`. Used when restoring state from
+ * pool-state.json on daemon restart, where the original cwd (e.g. a feature
+ * worktree) may differ from the entity_dir the restart will actually use. */
+export async function session_jsonl_exists_anywhere(session_id: string): Promise<boolean> {
+  const { readdir } = await import("node:fs/promises");
+  const projects_dir = join(homedir(), ".claude", "projects");
+  const filename = `${session_id}.jsonl`;
+  try {
+    const entries = await readdir(projects_dir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      try {
+        await access(join(projects_dir, entry.name, filename));
+        return true;
+      } catch {
+        // not in this project dir
+      }
+    }
+  } catch {
+    // ~/.claude/projects missing or unreadable — treat as "not found"
+  }
+  return false;
 }
 
 // ── Agent name resolution ──
@@ -203,6 +280,11 @@ export class BotPool extends EventEmitter {
   /** Queued messages for bots that weren't at the prompt when inject was attempted.
    * tmux_session → messages[]. Drained by the health check cycle (every 30s). */
   private pending_injections = new Map<string, string[]>();
+  /** Active session-confirmation watchers (issue #256). bot_id → timer handle.
+   * Each watcher polls for the JSONL transcript and promotes bot.session_confirmed
+   * from false → true once Claude commits its first turn to disk. Cleared on
+   * reassignment, release, or shutdown to prevent leaks. */
+  private session_watchers = new Map<number, ReturnType<typeof setTimeout>>();
 
   constructor(config: LobsterFarmConfig) {
     super();
@@ -221,6 +303,16 @@ export class BotPool extends EventEmitter {
    * .env file and makes a raw REST call. The pool never sees the token. */
   set_avatar_handler(handler: AvatarHandler): void {
     this.avatar_handler = handler;
+  }
+
+  /** Protected wrappers around JSONL existence checks so tests can override
+   * without touching the real filesystem. Defaults to the module-level helpers
+   * which read from `~/.claude/projects/`. */
+  protected check_session_jsonl_exists(working_dir: string, session_id: string): Promise<boolean> {
+    return session_jsonl_exists(working_dir, session_id);
+  }
+  protected check_session_jsonl_exists_anywhere(session_id: string): Promise<boolean> {
+    return session_jsonl_exists_anywhere(session_id);
   }
 
   /** Enter drain mode — no new assignments accepted. */
@@ -298,6 +390,7 @@ export class BotPool extends EventEmitter {
         archetype: null,
         channel_type: null,
         session_id: null,
+        session_confirmed: false,
         tmux_session,
         last_active: is_running ? new Date() : null,
         assigned_at: is_running ? new Date() : null,
@@ -328,14 +421,31 @@ export class BotPool extends EventEmitter {
     let restored = 0;
     this.resume_candidates = [];
 
-    // Restore session history from persisted state
+    // Restore session history from persisted state. Pre-flight the JSONL for
+    // each entry — a history entry whose transcript has gone missing is a
+    // phantom session that would crash-loop the next bot assigned to this
+    // channel (issue #256). Drop phantoms on the floor.
+    // We search *all* project slugs because the original session may have
+    // been spawned in a worktree cwd that no longer matches entity_dir.
     const now = Date.now();
+    let history_dropped = 0;
     for (const [key, session_id] of Object.entries(saved_state.session_history)) {
+      const exists = await this.check_session_jsonl_exists_anywhere(session_id);
+      if (!exists) {
+        console.warn(
+          `[pool] Dropping phantom session_history entry ${key} → ${session_id.slice(0, 8)} (no JSONL on disk)`,
+        );
+        history_dropped++;
+        continue;
+      }
       this.session_history.set(key, session_id);
       this.session_history_ts.set(key, now);
     }
     if (this.session_history.size > 0) {
       console.log(`[pool] Restored ${String(this.session_history.size)} session history entries`);
+    }
+    if (history_dropped > 0) {
+      console.warn(`[pool] Dropped ${String(history_dropped)} phantom session_history entries`);
     }
 
     // Restore avatar state for all bots (including those that will stay free).
@@ -374,6 +484,25 @@ export class BotPool extends EventEmitter {
         entry.effort ??
         (entry.archetype ? resolve_effort(DEFAULT_ARCHETYPES[entry.archetype].think) : null);
 
+      // Defensive pre-flight (issue #256): a persisted session_id must have a
+      // JSONL transcript on disk, otherwise --resume will fail and trigger a
+      // crash loop. If the file is missing — either because the state file
+      // predates the confirmation-gate fix, or because Claude Code deleted
+      // the JSONL externally — drop the session_id and fall through to a
+      // fresh spawn on next assignment. Logged loudly so we can see it.
+      // Search all project slugs in case the session was originally spawned
+      // in a feature worktree that differs from entity_dir.
+      let restored_session_id = entry.session_id;
+      if (restored_session_id) {
+        const exists = await this.check_session_jsonl_exists_anywhere(restored_session_id);
+        if (!exists) {
+          console.warn(
+            `[pool] pool-${String(entry.id)}: persisted session ${restored_session_id.slice(0, 8)} has no JSONL on disk — dropping to prevent --resume crash loop`,
+          );
+          restored_session_id = null;
+        }
+      }
+
       if (bot.state === "assigned") {
         // tmux is still running (survived restart, e.g. launchd) — restore metadata.
         // BUT the Claude process inside has a stale MCP connection to the old daemon.
@@ -383,7 +512,8 @@ export class BotPool extends EventEmitter {
         bot.entity_id = entry.entity_id;
         bot.archetype = entry.archetype;
         bot.channel_type = entry.channel_type;
-        bot.session_id = entry.session_id;
+        bot.session_id = restored_session_id;
+        bot.session_confirmed = !!restored_session_id;
         bot.model = restored_model;
         bot.effort = restored_effort;
         bot.last_active = entry.last_active ? new Date(entry.last_active) : null;
@@ -392,11 +522,12 @@ export class BotPool extends EventEmitter {
 
         // Add to resume candidates — the live tmux session has a dead MCP socket.
         // resume_parked_bots() will kill it and spawn fresh with --resume.
-        if (entry.state === "assigned" && entry.session_id) {
-          this.resume_candidates.push(entry);
+        // Only resume if the JSONL actually exists on disk.
+        if (entry.state === "assigned" && restored_session_id) {
+          this.resume_candidates.push({ ...entry, session_id: restored_session_id });
           console.log(
             `[pool] pool-${String(bot.id)} has live tmux but stale MCP — ` +
-              `queued for fresh resume (session: ${entry.session_id.slice(0, 8)})`,
+              `queued for fresh resume (session: ${restored_session_id.slice(0, 8)})`,
           );
         }
       } else {
@@ -408,7 +539,8 @@ export class BotPool extends EventEmitter {
         bot.entity_id = entry.entity_id;
         bot.archetype = entry.archetype;
         bot.channel_type = entry.channel_type;
-        bot.session_id = entry.session_id;
+        bot.session_id = restored_session_id;
+        bot.session_confirmed = !!restored_session_id;
         bot.model = restored_model;
         bot.effort = restored_effort;
         bot.last_active = entry.last_active ? new Date(entry.last_active) : null;
@@ -418,8 +550,8 @@ export class BotPool extends EventEmitter {
         // If this bot was actively assigned (not already parked) before shutdown
         // and has a session_id, it's a candidate for proactive resume.
         // Bots saved as "parked" were already idle — don't resume those.
-        if (entry.state === "assigned" && entry.session_id) {
-          this.resume_candidates.push(entry);
+        if (entry.state === "assigned" && restored_session_id) {
+          this.resume_candidates.push({ ...entry, session_id: restored_session_id });
         }
       }
 
@@ -577,8 +709,12 @@ export class BotPool extends EventEmitter {
           extra_env,
         );
 
-        // Update bot state to assigned
+        // Update bot state to assigned. The resumed session is known to have
+        // a JSONL on disk (pre-flight checked in initialize()), so mark it
+        // confirmed — persist() will now write the session_id.
         bot.state = "assigned";
+        bot.session_id = candidate.session_id;
+        bot.session_confirmed = true;
         bot.last_active = new Date();
         bot.assigned_at = new Date(); // Reset uptime — new process
 
@@ -765,7 +901,16 @@ export class BotPool extends EventEmitter {
       // Stash session history for the evicted bot's channel before overwriting.
       // Only stash if the bot is being reassigned away from a different channel
       // (i.e., not a returning parked bot reclaiming its own channel, and not a free bot).
-      if (bot.channel_id && bot.entity_id && bot.session_id && bot.channel_id !== channel_id) {
+      // Only stash *confirmed* sessions — stashing an unconfirmed UUID would
+      // plant a phantom that the next assignment on this channel would try
+      // (and fail) to --resume (issue #256).
+      if (
+        bot.channel_id &&
+        bot.entity_id &&
+        bot.session_id &&
+        bot.session_confirmed &&
+        bot.channel_id !== channel_id
+      ) {
         const evict_key = `${bot.entity_id}:${bot.channel_id}`;
         this.session_history.set(evict_key, bot.session_id);
         this.session_history_ts.set(evict_key, Date.now());
@@ -773,6 +918,11 @@ export class BotPool extends EventEmitter {
           `[pool] Stashed session history for ${evict_key}: ${bot.session_id.slice(0, 8)}`,
         );
       }
+
+      // Cancel any in-flight session-confirmation watcher for this bot —
+      // the old session is about to be killed, so confirming it would be
+      // a no-op at best and a race at worst.
+      this.cancel_session_watcher(bot.id);
 
       // Kill any existing tmux session
       this.kill_tmux(bot.tmux_session);
@@ -820,6 +970,11 @@ export class BotPool extends EventEmitter {
       bot.archetype = archetype;
       bot.channel_type = channel_type ?? null;
       bot.session_id = session_id;
+      // Resumed sessions already have a JSONL on disk (we pre-flight checked
+      // at the initialize() / history-restore layer). Fresh sessions start
+      // unconfirmed — persist() won't write the session_id until the
+      // confirmation watcher sees the JSONL materialize. See issue #256.
+      bot.session_confirmed = !!resolved_session_id;
       bot.model = resolve_model_id(assigned_defaults);
       bot.effort = resolve_effort(assigned_defaults.think);
       bot.last_active = new Date();
@@ -834,6 +989,15 @@ export class BotPool extends EventEmitter {
       }
 
       await this.persist();
+
+      // Kick off a background watcher for fresh sessions: once Claude writes
+      // its first JSONL turn we promote session_confirmed = true and persist
+      // the session_id. If the daemon restarts before confirmation, the next
+      // startup will not see session_id in pool-state.json and will cleanly
+      // spawn a new session instead of crash-looping on --resume.
+      if (!resolved_session_id) {
+        this.watch_session_confirmation(bot, resolved_dir, session_id);
+      }
 
       console.log(
         `[pool] Assigned pool-${String(bot.id)} to channel ${channel_id} ` +
@@ -875,6 +1039,7 @@ export class BotPool extends EventEmitter {
     try {
       const bot_id = bot.id;
       this.kill_tmux(bot.tmux_session);
+      this.cancel_session_watcher(bot_id);
 
       bot.state = "free";
       bot.channel_id = null;
@@ -882,6 +1047,7 @@ export class BotPool extends EventEmitter {
       bot.archetype = null;
       bot.channel_type = null;
       bot.session_id = null;
+      bot.session_confirmed = false;
       bot.model = null;
       bot.effort = null;
       bot.last_active = null;
@@ -1170,12 +1336,14 @@ export class BotPool extends EventEmitter {
           console.log(
             `[pool] Freeing orphan pool-${String(bot.id)} (no metadata — cannot restart)`,
           );
+          this.cancel_session_watcher(bot.id);
           bot.state = "free";
           bot.channel_id = null;
           bot.entity_id = null;
           bot.archetype = null;
           bot.channel_type = null;
           bot.session_id = null;
+          bot.session_confirmed = false;
           bot.model = null;
           bot.effort = null;
           bot.last_active = null;
@@ -1210,10 +1378,13 @@ export class BotPool extends EventEmitter {
 
     if (!entity_id || !archetype) {
       console.error(`[pool] Cannot restart pool-${String(bot.id)}: missing fields — force-freeing`);
+      this.cancel_session_watcher(bot.id);
 
       // Stash session history when possible — allows a future assignment on
       // this channel to resume the session even though we can't restart now.
-      if (session_id && channel_id && entity_id) {
+      // Only stash *confirmed* sessions (JSONL on disk) to avoid planting
+      // phantom session_history entries (issue #256).
+      if (session_id && bot.session_confirmed && channel_id && entity_id) {
         const key = `${entity_id}:${channel_id}`;
         this.session_history.set(key, session_id);
         this.session_history_ts.set(key, Date.now());
@@ -1238,8 +1409,30 @@ export class BotPool extends EventEmitter {
     // Look up entity config for alerting and GH_TOKEN resolution
     const entity_config = this.registry?.get(entity_id);
 
-    const resume_id = session_id ?? randomUUID();
-    const is_resume = !!session_id;
+    // Any in-flight session-confirmation watcher for this bot is stale now —
+    // the tmux/Claude process it was observing is dead.
+    this.cancel_session_watcher(bot.id);
+
+    // Defensive pre-flight (issue #256): if we have a session_id but its
+    // JSONL transcript doesn't exist anywhere on disk, --resume will fail
+    // every time. Fall through to a fresh session instead of burning
+    // crash-loop retries. We search all project slugs because the session
+    // may have been spawned in a worktree cwd that differs from entity_dir.
+    const working_dir = entity_dir(this.config.paths, entity_id);
+    let resume_id: string;
+    let is_resume: boolean;
+    if (session_id && (await this.check_session_jsonl_exists_anywhere(session_id))) {
+      resume_id = session_id;
+      is_resume = true;
+    } else {
+      if (session_id) {
+        console.warn(
+          `[pool] pool-${String(bot.id)}: session ${session_id.slice(0, 8)} has no JSONL on disk — spawning fresh session instead of --resume (prevents crash loop)`,
+        );
+      }
+      resume_id = randomUUID();
+      is_resume = false;
+    }
     let restarted = false;
     try {
       // Resolve per-entity GitHub token (if configured)
@@ -1258,8 +1451,7 @@ export class BotPool extends EventEmitter {
         await this.write_access_json(bot.state_dir, channel_id);
       }
 
-      // Restart tmux — use --resume if we have a session_id
-      const working_dir = entity_dir(this.config.paths, entity_id);
+      // Restart tmux — use --resume if we have a verified session_id
       await this.start_tmux(
         bot,
         archetype,
@@ -1270,12 +1462,21 @@ export class BotPool extends EventEmitter {
         extra_env,
       );
 
-      // Update state — bot stays assigned with refreshed timestamps
+      // Update state — bot stays assigned with refreshed timestamps.
+      // `is_resume` is only true when we pre-flighted the JSONL on disk, so
+      // a resumed session is already confirmed. A fresh session needs the
+      // confirmation watcher before persist() will write its session_id.
       bot.session_id = resume_id;
+      bot.session_confirmed = is_resume;
       bot.last_active = new Date();
       bot.assigned_at = new Date();
 
       await this.persist();
+
+      if (!is_resume) {
+        this.watch_session_confirmation(bot, working_dir, resume_id);
+      }
+
       restarted = true;
     } catch (err) {
       console.error(`[pool] Failed to restart pool-${String(bot.id)} after crash: ${String(err)}`);
@@ -1284,8 +1485,10 @@ export class BotPool extends EventEmitter {
         contexts: { crash: { entity_id, session_id, channel_id } },
       });
 
-      // Restart failed — fall back to the old behavior: stash session history and free the bot
-      if (session_id && channel_id && entity_id) {
+      // Restart failed — fall back to the old behavior: stash session history and free the bot.
+      // Only stash confirmed sessions (JSONL on disk) so the next channel
+      // assignment can't crash-loop on a phantom UUID (issue #256).
+      if (session_id && bot.session_confirmed && channel_id && entity_id) {
         const key = `${entity_id}:${channel_id}`;
         this.session_history.set(key, session_id);
         this.session_history_ts.set(key, Date.now());
@@ -1353,15 +1556,31 @@ export class BotPool extends EventEmitter {
     const archetype = bot.archetype;
 
     console.error(`[pool] Crash loop detected for pool-${String(bot.id)} — releasing`);
+    this.cancel_session_watcher(bot.id);
 
     // Look up entity config for alerting
     const entity_config = entity_id ? this.registry?.get(entity_id) : undefined;
 
-    // Stash session history before release so the channel can resume later
-    if (bot.session_id && channel_id && entity_id) {
-      const key = `${entity_id}:${channel_id}`;
-      this.session_history.set(key, bot.session_id);
-      this.session_history_ts.set(key, Date.now());
+    // Stash session history before release so the channel can resume later.
+    // A crash-looping session is almost certainly broken — only stash if the
+    // JSONL still exists on disk. Planting a phantom UUID here is how the
+    // original bug self-perpetuated: the next assignment would pull the dead
+    // UUID out of history and re-enter the crash loop (issue #256).
+    if (bot.session_id && bot.session_confirmed && channel_id && entity_id) {
+      const exists = await this.check_session_jsonl_exists_anywhere(bot.session_id);
+      if (exists) {
+        const key = `${entity_id}:${channel_id}`;
+        this.session_history.set(key, bot.session_id);
+        this.session_history_ts.set(key, Date.now());
+      } else {
+        console.warn(
+          `[pool] Not stashing crash-loop session ${bot.session_id.slice(0, 8)} — JSONL missing`,
+        );
+      }
+    } else if (bot.session_id && !bot.session_confirmed) {
+      console.warn(
+        `[pool] Not stashing unconfirmed crash-loop session ${bot.session_id.slice(0, 8)}`,
+      );
     }
 
     // Release the bot — this kills tmux, frees the bot, clears access.json
@@ -1454,9 +1673,99 @@ export class BotPool extends EventEmitter {
     }
   }
 
+  // ── Session confirmation (issue #256) ──
+
+  /**
+   * Watch for Claude Code to write the JSONL transcript for a freshly-spawned
+   * session. Once the file appears, promote `bot.session_confirmed` to true
+   * and persist — this is the gate that lets `persist()` write the session_id.
+   *
+   * Until the watcher fires, a daemon restart will see `session_id: null` in
+   * pool-state.json and spawn a fresh session on the next assignment instead
+   * of trying to --resume a phantom UUID (issue #256).
+   *
+   * Uses a simple poll loop with a 60-second cap. If the session never
+   * commits (e.g. the bot was parked without ever being talked to), we give
+   * up — the UUID just stays unpersisted, which is the correct behavior.
+   *
+   * Protected so tests can override timing.
+   */
+  protected watch_session_confirmation(
+    bot: PoolBot,
+    working_dir: string,
+    session_id: string,
+  ): void {
+    // Replace any prior watcher for this bot — only one live at a time
+    this.cancel_session_watcher(bot.id);
+
+    const poll_interval_ms = 500;
+    const max_attempts = 120; // 60 seconds total
+    const bot_id = bot.id;
+    let attempts = 0;
+
+    const tick = async (): Promise<void> => {
+      // Bot may have been reassigned / released while we were waiting —
+      // verify the session_id still matches before promoting.
+      const current = this.bots.find((b) => b.id === bot_id);
+      if (!current || current.session_id !== session_id) {
+        this.session_watchers.delete(bot_id);
+        return;
+      }
+
+      const exists = await this.check_session_jsonl_exists(working_dir, session_id);
+      if (exists) {
+        current.session_confirmed = true;
+        this.session_watchers.delete(bot_id);
+        console.log(
+          `[pool] pool-${String(bot_id)} session ${session_id.slice(0, 8)} confirmed — JSONL on disk, persisting`,
+        );
+        await this.persist();
+        return;
+      }
+
+      attempts++;
+      if (attempts >= max_attempts) {
+        this.session_watchers.delete(bot_id);
+        console.warn(
+          `[pool] pool-${String(bot_id)} session ${session_id.slice(0, 8)} unconfirmed ` +
+            `after ${String(max_attempts * poll_interval_ms)}ms — leaving unpersisted`,
+        );
+        return;
+      }
+
+      const next = setTimeout(() => {
+        void tick();
+      }, poll_interval_ms);
+      this.session_watchers.set(bot_id, next);
+    };
+
+    // First tick runs immediately — in tests the file may already exist.
+    const initial = setTimeout(() => {
+      void tick();
+    }, 0);
+    this.session_watchers.set(bot_id, initial);
+  }
+
+  /** Cancel any pending session-confirmation watcher for a bot. Safe to call
+   * when no watcher exists. */
+  protected cancel_session_watcher(bot_id: number): void {
+    const timer = this.session_watchers.get(bot_id);
+    if (timer) {
+      clearTimeout(timer);
+      this.session_watchers.delete(bot_id);
+    }
+  }
+
   /** Stop all pool bot sessions. Used during daemon shutdown. */
   async shutdown(): Promise<void> {
     this.stop_health_monitor();
+
+    // Cancel all in-flight session confirmation watchers — we're about to
+    // kill tmux anyway, and the timers would otherwise keep the event loop
+    // alive past shutdown.
+    for (const bot_id of Array.from(this.session_watchers.keys())) {
+      this.cancel_session_watcher(bot_id);
+    }
 
     // Snapshot current state before killing tmux — this is what the next
     // daemon startup will load for proactive resume.
@@ -1487,7 +1796,11 @@ export class BotPool extends EventEmitter {
         entity_id: b.entity_id!,
         archetype: b.archetype!,
         channel_type: b.channel_type,
-        session_id: b.session_id,
+        // Only persist session_id once Claude has committed the JSONL to disk
+        // (issue #256). Writing an unconfirmed UUID would let a restart during
+        // the pre-confirmation window crash-loop on --resume of a session that
+        // was never materialized.
+        session_id: b.session_confirmed ? b.session_id : null,
         model: b.model,
         effort: b.effort,
         last_active: b.last_active?.toISOString() ?? null,
@@ -1602,6 +1915,18 @@ export class BotPool extends EventEmitter {
     const model_id = resolve_model_id(archetype_defaults);
     const effort = resolve_effort(archetype_defaults.think);
 
+    // Trusted directory set for `--permission-mode bypassPermissions`. Beyond
+    // the entity/working dir we also include:
+    //   - ~/.claude  — global skill + agent library. Bots load skills from
+    //     here via auto-load, so operator meta-tasks that need to read or
+    //     write the skill files themselves (e.g. diffing, porting) don't
+    //     trigger an interactive approval modal. See issue #260.
+    //   - /tmp       — standard scratch dir. Lets bots stage intermediate
+    //     artifacts without polluting the entity worktree's git status.
+    // Both paths are already world-accessible to this user — adding them to
+    // the trusted set doesn't widen the blast radius, it just stops the
+    // modal stalls. We resolve ~ via homedir() because tmux command-string
+    // parsing doesn't expand tildes.
     const claude_args = [
       sq(claude_bin),
       "--channels",
@@ -1616,6 +1941,10 @@ export class BotPool extends EventEmitter {
       sq(working_dir),
       "--add-dir",
       sq(entity_dir(this.config.paths, entity_id)),
+      "--add-dir",
+      sq(join(homedir(), ".claude")),
+      "--add-dir",
+      sq("/tmp"),
     ];
 
     if (effort) {

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -1,7 +1,7 @@
 import { execFileSync, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
-import { access, readFile, stat, unlink, writeFile } from "node:fs/promises";
+import { access, readFile, readdir, stat, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { ArchetypeRole, LobsterFarmConfig } from "@lobster-farm/shared";
@@ -166,7 +166,6 @@ export async function session_jsonl_exists(
  * pool-state.json on daemon restart, where the original cwd (e.g. a feature
  * worktree) may differ from the entity_dir the restart will actually use. */
 export async function session_jsonl_exists_anywhere(session_id: string): Promise<boolean> {
-  const { readdir } = await import("node:fs/promises");
   const projects_dir = join(homedir(), ".claude", "projects");
   const filename = `${session_id}.jsonl`;
   try {
@@ -1713,8 +1712,18 @@ export class BotPool extends EventEmitter {
       }
 
       const exists = await this.check_session_jsonl_exists(working_dir, session_id);
+
+      // Re-check after await: bot may have been reassigned during the async
+      // suspension — cancel_session_watcher only stops future ticks, not an
+      // in-flight continuation. (#256)
+      const still_current = this.bots.find((b) => b.id === bot_id);
+      if (!still_current || still_current.session_id !== session_id) {
+        this.session_watchers.delete(bot_id);
+        return;
+      }
+
       if (exists) {
-        current.session_confirmed = true;
+        still_current.session_confirmed = true;
         this.session_watchers.delete(bot_id);
         console.log(
           `[pool] pool-${String(bot_id)} session ${session_id.slice(0, 8)} confirmed — JSONL on disk, persisting`,


### PR DESCRIPTION
## Summary

- **#256** — Pool bots crash-looped on daemon restart when \`session_id\` was persisted before Claude Code wrote the JSONL transcript. Added a \`session_confirmed\` gate: only confirmed sessions are written to \`pool-state.json\`, a background watcher promotes fresh sessions once the transcript appears on disk, and all restore paths (\`initialize\`, \`restart_crashed_session\`, \`handle_crash_loop\`) pre-flight the JSONL on disk before resuming — phantom UUIDs are dropped instead of rehydrated, closing the self-perpetuation loop.
- **#260** — Extended pool bot \`--add-dir\` defaults to include \`~/.claude\` and \`/tmp\`, so skill/scratch paths are already trusted under \`bypassPermissions\` and don't freeze bots on an interactive approval modal.

## Test plan

- [x] \`pnpm --filter @lobster-farm/daemon typecheck\` clean
- [x] \`pnpm lint\` (biome) clean
- [x] \`pnpm --filter @lobster-farm/daemon build\` clean
- [x] \`pnpm --filter @lobster-farm/daemon test\` — 790 tests pass (11 new)
- [x] New tests cover: phantom \`session_id\` dropped on restore, phantom \`session_history\` dropped on restore, confirmed sessions survive round-trip, \`persist()\` writes \`null\` for unconfirmed, \`handle_crash_loop\` refuses to stash phantom/unconfirmed, \`start_tmux\` emits \`--add-dir ~/.claude\` and \`--add-dir /tmp\`

Closes #256
Closes #260