### PR TITLE
feat(pool): auto-recover bots stuck on rate-limit modal

### DIFF
--- a/packages/daemon/src/__tests__/rate-limit-recovery.test.ts
+++ b/packages/daemon/src/__tests__/rate-limit-recovery.test.ts
@@ -1,0 +1,473 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
+import type { LobsterFarmConfig } from "@lobster-farm/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PoolBot } from "../pool.js";
+import { detect_rate_limit_modal, type scan_and_recover } from "../rate-limit-recovery.js";
+import { BotPoolTestBase } from "./helpers/test-bot-pool-base.js";
+
+// Mock actions.ts — notify is imported by pool.ts for alerting
+vi.mock("../actions.js", () => ({
+  notify: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock persistence to avoid filesystem side effects
+vi.mock("../persistence.js", () => ({
+  save_pool_state: vi.fn().mockResolvedValue(undefined),
+  load_pool_state: vi.fn().mockResolvedValue({
+    bots: [],
+    session_history: {},
+    avatar_state: {},
+  }),
+}));
+
+// Mock sentry
+vi.mock("../sentry.js", () => ({
+  captureException: vi.fn(),
+  addBreadcrumb: vi.fn(),
+}));
+
+// Mock the rate-limit-recovery module's tmux functions so pool integration
+// tests don't need real tmux sessions. The module-level import in pool.ts
+// calls scan_and_recover which defaults to real tmux capture — we mock the
+// entire module and provide a controllable scan_and_recover in pool tests.
+vi.mock("../rate-limit-recovery.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../rate-limit-recovery.js")>();
+  return {
+    ...original,
+    // Keep the pure detection function unchanged — it's tested directly
+    detect_rate_limit_modal: original.detect_rate_limit_modal,
+    // scan_and_recover is mocked per-test in the pool integration section
+    scan_and_recover: vi.fn().mockReturnValue([]),
+  };
+});
+
+// ── Test helpers ──
+
+let temp_dir: string;
+
+function make_config(): LobsterFarmConfig {
+  return LobsterFarmConfigSchema.parse({
+    user: { name: "Test" },
+    paths: { lobsterfarm_dir: temp_dir },
+  });
+}
+
+function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
+  return {
+    state: "free",
+    channel_id: null,
+    entity_id: null,
+    archetype: null,
+    channel_type: null,
+    session_id: null,
+    session_confirmed: true,
+    tmux_session: `pool-${String(overrides.id)}`,
+    last_active: null,
+    assigned_at: null,
+    state_dir: `/tmp/test-pool-${String(overrides.id)}`,
+    model: null,
+    effort: null,
+    last_avatar_archetype: null,
+    last_avatar_set_at: null,
+    ...overrides,
+  };
+}
+
+// ── Pure detection tests ──
+
+describe("detect_rate_limit_modal", () => {
+  it("detects 'Switch to extra usage' in last 10 lines", () => {
+    const output = [
+      "some output line 1",
+      "some output line 2",
+      "You've exceeded your usage limit.",
+      "",
+      "  ● Wait 3 hours",
+      "  ● Switch to extra usage",
+      "  ● Switch to Team plan",
+      "",
+      "Enter to confirm · Esc to cancel",
+      "",
+    ].join("\n");
+
+    expect(detect_rate_limit_modal(output)).toBe(true);
+  });
+
+  it("detects 'exceeded' + 'Esc to cancel' combo", () => {
+    const output = [
+      "some output line 1",
+      "You've exceeded your usage limit.",
+      "",
+      "Press Esc to cancel or Enter to confirm.",
+      "",
+    ].join("\n");
+
+    expect(detect_rate_limit_modal(output)).toBe(true);
+  });
+
+  it("returns false for normal working output", () => {
+    const output = [
+      "Reading file: /src/pool.ts",
+      "Analyzing code...",
+      "",
+      "I'll make the following changes:",
+      "",
+      "1. Add a new function for rate limiting",
+      "2. Update the health check",
+      "",
+      "esc to interrupt",
+      "",
+    ].join("\n");
+
+    expect(detect_rate_limit_modal(output)).toBe(false);
+  });
+
+  it("returns false for empty output", () => {
+    expect(detect_rate_limit_modal("")).toBe(false);
+  });
+
+  it("returns false for prompt-only output", () => {
+    const output = "❯ ";
+    expect(detect_rate_limit_modal(output)).toBe(false);
+  });
+
+  it("is case-insensitive for pattern matching", () => {
+    const output = ["some lines", "SWITCH TO EXTRA USAGE", "more lines"].join("\n");
+
+    expect(detect_rate_limit_modal(output)).toBe(true);
+  });
+
+  it("only considers last 10 lines", () => {
+    // Put the pattern before line 10 from the end — should not trigger
+    const lines = [
+      "Switch to extra usage", // line 1 — this is the 12th from end
+      "line 2",
+      "line 3",
+      "line 4",
+      "line 5",
+      "line 6",
+      "line 7",
+      "line 8",
+      "line 9",
+      "line 10",
+      "line 11", // last 10 starts here
+      "line 12",
+      "line 13",
+      "line 14",
+      "line 15",
+      "line 16",
+      "line 17",
+      "line 18",
+      "line 19",
+      "line 20",
+    ];
+
+    expect(detect_rate_limit_modal(lines.join("\n"))).toBe(false);
+  });
+
+  it("detects pattern within last 10 lines of longer output", () => {
+    const lines = [
+      "old line 1",
+      "old line 2",
+      "old line 3",
+      "old line 4",
+      "old line 5",
+      "old line 6",
+      "old line 7",
+      "old line 8",
+      "old line 9",
+      "old line 10",
+      "old line 11",
+      "old line 12",
+      "You've exceeded your usage limit.",
+      "",
+      "  ● Wait 3 hours",
+      "  ● Switch to extra usage",
+      "  ● Switch to Team plan",
+      "",
+      "Enter to confirm · Esc to cancel",
+      "",
+    ];
+
+    expect(detect_rate_limit_modal(lines.join("\n"))).toBe(true);
+  });
+
+  it("detects partial match: just 'exceeded' and 'esc to cancel'", () => {
+    const output = ["You've exceeded your weekly usage.", "Esc to cancel"].join("\n");
+
+    expect(detect_rate_limit_modal(output)).toBe(true);
+  });
+});
+
+// ── scan_and_recover (with mock tmux functions) ──
+
+describe("scan_and_recover", () => {
+  // Use the REAL scan_and_recover from the module (not the mocked version used
+  // by pool tests). We import the original implementation for direct unit testing.
+  let real_scan_and_recover: typeof scan_and_recover;
+
+  beforeEach(async () => {
+    // Import the original module directly (bypassing vi.mock)
+    const original = await vi.importActual<typeof import("../rate-limit-recovery.js")>(
+      "../rate-limit-recovery.js",
+    );
+    real_scan_and_recover = original.scan_and_recover;
+  });
+
+  it("recovers bot showing rate-limit modal", () => {
+    const bot = make_bot({
+      id: 1,
+      state: "assigned",
+      entity_id: "test-entity",
+    });
+
+    const modal_output = [
+      "You've exceeded your usage limit.",
+      "  ● Switch to extra usage",
+      "Enter to confirm · Esc to cancel",
+    ].join("\n");
+
+    const mock_capture = vi.fn().mockReturnValue(modal_output);
+    const mock_escape = vi.fn();
+
+    const results = real_scan_and_recover([bot], mock_capture, mock_escape);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      bot_id: 1,
+      tmux_session: "pool-1",
+      entity_id: "test-entity",
+    });
+    expect(mock_escape).toHaveBeenCalledWith("pool-1");
+  });
+
+  it("skips bots without rate-limit modal", () => {
+    const bot = make_bot({
+      id: 2,
+      state: "assigned",
+      entity_id: "test-entity",
+    });
+
+    const normal_output = "Working on something...\n❯ ";
+    const mock_capture = vi.fn().mockReturnValue(normal_output);
+    const mock_escape = vi.fn();
+
+    const results = real_scan_and_recover([bot], mock_capture, mock_escape);
+
+    expect(results).toHaveLength(0);
+    expect(mock_escape).not.toHaveBeenCalled();
+  });
+
+  it("skips non-assigned bots", () => {
+    const bot = make_bot({
+      id: 3,
+      state: "parked",
+      entity_id: "test-entity",
+    });
+
+    const mock_capture = vi.fn();
+    const mock_escape = vi.fn();
+
+    const results = real_scan_and_recover([bot], mock_capture, mock_escape);
+
+    expect(results).toHaveLength(0);
+    expect(mock_capture).not.toHaveBeenCalled();
+  });
+
+  it("handles capture failure gracefully", () => {
+    const bot = make_bot({
+      id: 4,
+      state: "assigned",
+      entity_id: "test-entity",
+    });
+
+    const mock_capture = vi.fn().mockReturnValue(null); // tmux capture failed
+    const mock_escape = vi.fn();
+
+    const results = real_scan_and_recover([bot], mock_capture, mock_escape);
+
+    expect(results).toHaveLength(0);
+    expect(mock_escape).not.toHaveBeenCalled();
+  });
+
+  it("handles escape failure gracefully — does not crash loop", () => {
+    const bot = make_bot({
+      id: 5,
+      state: "assigned",
+      entity_id: "test-entity",
+    });
+
+    const modal_output = "Switch to extra usage\nEsc to cancel";
+    const mock_capture = vi.fn().mockReturnValue(modal_output);
+    const mock_escape = vi.fn().mockImplementation(() => {
+      throw new Error("tmux send-keys failed");
+    });
+
+    // Should not throw — failure is caught and logged
+    const results = real_scan_and_recover([bot], mock_capture, mock_escape);
+
+    expect(results).toHaveLength(0); // recovery failed, not counted
+    expect(mock_escape).toHaveBeenCalledWith("pool-5");
+  });
+
+  it("recovers multiple bots in a single scan", () => {
+    const bots = [
+      make_bot({ id: 1, state: "assigned", entity_id: "entity-a" }),
+      make_bot({ id: 2, state: "assigned", entity_id: "entity-b" }),
+      make_bot({ id: 3, state: "assigned", entity_id: "entity-c" }),
+    ];
+
+    const mock_capture = vi
+      .fn()
+      .mockReturnValueOnce("Switch to extra usage\nEsc to cancel") // bot 1: stuck
+      .mockReturnValueOnce("Working normally\n❯ ") // bot 2: fine
+      .mockReturnValueOnce("exceeded your limit\nEsc to cancel"); // bot 3: stuck
+
+    const mock_escape = vi.fn();
+
+    const results = real_scan_and_recover(bots, mock_capture, mock_escape);
+
+    expect(results).toHaveLength(2);
+    expect(results[0].bot_id).toBe(1);
+    expect(results[1].bot_id).toBe(3);
+    expect(mock_escape).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── Pool integration tests (check_rate_limit_modals) ──
+
+class TestBotPool extends BotPoolTestBase {
+  inject_bots(bots: PoolBot[]): void {
+    (this as unknown as { bots: PoolBot[] }).bots = bots;
+  }
+
+  get_bots(): PoolBot[] {
+    return (this as unknown as { bots: PoolBot[] }).bots;
+  }
+
+  /** Expose check_rate_limit_modals for direct invocation in tests. */
+  async run_rate_limit_check(): Promise<void> {
+    await this.check_rate_limit_modals();
+  }
+}
+
+describe("pool rate-limit recovery integration", () => {
+  let config: LobsterFarmConfig;
+  let pool: TestBotPool;
+  let mock_notify: ReturnType<typeof vi.fn>;
+  let mock_scan: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    temp_dir = await mkdtemp(join(tmpdir(), "rate-limit-test-"));
+    config = make_config();
+    pool = new TestBotPool(config);
+
+    // Get the module-level mocks
+    const actions = await import("../actions.js");
+    mock_notify = actions.notify as unknown as ReturnType<typeof vi.fn>;
+    mock_notify.mockClear();
+
+    const recovery = await import("../rate-limit-recovery.js");
+    mock_scan = recovery.scan_and_recover as unknown as ReturnType<typeof vi.fn>;
+    mock_scan.mockClear();
+
+    // Stub side effects
+    vi.spyOn(pool as unknown as Record<string, unknown>, "kill_tmux" as never).mockImplementation(
+      () => {},
+    );
+    vi.spyOn(
+      pool as unknown as Record<string, unknown>,
+      "write_access_json" as never,
+    ).mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    pool.stop_rate_limit_monitor();
+    vi.restoreAllMocks();
+    await rm(temp_dir, { recursive: true, force: true });
+  });
+
+  it("calls scan_and_recover with assigned bots", async () => {
+    const bots = [
+      make_bot({ id: 1, state: "assigned", entity_id: "e1", channel_id: "ch-1" }),
+      make_bot({ id: 2, state: "free" }),
+      make_bot({ id: 3, state: "assigned", entity_id: "e2", channel_id: "ch-2" }),
+    ];
+    pool.inject_bots(bots);
+    mock_scan.mockReturnValue([]);
+
+    await pool.run_rate_limit_check();
+
+    expect(mock_scan).toHaveBeenCalledTimes(1);
+    // Should pass only the assigned bots
+    const passed_bots = mock_scan.mock.calls[0][0] as PoolBot[];
+    expect(passed_bots).toHaveLength(2);
+    expect(passed_bots[0].id).toBe(1);
+    expect(passed_bots[1].id).toBe(3);
+  });
+
+  it("posts alert for each recovered bot", async () => {
+    const bots = [
+      make_bot({ id: 1, state: "assigned", entity_id: "test-entity", channel_id: "ch-1" }),
+    ];
+    pool.inject_bots(bots);
+
+    mock_scan.mockReturnValue([{ bot_id: 1, tmux_session: "pool-1", entity_id: "test-entity" }]);
+
+    await pool.run_rate_limit_check();
+
+    expect(mock_notify).toHaveBeenCalledTimes(1);
+    const [channel_type, message] = mock_notify.mock.calls[0] as [string, string];
+    expect(channel_type).toBe("alerts");
+    expect(message).toContain("Pool bot 1");
+    expect(message).toContain("rate-limit");
+    expect(message).toContain("auto-dismissed");
+    expect(message).toContain("test-entity");
+  });
+
+  it("skips scan when draining", async () => {
+    pool.drain();
+    pool.inject_bots([make_bot({ id: 1, state: "assigned", entity_id: "e1", channel_id: "ch-1" })]);
+
+    await pool.run_rate_limit_check();
+
+    expect(mock_scan).not.toHaveBeenCalled();
+  });
+
+  it("skips scan when no assigned bots", async () => {
+    pool.inject_bots([make_bot({ id: 1, state: "free" })]);
+
+    await pool.run_rate_limit_check();
+
+    expect(mock_scan).not.toHaveBeenCalled();
+  });
+
+  it("tolerates notify failure without crashing", async () => {
+    pool.inject_bots([make_bot({ id: 1, state: "assigned", entity_id: "e1", channel_id: "ch-1" })]);
+    mock_scan.mockReturnValue([{ bot_id: 1, tmux_session: "pool-1", entity_id: "e1" }]);
+    mock_notify.mockRejectedValue(new Error("Discord down"));
+
+    // Should not throw
+    await pool.run_rate_limit_check();
+
+    expect(mock_notify).toHaveBeenCalledTimes(1);
+  });
+
+  it("posts multiple alerts when multiple bots recovered", async () => {
+    pool.inject_bots([
+      make_bot({ id: 1, state: "assigned", entity_id: "e1", channel_id: "ch-1" }),
+      make_bot({ id: 2, state: "assigned", entity_id: "e2", channel_id: "ch-2" }),
+    ]);
+    mock_scan.mockReturnValue([
+      { bot_id: 1, tmux_session: "pool-1", entity_id: "e1" },
+      { bot_id: 2, tmux_session: "pool-2", entity_id: "e2" },
+    ]);
+
+    await pool.run_rate_limit_check();
+
+    expect(mock_notify).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -158,6 +158,9 @@ async function main(): Promise<void> {
   // Start health monitor for detecting dead tmux sessions
   pool.start_health_monitor();
 
+  // Start rate-limit modal recovery monitor (issue #270)
+  pool.start_rate_limit_monitor();
+
   // Initialize Discord bot (optional — daemon works without it via HTTP API)
   const discord = new DiscordBot(config, registry);
   let discord_connected = false;

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -12,6 +12,7 @@ import { resolve_binary } from "./env.js";
 import { resolve_effort, resolve_model_id } from "./models.js";
 import { load_pool_state, save_pool_state } from "./persistence.js";
 import type { PersistedBotAvatarState, PersistedPoolBot } from "./persistence.js";
+import { scan_and_recover } from "./rate-limit-recovery.js";
 import type { EntityRegistry } from "./registry.js";
 import * as sentry from "./sentry.js";
 import { sq } from "./shell.js";
@@ -284,6 +285,8 @@ export class BotPool extends EventEmitter {
    * from false → true once Claude commits its first turn to disk. Cleared on
    * reassignment, release, or shutdown to prevent leaks. */
   private session_watchers = new Map<number, ReturnType<typeof setTimeout>>();
+  /** Timer for the rate-limit modal recovery scan (60s interval, issue #270). */
+  private rate_limit_timer: ReturnType<typeof setInterval> | null = null;
 
   constructor(config: LobsterFarmConfig) {
     super();
@@ -1286,6 +1289,64 @@ export class BotPool extends EventEmitter {
   }
 
   /**
+   * Start the rate-limit modal recovery monitor (issue #270).
+   *
+   * Every 60 seconds, captures the last lines of each assigned pool bot's tmux
+   * pane and checks for the Claude Code usage-limit modal. If detected, sends
+   * Escape to dismiss the modal and posts to the entity's alerts channel.
+   *
+   * Separate from the 30s health monitor because the concerns are different:
+   * health = dead sessions, rate-limit = stuck modals on live sessions.
+   */
+  start_rate_limit_monitor(): void {
+    if (this.rate_limit_timer) return; // already running
+
+    this.rate_limit_timer = setInterval(() => {
+      this.check_rate_limit_modals();
+    }, 60_000);
+
+    console.log("[pool] Rate-limit recovery monitor started (60s interval)");
+  }
+
+  /** Stop the rate-limit recovery monitor. */
+  stop_rate_limit_monitor(): void {
+    if (this.rate_limit_timer) {
+      clearInterval(this.rate_limit_timer);
+      this.rate_limit_timer = null;
+      console.log("[pool] Rate-limit recovery monitor stopped");
+    }
+  }
+
+  /**
+   * Scan assigned bots for rate-limit modals and dismiss them.
+   * Protected so tests can invoke directly without waiting for the interval.
+   */
+  protected async check_rate_limit_modals(): Promise<void> {
+    if (this._draining) return;
+
+    const assigned = this.bots.filter((b) => b.state === "assigned");
+    if (assigned.length === 0) return;
+
+    const recovered = scan_and_recover(assigned);
+
+    // Post alerts for each recovered bot
+    for (const result of recovered) {
+      const entity_config = result.entity_id ? this.registry?.get(result.entity_id) : undefined;
+      try {
+        await notify(
+          "alerts",
+          `\u26a0\ufe0f Pool bot ${String(result.bot_id)} hit rate-limit modal — auto-dismissed for ${result.entity_id ?? "unknown"}`,
+          entity_config,
+        );
+      } catch (err) {
+        console.warn(
+          `[rate-limit-recovery] Failed to alert for ${result.tmux_session}: ${String(err)}`,
+        );
+      }
+    }
+  }
+
+  /**
    * Check all assigned bots for dead tmux sessions.
    * When a dead session is found, attempts to restart it automatically.
    * If a bot crashes too often (>3 times in 1 hour), it's released instead
@@ -1768,6 +1829,7 @@ export class BotPool extends EventEmitter {
   /** Stop all pool bot sessions. Used during daemon shutdown. */
   async shutdown(): Promise<void> {
     this.stop_health_monitor();
+    this.stop_rate_limit_monitor();
 
     // Cancel all in-flight session confirmation watchers — we're about to
     // kill tmux anyway, and the timers would otherwise keep the event loop

--- a/packages/daemon/src/rate-limit-recovery.ts
+++ b/packages/daemon/src/rate-limit-recovery.ts
@@ -1,0 +1,128 @@
+/**
+ * Auto-recovery for pool bots stuck on Claude Code's usage-limit modal.
+ *
+ * When a pool bot hits the rate limit, Claude Code shows a modal that freezes
+ * the session waiting for user input (Enter to confirm, Esc to cancel). Since
+ * pool bots are unattended, nobody presses a key. This module detects the modal
+ * by scraping the tmux pane output and sends Escape to dismiss it.
+ *
+ * Detection patterns (spec: issue #270):
+ *   - "Switch to extra usage" anywhere in the last 10 lines
+ *   - "exceeded" + "Esc to cancel" both present in the last 10 lines
+ *
+ * Pool-only. Commander (Pat) and failsafe sessions are interactive and
+ * handled by the user.
+ */
+import { execFileSync } from "node:child_process";
+import type { PoolBot } from "./pool.js";
+
+// ── Pure detection ──
+
+/**
+ * Check whether the given pane output contains the rate-limit modal.
+ *
+ * Examines the last 10 lines for two independent patterns (either triggers):
+ * 1. "Switch to extra usage" (the modal's option text)
+ * 2. "exceeded" AND "Esc to cancel" (the header + dismiss instruction)
+ *
+ * Pure function — no side effects, easy to test.
+ */
+export function detect_rate_limit_modal(pane_output: string): boolean {
+  const lines = pane_output.split("\n");
+  const tail = lines.slice(-10).join("\n").toLowerCase();
+
+  // Pattern 1: modal option text
+  if (tail.includes("switch to extra usage")) return true;
+
+  // Pattern 2: exceeded + dismiss instruction
+  if (tail.includes("exceeded") && tail.includes("esc to cancel")) return true;
+
+  return false;
+}
+
+// ── Tmux interaction ──
+
+/**
+ * Capture the full content of a tmux pane.
+ *
+ * Uses `tmux capture-pane -p` which prints the visible pane content to stdout.
+ * Returns null if the pane can't be read (session dead, timeout, etc.).
+ */
+export function capture_tmux_pane(tmux_session: string): string | null {
+  try {
+    return execFileSync("tmux", ["capture-pane", "-t", tmux_session, "-p"], {
+      encoding: "utf-8",
+      timeout: 2000,
+    });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Send Escape to a tmux session to dismiss the rate-limit modal.
+ *
+ * Uses the literal key name "Escape" which tmux interprets as the Esc keystroke.
+ */
+export function send_escape(tmux_session: string): void {
+  execFileSync("tmux", ["send-keys", "-t", tmux_session, "Escape"], {
+    stdio: "ignore",
+    timeout: 2000,
+  });
+}
+
+// ── Scan result ──
+
+export interface RateLimitRecoveryResult {
+  bot_id: number;
+  tmux_session: string;
+  entity_id: string | null;
+}
+
+// ── Scan and recover ──
+
+/**
+ * Scan all assigned pool bots for the rate-limit modal and dismiss it.
+ *
+ * Returns the list of bots that were recovered. Callers use this to
+ * post alerts and log the events.
+ *
+ * @param bots - assigned pool bots to scan
+ * @param capture_fn - tmux capture function (injectable for testing)
+ * @param escape_fn - tmux escape function (injectable for testing)
+ */
+export function scan_and_recover(
+  bots: readonly PoolBot[],
+  capture_fn: (session: string) => string | null = capture_tmux_pane,
+  escape_fn: (session: string) => void = send_escape,
+): RateLimitRecoveryResult[] {
+  const recovered: RateLimitRecoveryResult[] = [];
+
+  for (const bot of bots) {
+    if (bot.state !== "assigned") continue;
+
+    const output = capture_fn(bot.tmux_session);
+    if (!output) continue;
+
+    if (detect_rate_limit_modal(output)) {
+      try {
+        escape_fn(bot.tmux_session);
+        recovered.push({
+          bot_id: bot.id,
+          tmux_session: bot.tmux_session,
+          entity_id: bot.entity_id,
+        });
+        console.log(
+          `[rate-limit-recovery] Dismissed rate-limit modal for ${bot.tmux_session} ` +
+            `(entity: ${bot.entity_id ?? "unknown"})`,
+        );
+      } catch (err) {
+        console.warn(
+          `[rate-limit-recovery] Failed to send Escape to ${bot.tmux_session}: ${String(err)}`,
+        );
+      }
+    }
+  }
+
+  return recovered;
+}


### PR DESCRIPTION
## Summary

- Adds periodic detection (60s interval) of Claude Code's usage-limit modal on pool bots by pattern-matching the last 10 lines of each assigned bot's tmux pane
- Sends Escape to dismiss the modal automatically, then posts to the entity's alerts channel
- Pool-only — Commander (Pat) and failsafe sessions are not touched

## Implementation

- `rate-limit-recovery.ts` — pure detection function (`detect_rate_limit_modal`) + tmux capture/escape helpers + `scan_and_recover` orchestrator with injectable deps for testability
- `pool.ts` — adds `start_rate_limit_monitor()` / `stop_rate_limit_monitor()` on a separate 60s timer, wired into daemon startup and shutdown
- 21 unit tests covering detection patterns, edge cases, scan/recover flow, and pool integration

## Edge cases handled

- Modal before extra usage toggled: Esc still dismisses, session retries
- Tmux capture failure: gracefully skipped (null return)
- Escape send failure: logged and skipped, does not crash the scan loop
- Notify failure: caught and logged, does not block other bot alerts
- Draining pool: scan skipped entirely
- No assigned bots: early return, no work

## Test plan

- [x] `pnpm test` — 872/872 tests pass (21 new)
- [x] `pnpm typecheck` — clean
- [x] `pnpm exec biome check packages/` — clean
- [ ] AutoReviewer approves and merges

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)