### PR TITLE
feat(alerts): tiered thread routing for #alerts channels

### DIFF
--- a/packages/daemon/src/__tests__/alert-router.test.ts
+++ b/packages/daemon/src/__tests__/alert-router.test.ts
@@ -397,3 +397,84 @@ describe("post_alert — no alerts channel", () => {
     expect(discord.send_embed).not.toHaveBeenCalled();
   });
 });
+
+// ── Daily thread cache eviction on date rollover ──
+
+describe("daily thread cache eviction", () => {
+  it("evicts stale entries from previous days on new-day access", async () => {
+    const discord = make_discord_mock();
+    const daily_threads = new Map<string, string>();
+    // Pre-populate with yesterday's entry
+    daily_threads.set("test-entity:2026-04-14", "old-thread-id");
+    const router = new AlertRouter(discord as unknown as any, config, { daily_threads });
+
+    // Post a routine alert "today" (April 15)
+    const now = new Date(2026, 3, 15, 10, 0, 0);
+    // We can't inject `now` into post_alert directly — it flows through resolve_daily_thread.
+    // But we can verify the cache state after a routine event by checking thread creation behavior.
+    // The stale entry for 2026-04-14 should be evicted, and a new thread created for 2026-04-15.
+
+    await router.post_alert({
+      entity_id: "test-entity",
+      tier: "routine",
+      title: "PR merged",
+      body: "feat: something",
+    });
+
+    // Yesterday's key should be evicted
+    expect(daily_threads.has("test-entity:2026-04-14")).toBe(false);
+    // Today's key should exist (created during the routine post)
+    // The exact key depends on the current date since we can't inject `now` into post_alert,
+    // but the map should have exactly 1 entry (stale one evicted, new one added)
+    expect(daily_threads.size).toBe(1);
+  });
+});
+
+// ── resolve_incident title-strip regex ──
+
+describe("resolve_incident title regex", () => {
+  it("strips leading emoji from incident title", async () => {
+    const discord = make_discord_mock();
+    const router = new AlertRouter(discord as unknown as any, config);
+
+    const incidents: ActiveIncidentsState = {
+      "thread-001": {
+        entity_id: "test-entity",
+        thread_id: "thread-001",
+        message_id: "msg-001",
+        channel_id: "alerts-channel-123",
+        title: "🔴 P0: NullRef in order_executor.py",
+        created_at: new Date().toISOString(),
+      },
+    };
+    await save_active_incidents(incidents, config);
+
+    await router.resolve_incident("thread-001", "Fixed in PR #99");
+
+    const embed_arg = discord.edit_message_embed.mock.calls[0]![2] as EmbedBuilder;
+    // Should strip the emoji prefix, preserving "P0: NullRef..."
+    expect(embed_arg.data.title).toBe("✅ Resolved: P0: NullRef in order_executor.py");
+  });
+
+  it("preserves title when no leading emoji", async () => {
+    const discord = make_discord_mock();
+    const router = new AlertRouter(discord as unknown as any, config);
+
+    const incidents: ActiveIncidentsState = {
+      "thread-002": {
+        entity_id: "test-entity",
+        thread_id: "thread-002",
+        message_id: "msg-002",
+        channel_id: "alerts-channel-123",
+        title: "P1: Connection pool exhaustion",
+        created_at: new Date().toISOString(),
+      },
+    };
+    await save_active_incidents(incidents, config);
+
+    await router.resolve_incident("thread-002", "Increased pool size");
+
+    const embed_arg = discord.edit_message_embed.mock.calls[0]![2] as EmbedBuilder;
+    expect(embed_arg.data.title).toBe("✅ Resolved: P1: Connection pool exhaustion");
+  });
+});

--- a/packages/daemon/src/__tests__/alert-router.test.ts
+++ b/packages/daemon/src/__tests__/alert-router.test.ts
@@ -1,0 +1,399 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { LobsterFarmConfig } from "@lobster-farm/shared";
+import type { EmbedBuilder } from "discord.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ALERT_COLOR_AMBER,
+  ALERT_COLOR_GREEN,
+  ALERT_COLOR_RED,
+  type ActiveIncidentsState,
+  AlertRouter,
+  daily_thread_title,
+  load_active_incidents,
+  save_active_incidents,
+} from "../alert-router.js";
+
+// Mock sentry
+vi.mock("../sentry.js", () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  addBreadcrumb: vi.fn(),
+}));
+
+// ── Test infrastructure ──
+
+/** Minimal DiscordBot mock with the methods alert-router needs. */
+function make_discord_mock() {
+  return {
+    get_entity_channel_id: vi.fn((_entity: string, _type: string) => "alerts-channel-123"),
+    send_embed: vi.fn(async () => "msg-001"),
+    create_thread_from_message: vi.fn(async () => "thread-001"),
+    send_to_thread: vi.fn(async () => {}),
+    edit_message_embed: vi.fn(async () => true),
+    find_thread_by_name: vi.fn(async () => null),
+    send: vi.fn(async () => {}),
+  };
+}
+
+type DiscordMock = ReturnType<typeof make_discord_mock>;
+
+let tmp_dir: string;
+let config: LobsterFarmConfig;
+
+beforeEach(async () => {
+  tmp_dir = join(tmpdir(), `alert-router-test-${randomUUID().slice(0, 8)}`);
+  await mkdir(join(tmp_dir, "state"), { recursive: true });
+  config = {
+    paths: { lobsterfarm_dir: tmp_dir, projects_dir: tmp_dir },
+  } as unknown as LobsterFarmConfig;
+});
+
+afterEach(async () => {
+  await rm(tmp_dir, { recursive: true, force: true });
+});
+
+// ── daily_thread_title ──
+
+describe("daily_thread_title", () => {
+  it("formats with emoji, em dash, weekday and date", () => {
+    // Wednesday, April 15, 2026
+    const now = new Date(2026, 3, 15);
+    expect(daily_thread_title(now)).toBe("📋 Activity — Wed Apr 15");
+  });
+
+  it("handles single-digit days", () => {
+    // Sunday, January 5, 2025
+    const now = new Date(2025, 0, 5);
+    expect(daily_thread_title(now)).toBe("📋 Activity — Sun Jan 5");
+  });
+});
+
+// ── Tier 1: action_required ──
+
+describe("post_alert — action_required", () => {
+  it("sends an embed to the alerts channel top-level", async () => {
+    const discord = make_discord_mock();
+    const router = new AlertRouter(discord as unknown as any, config);
+
+    const result = await router.post_alert({
+      entity_id: "test-entity",
+      tier: "action_required",
+      title: "⚠️ Deploy failed on main",
+      body: "Workflow 'CI' failed. https://github.com/...",
+    });
+
+    expect(result.message_id).toBe("msg-001");
+    expect(result.thread_id).toBeUndefined();
+    expect(discord.send_embed).toHaveBeenCalledOnce();
+
+    // Verify embed color defaults to red
+    const embed_arg = discord.send_embed.mock.calls[0]![1] as EmbedBuilder;
+    expect(embed_arg.data.color).toBe(ALERT_COLOR_RED);
+    expect(embed_arg.data.title).toBe("⚠️ Deploy failed on main");
+  });
+
+  it("uses amber color when specified", async () => {
+    const discord = make_discord_mock();
+    const router = new AlertRouter(discord as unknown as any, config);
+
+    await router.post_alert({
+      entity_id: "test-entity",
+      tier: "action_required",
+      title: "Approval needed",
+      body: "Agent needs human approval",
+      embed_color: ALERT_COLOR_AMBER,
+    });
+
+    const embed_arg = discord.send_embed.mock.calls[0]![1] as EmbedBuilder;
+    expect(embed_arg.data.color).toBe(ALERT_COLOR_AMBER);
+  });
+});
+
+// ── Tier 2: routine ──
+
+describe("post_alert — routine", () => {
+  it("creates a daily thread on first event and posts there", async () => {
+    const discord = make_discord_mock();
+    const router = new AlertRouter(discord as unknown as any, config);
+
+    const result = await router.post_alert({
+      entity_id: "test-entity",
+      tier: "routine",
+      title: "PR #42 merged",
+      body: "feat: add funding endpoint",
+    });
+
+    // Should have created the thread
+    expect(discord.send_embed).toHaveBeenCalledOnce(); // placeholder message
+    expect(discord.create_thread_from_message).toHaveBeenCalledOnce();
+    expect(discord.send_to_thread).toHaveBeenCalledOnce();
+    expect(result.thread_id).toBe("thread-001");
+  });
+
+  it("reuses cached thread on subsequent events", async () => {
+    const discord = make_discord_mock();
+    const router = new AlertRouter(discord as unknown as any, config);
+
+    // First event creates the thread
+    await router.post_alert({
+      entity_id: "test-entity",
+      tier: "routine",
+      title: "PR #42 merged",
+      body: "feat: add funding endpoint",
+    });
+
+    // Second event reuses the cached thread
+    await router.post_alert({
+      entity_id: "test-entity",
+      tier: "routine",
+      title: "PR #43 opened",
+      body: "fix: rate limit handling",
+    });
+
+    // Thread creation should happen only once
+    expect(discord.create_thread_from_message).toHaveBeenCalledOnce();
+    // But send_to_thread should be called twice
+    expect(discord.send_to_thread).toHaveBeenCalledTimes(2);
+  });
+
+  it("finds existing thread on daemon restart (cache miss)", async () => {
+    const discord = make_discord_mock();
+    discord.find_thread_by_name.mockResolvedValue("existing-thread-999");
+    const router = new AlertRouter(discord as unknown as any, config);
+
+    const result = await router.post_alert({
+      entity_id: "test-entity",
+      tier: "routine",
+      title: "PR #42 merged",
+      body: "feat: add funding endpoint",
+    });
+
+    // Should NOT create a new thread
+    expect(discord.create_thread_from_message).not.toHaveBeenCalled();
+    // Should post to the found thread
+    expect(discord.send_to_thread).toHaveBeenCalledWith(
+      "existing-thread-999",
+      expect.stringContaining("PR #42 merged"),
+    );
+    expect(result.thread_id).toBe("existing-thread-999");
+  });
+
+  it("falls back to channel if thread creation fails", async () => {
+    const discord = make_discord_mock();
+    discord.send_embed.mockResolvedValue(null); // embed send fails
+    const router = new AlertRouter(discord as unknown as any, config);
+
+    const result = await router.post_alert({
+      entity_id: "test-entity",
+      tier: "routine",
+      title: "PR #42 merged",
+      body: "feat: add funding endpoint",
+    });
+
+    // Should fall back to direct channel send
+    expect(discord.send).toHaveBeenCalledOnce();
+    expect(result.message_id).toBeNull();
+  });
+});
+
+// ── Tier 3: incident_open ──
+
+describe("post_alert — incident_open", () => {
+  it("posts top-level embed, creates thread, persists state", async () => {
+    const discord = make_discord_mock();
+    const router = new AlertRouter(discord as unknown as any, config);
+
+    const result = await router.post_alert({
+      entity_id: "test-entity",
+      tier: "incident_open",
+      title: "🔴 P0: NullRef in order_executor.py",
+      body: "Production error affecting order execution",
+    });
+
+    expect(result.message_id).toBe("msg-001");
+    expect(result.thread_id).toBe("thread-001");
+
+    // Verify embed was sent with red color
+    const embed_arg = discord.send_embed.mock.calls[0]![1] as EmbedBuilder;
+    expect(embed_arg.data.color).toBe(ALERT_COLOR_RED);
+
+    // Verify thread was created from the embed message
+    expect(discord.create_thread_from_message).toHaveBeenCalledWith(
+      "alerts-channel-123",
+      "msg-001",
+      "🔴 P0: NullRef in order_executor.py",
+    );
+
+    // Verify incident was persisted
+    const incidents = await load_active_incidents(config);
+    expect(incidents["thread-001"]).toBeDefined();
+    expect(incidents["thread-001"]!.entity_id).toBe("test-entity");
+    expect(incidents["thread-001"]!.message_id).toBe("msg-001");
+  });
+});
+
+// ── Tier 3: incident_update ──
+
+describe("post_alert — incident_update", () => {
+  it("posts to the incident thread", async () => {
+    const discord = make_discord_mock();
+    const router = new AlertRouter(discord as unknown as any, config);
+
+    const result = await router.post_alert({
+      entity_id: "test-entity",
+      tier: "incident_update",
+      title: "Ray diagnosis",
+      body: "Root cause: connection pool exhaustion in db/pool.py",
+      incident_id: "thread-001",
+    });
+
+    expect(discord.send_to_thread).toHaveBeenCalledWith(
+      "thread-001",
+      "Root cause: connection pool exhaustion in db/pool.py",
+    );
+    expect(result.thread_id).toBe("thread-001");
+  });
+
+  it("warns and returns null when incident_id is missing", async () => {
+    const discord = make_discord_mock();
+    const router = new AlertRouter(discord as unknown as any, config);
+
+    const result = await router.post_alert({
+      entity_id: "test-entity",
+      tier: "incident_update",
+      title: "Update",
+      body: "Some update",
+      // no incident_id
+    });
+
+    expect(discord.send_to_thread).not.toHaveBeenCalled();
+    expect(result.message_id).toBeNull();
+  });
+});
+
+// ── resolve_incident ──
+
+describe("resolve_incident", () => {
+  it("edits the original embed to green and removes from state", async () => {
+    const discord = make_discord_mock();
+    const router = new AlertRouter(discord as unknown as any, config);
+
+    // Pre-populate an active incident
+    const incidents: ActiveIncidentsState = {
+      "thread-001": {
+        entity_id: "test-entity",
+        thread_id: "thread-001",
+        message_id: "msg-001",
+        channel_id: "alerts-channel-123",
+        title: "🔴 P0: NullRef in order_executor.py",
+        created_at: new Date().toISOString(),
+      },
+    };
+    await save_active_incidents(incidents, config);
+
+    await router.resolve_incident("thread-001", "Fixed in PR #99");
+
+    // Verify embed was edited to green
+    expect(discord.edit_message_embed).toHaveBeenCalledOnce();
+    const [ch_id, msg_id, embed] = discord.edit_message_embed.mock.calls[0]!;
+    expect(ch_id).toBe("alerts-channel-123");
+    expect(msg_id).toBe("msg-001");
+    expect((embed as EmbedBuilder).data.color).toBe(ALERT_COLOR_GREEN);
+    expect((embed as EmbedBuilder).data.title).toContain("Resolved");
+
+    // Verify resolution message was posted to thread
+    expect(discord.send_to_thread).toHaveBeenCalledWith(
+      "thread-001",
+      expect.stringContaining("Fixed in PR #99"),
+    );
+
+    // Verify incident was removed from persistent state
+    const state = await load_active_incidents(config);
+    expect(state["thread-001"]).toBeUndefined();
+  });
+
+  it("no-ops gracefully for unknown incident IDs", async () => {
+    const discord = make_discord_mock();
+    const router = new AlertRouter(discord as unknown as any, config);
+
+    // Should not throw
+    await router.resolve_incident("nonexistent-thread", "Fixed in PR #99");
+    expect(discord.edit_message_embed).not.toHaveBeenCalled();
+  });
+});
+
+// ── State persistence round-trip ──
+
+describe("active incidents persistence", () => {
+  it("round-trips through save/load", async () => {
+    const incidents: ActiveIncidentsState = {
+      "thread-abc": {
+        entity_id: "my-entity",
+        thread_id: "thread-abc",
+        message_id: "msg-xyz",
+        channel_id: "ch-123",
+        title: "P0: Something broke",
+        created_at: "2026-04-15T10:00:00.000Z",
+      },
+    };
+
+    await save_active_incidents(incidents, config);
+    const loaded = await load_active_incidents(config);
+
+    expect(loaded).toEqual(incidents);
+  });
+
+  it("returns empty object when file does not exist", async () => {
+    // Use a fresh config pointing to a directory with no state file
+    const fresh_dir = join(tmpdir(), `alert-router-empty-${randomUUID().slice(0, 8)}`);
+    await mkdir(join(fresh_dir, "state"), { recursive: true });
+    const fresh_config = {
+      paths: { lobsterfarm_dir: fresh_dir, projects_dir: fresh_dir },
+    } as unknown as LobsterFarmConfig;
+
+    const loaded = await load_active_incidents(fresh_config);
+    expect(loaded).toEqual({});
+
+    await rm(fresh_dir, { recursive: true, force: true });
+  });
+});
+
+// ── No Discord (offline) ──
+
+describe("post_alert — no Discord", () => {
+  it("returns null message_id when Discord is null", async () => {
+    const router = new AlertRouter(null, config);
+
+    const result = await router.post_alert({
+      entity_id: "test-entity",
+      tier: "action_required",
+      title: "Deploy failed",
+      body: "...",
+    });
+
+    expect(result.message_id).toBeNull();
+  });
+});
+
+// ── No alerts channel ──
+
+describe("post_alert — no alerts channel", () => {
+  it("returns null when entity has no alerts channel", async () => {
+    const discord = make_discord_mock();
+    discord.get_entity_channel_id.mockReturnValue(null);
+    const router = new AlertRouter(discord as unknown as any, config);
+
+    const result = await router.post_alert({
+      entity_id: "missing-entity",
+      tier: "action_required",
+      title: "Deploy failed",
+      body: "...",
+    });
+
+    expect(result.message_id).toBeNull();
+    expect(discord.send_embed).not.toHaveBeenCalled();
+  });
+});

--- a/packages/daemon/src/__tests__/ci-fix-loop.test.ts
+++ b/packages/daemon/src/__tests__/ci-fix-loop.test.ts
@@ -365,6 +365,13 @@ function make_session_manager(): ClaudeSessionManager {
   return manager as unknown as ClaudeSessionManager;
 }
 
+function make_alert_router() {
+  return {
+    post_alert: vi.fn().mockResolvedValue({ message_id: null }),
+    resolve_incident: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
 function make_context(overrides: Partial<WebhookContext> = {}): WebhookContext {
   return {
     github_app: make_github_app(),
@@ -376,6 +383,7 @@ function make_context(overrides: Partial<WebhookContext> = {}): WebhookContext {
     } as WebhookContext["config"],
     pool: null,
     pr_watches: null,
+    alert_router: make_alert_router() as unknown as WebhookContext["alert_router"],
     ...overrides,
   };
 }
@@ -445,7 +453,8 @@ async function trigger_review_completion(
 
   const discord = ctx.discord as unknown as { send_to_entity: ReturnType<typeof vi.fn> };
   const sm = ctx.session_manager as unknown as { spawn: ReturnType<typeof vi.fn> };
-  return { ctx, discord, session_manager: sm };
+  const alert_router = ctx.alert_router as unknown as { post_alert: ReturnType<typeof vi.fn> };
+  return { ctx, discord, session_manager: sm, alert_router };
 }
 
 describe("webhook handler — CI fix loop", () => {
@@ -460,7 +469,7 @@ describe("webhook handler — CI fix loop", () => {
   });
 
   it("spawns a builder when CI checks fail on an approved PR", async () => {
-    const { session_manager, discord } = await trigger_review_completion(() => ({
+    const { session_manager, alert_router } = await trigger_review_completion(() => ({
       stdout: JSON.stringify([
         { name: "Lint", state: "COMPLETED", conclusion: "SUCCESS" },
         { name: "Build", state: "COMPLETED", conclusion: "FAILURE" },
@@ -477,18 +486,13 @@ describe("webhook handler — CI fix loop", () => {
     expect((ci_fix_spawn![0] as { archetype: string }).archetype).toBe("builder");
     expect((ci_fix_spawn![0] as { dna: string[] }).dna).toEqual(["coding-dna"]);
 
-    // Should alert about spawning CI fix
-    expect(discord.send_to_entity).toHaveBeenCalledWith(
-      "test-entity",
-      "alerts",
-      expect.stringContaining("spawning builder to fix"),
-      "reviewer",
-    );
-    expect(discord.send_to_entity).toHaveBeenCalledWith(
-      "test-entity",
-      "alerts",
-      expect.stringContaining("attempt 1/3"),
-      "reviewer",
+    // Should alert about spawning CI fix via alert router
+    expect(alert_router.post_alert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity_id: "test-entity",
+        tier: "routine",
+        body: expect.stringContaining("spawning builder"),
+      }),
     );
   });
 
@@ -532,7 +536,7 @@ describe("webhook handler — CI fix loop", () => {
       },
     };
 
-    const { session_manager, discord } = await trigger_review_completion(() => ({
+    const { session_manager, alert_router } = await trigger_review_completion(() => ({
       stdout: JSON.stringify([{ name: "Build", state: "COMPLETED", conclusion: "FAILURE" }]),
     }));
 
@@ -547,12 +551,13 @@ describe("webhook handler — CI fix loop", () => {
     const entry = mock_pr_state["test-entity:42"] as { ci_fix_attempts?: number } | undefined;
     expect(entry?.ci_fix_attempts).toBe(3);
 
-    // Should alert about reaching the cap
-    expect(discord.send_to_entity).toHaveBeenCalledWith(
-      "test-entity",
-      "alerts",
-      expect.stringContaining("human intervention"),
-      "reviewer",
+    // Should alert about reaching the cap via alert router
+    expect(alert_router.post_alert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity_id: "test-entity",
+        tier: "action_required",
+        body: expect.stringContaining("human intervention"),
+      }),
     );
   });
 

--- a/packages/daemon/src/__tests__/ci-gating.test.ts
+++ b/packages/daemon/src/__tests__/ci-gating.test.ts
@@ -359,6 +359,13 @@ function make_session_manager(): ClaudeSessionManager {
   return manager as unknown as ClaudeSessionManager;
 }
 
+function make_alert_router() {
+  return {
+    post_alert: vi.fn().mockResolvedValue({ message_id: null }),
+    resolve_incident: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
 function make_context(overrides: Partial<WebhookContext> = {}): WebhookContext {
   return {
     github_app: make_github_app(),
@@ -370,6 +377,7 @@ function make_context(overrides: Partial<WebhookContext> = {}): WebhookContext {
     } as WebhookContext["config"],
     pool: null,
     pr_watches: null,
+    alert_router: make_alert_router() as unknown as WebhookContext["alert_router"],
     ...overrides,
   };
 }
@@ -423,19 +431,15 @@ describe("webhook handler — workflow_run events", () => {
     await new Promise((resolve) => setTimeout(resolve, 150));
 
     expect(res._status).toBe(200);
-    const discord = ctx.discord as unknown as { send_to_entity: ReturnType<typeof vi.fn> };
-    // Updated in #199: alert now mentions Gary triaging instead of a raw failure message
-    expect(discord.send_to_entity).toHaveBeenCalledWith(
-      "test-entity",
-      "alerts",
-      expect.stringContaining("Deploy failed on main"),
-      "reviewer",
-    );
-    expect(discord.send_to_entity).toHaveBeenCalledWith(
-      "test-entity",
-      "alerts",
-      expect.stringContaining("Gary triaging"),
-      "reviewer",
+    const alert_router = ctx.alert_router as unknown as { post_alert: ReturnType<typeof vi.fn> };
+    // Updated in #199/#253: alert now posts a top-level embed via alert router
+    expect(alert_router.post_alert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity_id: "test-entity",
+        tier: "action_required",
+        title: expect.stringContaining("Deploy failed on main"),
+        body: expect.stringContaining("Gary triaging"),
+      }),
     );
   });
 
@@ -623,11 +627,12 @@ describe("webhook handler — CI gating on review completion", () => {
     await new Promise((resolve) => setTimeout(resolve, 100));
 
     const discord = ctx.discord as unknown as { send_to_entity: ReturnType<typeof vi.fn> };
-    return { ctx, discord };
+    const alert_router = ctx.alert_router as unknown as { post_alert: ReturnType<typeof vi.fn> };
+    return { ctx, discord, alert_router };
   }
 
   it("blocks merge and spawns CI fixer when CI checks are failing", async () => {
-    const { discord } = await trigger_review_completion(() => ({
+    const { alert_router } = await trigger_review_completion(() => ({
       stdout: JSON.stringify([
         { name: "Lint", state: "COMPLETED", conclusion: "SUCCESS" },
         { name: "Build", state: "COMPLETED", conclusion: "FAILURE" },
@@ -635,17 +640,12 @@ describe("webhook handler — CI gating on review completion", () => {
     }));
 
     // Should alert about CI failure and spawn builder to fix (#196)
-    expect(discord.send_to_entity).toHaveBeenCalledWith(
-      "test-entity",
-      "alerts",
-      expect.stringContaining("spawning builder to fix"),
-      "reviewer",
-    );
-    expect(discord.send_to_entity).toHaveBeenCalledWith(
-      "test-entity",
-      "alerts",
-      expect.stringContaining("Build"),
-      "reviewer",
+    expect(alert_router.post_alert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity_id: "test-entity",
+        tier: "routine",
+        body: expect.stringContaining("spawning builder"),
+      }),
     );
   });
 
@@ -676,7 +676,7 @@ describe("webhook handler — CI gating on review completion", () => {
 
     const merge_route = vi.fn(() => ({ stdout: "merged" }));
 
-    const { discord } = await trigger_review_completion(
+    const { alert_router } = await trigger_review_completion(
       () => ({
         stdout: JSON.stringify([{ name: "Build", state: "IN_PROGRESS", conclusion: "" }]),
       }),
@@ -694,11 +694,11 @@ describe("webhook handler — CI gating on review completion", () => {
 
     // Assert on success-specific text ("CI pending bypassed" only appears in the
     // success alert, not the failure one which says "Merge failed")
-    expect(discord.send_to_entity).toHaveBeenCalledWith(
-      "test-entity",
-      "alerts",
-      expect.stringContaining("CI pending bypassed"),
-      "reviewer",
+    expect(alert_router.post_alert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity_id: "test-entity",
+        body: expect.stringContaining("CI pending bypassed"),
+      }),
     );
   });
 
@@ -708,7 +708,7 @@ describe("webhook handler — CI gating on review completion", () => {
       pr_cron: { enabled: false },
     } as WebhookContext["config"];
 
-    const { discord } = await trigger_review_completion(
+    const { alert_router } = await trigger_review_completion(
       () => ({
         stdout: JSON.stringify([{ name: "Build", state: "IN_PROGRESS", conclusion: "" }]),
       }),
@@ -723,11 +723,11 @@ describe("webhook handler — CI gating on review completion", () => {
     );
 
     // Should alert about the failed merge with pr-cron disabled context
-    expect(discord.send_to_entity).toHaveBeenCalledWith(
-      "test-entity",
-      "alerts",
-      expect.stringContaining("pr-cron is disabled"),
-      "reviewer",
+    expect(alert_router.post_alert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity_id: "test-entity",
+        body: expect.stringContaining("pr-cron disabled"),
+      }),
     );
   });
 });

--- a/packages/daemon/src/__tests__/deploy-triage.test.ts
+++ b/packages/daemon/src/__tests__/deploy-triage.test.ts
@@ -292,6 +292,13 @@ function make_session_manager(): ClaudeSessionManager {
   return manager as unknown as ClaudeSessionManager;
 }
 
+function make_alert_router() {
+  return {
+    post_alert: vi.fn().mockResolvedValue({ message_id: null }),
+    resolve_incident: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
 function make_context(overrides: Partial<WebhookContext> = {}): WebhookContext {
   return {
     github_app: make_github_app(),
@@ -303,6 +310,7 @@ function make_context(overrides: Partial<WebhookContext> = {}): WebhookContext {
     } as WebhookContext["config"],
     pool: null,
     pr_watches: null,
+    alert_router: make_alert_router() as unknown as WebhookContext["alert_router"],
     ...overrides,
   };
 }
@@ -379,18 +387,19 @@ describe("webhook handler — deploy triage", () => {
     const ctx = make_context();
     await send_workflow_run_webhook(ctx);
 
-    const discord = ctx.discord as unknown as { send_to_entity: ReturnType<typeof vi.fn> };
-    expect(discord.send_to_entity).toHaveBeenCalledWith(
-      "test-entity",
-      "alerts",
-      expect.stringContaining("Gary triaging"),
-      "reviewer",
+    const alert_router = ctx.alert_router as unknown as { post_alert: ReturnType<typeof vi.fn> };
+    expect(alert_router.post_alert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity_id: "test-entity",
+        tier: "action_required",
+        body: expect.stringContaining("Gary triaging"),
+      }),
     );
-    expect(discord.send_to_entity).toHaveBeenCalledWith(
-      "test-entity",
-      "alerts",
-      expect.stringContaining("attempt 1/2"),
-      "reviewer",
+    expect(alert_router.post_alert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity_id: "test-entity",
+        body: expect.stringContaining("attempt 1/2"),
+      }),
     );
   });
 
@@ -435,18 +444,14 @@ describe("webhook handler — deploy triage", () => {
     expect(sm.spawn).not.toHaveBeenCalled();
 
     // Should alert about exhaustion
-    const discord = ctx.discord as unknown as { send_to_entity: ReturnType<typeof vi.fn> };
-    expect(discord.send_to_entity).toHaveBeenCalledWith(
-      "test-entity",
-      "alerts",
-      expect.stringContaining("Manual intervention needed"),
-      "reviewer",
-    );
-    expect(discord.send_to_entity).toHaveBeenCalledWith(
-      "test-entity",
-      "alerts",
-      expect.stringContaining("fix loop exhausted"),
-      "reviewer",
+    const alert_router = ctx.alert_router as unknown as { post_alert: ReturnType<typeof vi.fn> };
+    expect(alert_router.post_alert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity_id: "test-entity",
+        tier: "action_required",
+        title: expect.stringContaining("Deploy fix exhausted"),
+        body: expect.stringContaining("Manual intervention needed"),
+      }),
     );
   });
 
@@ -487,12 +492,13 @@ describe("webhook handler — deploy triage", () => {
     expect(sm.spawn).not.toHaveBeenCalled();
 
     // Should alert about safety valve
-    const discord = ctx.discord as unknown as { send_to_entity: ReturnType<typeof vi.fn> };
-    expect(discord.send_to_entity).toHaveBeenCalledWith(
-      "test-entity",
-      "alerts",
-      expect.stringContaining("safety valve"),
-      "reviewer",
+    const alert_router = ctx.alert_router as unknown as { post_alert: ReturnType<typeof vi.fn> };
+    expect(alert_router.post_alert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity_id: "test-entity",
+        tier: "action_required",
+        body: expect.stringContaining("safety valve"),
+      }),
     );
   });
 

--- a/packages/daemon/src/__tests__/pr-cron-author.test.ts
+++ b/packages/daemon/src/__tests__/pr-cron-author.test.ts
@@ -51,7 +51,7 @@ describe("PR cron — author-based alert labeling", () => {
     on: ReturnType<typeof vi.fn>;
     removeListener: ReturnType<typeof vi.fn>;
   };
-  let mock_discord: { send_to_entity: ReturnType<typeof vi.fn> };
+  let mock_alert_router: { post_alert: ReturnType<typeof vi.fn> };
   beforeEach(() => {
     alerts = [];
 
@@ -67,13 +67,12 @@ describe("PR cron — author-based alert labeling", () => {
       removeListener: vi.fn(),
     };
 
-    mock_discord = {
-      send_to_entity: vi
-        .fn()
-        .mockImplementation((_entity: string, _channel: string, message: string) => {
-          alerts.push(message);
-          return Promise.resolve();
-        }),
+    mock_alert_router = {
+      post_alert: vi.fn().mockImplementation((payload: { title: string; body: string }) => {
+        // Combine title + body for backward-compatible string assertions
+        alerts.push(`${payload.title}: ${payload.body}`);
+        return Promise.resolve({ message_id: null });
+      }),
     };
   });
 
@@ -83,7 +82,10 @@ describe("PR cron — author-based alert labeling", () => {
       mock_registry as any,
       mock_session_manager as any,
       make_config(),
-      mock_discord as any,
+      null, // discord
+      null, // github_app
+      null, // pr_watches
+      mock_alert_router as any,
     );
   }
 
@@ -116,7 +118,7 @@ describe("PR cron — author-based alert labeling", () => {
     await trigger_review(cron, "test-org", "changes_requested");
 
     expect(alerts).toHaveLength(1);
-    expect(alerts[0]).toMatch(/^PR #42:/);
+    expect(alerts[0]).toContain("PR #42");
     expect(alerts[0]).not.toContain("External");
     expect(alerts[0]).not.toContain("@test-org");
   });
@@ -128,7 +130,9 @@ describe("PR cron — author-based alert labeling", () => {
     await trigger_review(cron, "contributor123", "changes_requested");
 
     expect(alerts).toHaveLength(1);
-    expect(alerts[0]).toMatch(/^External PR #42 from @contributor123:/);
+    expect(alerts[0]).toContain("External");
+    expect(alerts[0]).toContain("@contributor123");
+    expect(alerts[0]).toContain("PR #42");
   });
 
   it("treats all non-feature PRs as external when entity has no github.user", async () => {
@@ -138,15 +142,13 @@ describe("PR cron — author-based alert labeling", () => {
     await trigger_review(cron, "test-org", "changes_requested");
 
     expect(alerts).toHaveLength(1);
-    expect(alerts[0]).toMatch(/^External PR #42 from @test-org:/);
+    expect(alerts[0]).toContain("External");
+    expect(alerts[0]).toContain("@test-org");
+    expect(alerts[0]).toContain("PR #42");
   });
 
   it("labels approved+merged internal PR without 'External'", async () => {
     mock_registry.get.mockReturnValue(make_entity("test-org"));
-
-    // Mock check_pr_merged — we need execFile to return MERGED state
-    const { execFile } = await import("node:child_process");
-    const { promisify } = await import("node:util");
 
     const cron = await create_cron();
 
@@ -156,7 +158,7 @@ describe("PR cron — author-based alert labeling", () => {
     await trigger_review(cron, "test-org", "approved");
 
     expect(alerts).toHaveLength(1);
-    expect(alerts[0]).toMatch(/^PR #42:/);
+    expect(alerts[0]).toContain("PR #42");
     expect(alerts[0]).toContain("approved and merged to main");
     expect(alerts[0]).not.toContain("External");
   });
@@ -170,7 +172,8 @@ describe("PR cron — author-based alert labeling", () => {
     await trigger_review(cron, "outsider", "approved");
 
     expect(alerts).toHaveLength(1);
-    expect(alerts[0]).toMatch(/^External PR #42 from @outsider:/);
+    expect(alerts[0]).toContain("External");
+    expect(alerts[0]).toContain("@outsider");
     expect(alerts[0]).toContain("approved and merged to main");
   });
 
@@ -184,7 +187,7 @@ describe("PR cron — author-based alert labeling", () => {
 
     expect(alerts).toHaveLength(1);
     expect(alerts[0]).toContain("awaiting human merge");
-    expect(alerts[0]).toMatch(/^External PR #42 from @outsider:/);
+    expect(alerts[0]).toContain("@outsider");
   });
 
   it("still spawns fixer for both internal and external PRs needing changes", async () => {

--- a/packages/daemon/src/__tests__/pr-cron.test.ts
+++ b/packages/daemon/src/__tests__/pr-cron.test.ts
@@ -477,6 +477,13 @@ function make_entity_with_github_user(github_user: string): EntityConfig {
  * Create a PRReviewCron instance with private methods patched for testing
  * the retry_approved_unmerged pass without needing real gh CLI calls.
  */
+function make_mock_alert_router() {
+  return {
+    post_alert: vi.fn().mockResolvedValue({ message_id: null }),
+    resolve_incident: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
 function make_retry_test_cron(
   opts: {
     discord?: DiscordBot | null;
@@ -485,6 +492,7 @@ function make_retry_test_cron(
   } = {},
 ): {
   cron: PRReviewCron;
+  alert_router: ReturnType<typeof make_mock_alert_router>;
   get_processed: () => Record<string, ProcessedPR>;
   call_retry: (
     entity_id: string,
@@ -494,12 +502,15 @@ function make_retry_test_cron(
   ) => Promise<void>;
 } {
   const config = make_config();
+  const alert_router = make_mock_alert_router();
   const cron = new PRReviewCron(
     { get_active: () => [], get: vi.fn() } as never,
     { spawn: vi.fn(), on: vi.fn(), removeListener: vi.fn() } as never,
     config,
     opts.discord ?? null,
-    null,
+    null, // github_app
+    null, // pr_watches
+    alert_router as never,
   );
 
   // Patch private methods that require gh CLI or GitHub App auth
@@ -519,9 +530,6 @@ function make_retry_test_cron(
   // close_issues_for_merged_pr — no-op
   cron_any.close_issues_for_merged_pr = vi.fn().mockResolvedValue(undefined);
 
-  // notify_alerts — no-op (or spy on discord mock)
-  cron_any.notify_alerts = vi.fn().mockResolvedValue(undefined);
-
   // Seed processed state
   if (opts.processed) {
     cron_any.processed = { ...opts.processed };
@@ -529,6 +537,7 @@ function make_retry_test_cron(
 
   return {
     cron,
+    alert_router,
     get_processed: () => cron_any.processed as Record<string, ProcessedPR>,
     call_retry: (entity_id, repo_path, prs, entity_config) =>
       (
@@ -630,7 +639,7 @@ describe("PRReviewCron.retry_approved_unmerged", () => {
       failures: ["Build", "Test"],
     });
 
-    const { cron, call_retry, get_processed } = make_retry_test_cron({
+    const { alert_router, call_retry, get_processed } = make_retry_test_cron({
       processed: {
         [`${entity_id}:42`]: {
           entity_id,
@@ -644,12 +653,11 @@ describe("PRReviewCron.retry_approved_unmerged", () => {
     await call_retry(entity_id, repo_path, [pr], entity_config);
 
     expect(mock_auto_merge).not.toHaveBeenCalled();
-    const notify_alerts = (cron as unknown as Record<string, unknown>).notify_alerts as ReturnType<
-      typeof vi.fn
-    >;
-    expect(notify_alerts).toHaveBeenCalledWith(
-      entity_id,
-      expect.stringContaining("spawning builder to fix"),
+    expect(alert_router.post_alert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity_id,
+        body: expect.stringContaining("spawning builder"),
+      }),
     );
 
     // Should record the failure set for deduplication
@@ -669,7 +677,7 @@ describe("PRReviewCron.retry_approved_unmerged", () => {
       failures: ["Build", "Test"],
     });
 
-    const { cron, call_retry } = make_retry_test_cron({
+    const { alert_router, call_retry } = make_retry_test_cron({
       processed: {
         [`${entity_id}:42`]: {
           entity_id,
@@ -684,10 +692,7 @@ describe("PRReviewCron.retry_approved_unmerged", () => {
     await call_retry(entity_id, repo_path, [pr], entity_config);
 
     // Should NOT alert again — same failure set
-    const notify_alerts = (cron as unknown as Record<string, unknown>).notify_alerts as ReturnType<
-      typeof vi.fn
-    >;
-    expect(notify_alerts).not.toHaveBeenCalled();
+    expect(alert_router.post_alert).not.toHaveBeenCalled();
     expect(mock_auto_merge).not.toHaveBeenCalled();
   });
 
@@ -702,7 +707,7 @@ describe("PRReviewCron.retry_approved_unmerged", () => {
       failures: ["Lint", "Deploy"],
     });
 
-    const { cron, call_retry, get_processed } = make_retry_test_cron({
+    const { alert_router, call_retry, get_processed } = make_retry_test_cron({
       processed: {
         [`${entity_id}:42`]: {
           entity_id,
@@ -717,12 +722,11 @@ describe("PRReviewCron.retry_approved_unmerged", () => {
     await call_retry(entity_id, repo_path, [pr], entity_config);
 
     // Should alert — different failure set
-    const notify_alerts = (cron as unknown as Record<string, unknown>).notify_alerts as ReturnType<
-      typeof vi.fn
-    >;
-    expect(notify_alerts).toHaveBeenCalledWith(
-      entity_id,
-      expect.stringContaining("spawning builder to fix"),
+    expect(alert_router.post_alert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity_id,
+        body: expect.stringContaining("spawning builder"),
+      }),
     );
 
     // Should update the recorded failure set
@@ -836,6 +840,7 @@ function make_ci_fixer_test_cron(
 ): {
   cron: PRReviewCron;
   session_manager: { spawn: ReturnType<typeof vi.fn> };
+  alert_router: ReturnType<typeof make_mock_alert_router>;
   get_processed: () => Record<string, ProcessedPR>;
   get_active_reviews: () => Map<string, unknown>;
   resolve_entity_token: ReturnType<typeof vi.fn>;
@@ -848,6 +853,7 @@ function make_ci_fixer_test_cron(
   ) => Promise<boolean>;
 } {
   const config = make_config();
+  const alert_router = make_mock_alert_router();
   const mock_spawn = vi.fn().mockResolvedValue({
     session_id: "ci-fix-session-123",
     entity_id: "test-entity",
@@ -865,8 +871,10 @@ function make_ci_fixer_test_cron(
     { get_active: () => [], get: vi.fn() } as never,
     session_manager as never,
     config,
-    null,
-    null,
+    null, // discord
+    null, // github_app
+    null, // pr_watches
+    alert_router as never,
   );
 
   const cron_any = cron as unknown as Record<string, unknown>;
@@ -877,9 +885,6 @@ function make_ci_fixer_test_cron(
     : vi.fn().mockResolvedValue("ghs_test_token");
   cron_any.resolve_entity_token = resolve_token_mock;
 
-  // notify_alerts — no-op spy
-  cron_any.notify_alerts = vi.fn().mockResolvedValue(undefined);
-
   // Seed processed state
   if (opts.processed) {
     cron_any.processed = { ...opts.processed };
@@ -888,6 +893,7 @@ function make_ci_fixer_test_cron(
   return {
     cron,
     session_manager,
+    alert_router,
     get_processed: () => cron_any.processed as Record<string, ProcessedPR>,
     get_active_reviews: () => cron_any.active_reviews as Map<string, unknown>,
     resolve_entity_token: resolve_token_mock,
@@ -953,7 +959,7 @@ describe("PRReviewCron.spawn_ci_fixer", () => {
     const pr = make_test_pr();
     const entity_config = make_entity_with_github_user("test-user");
 
-    const { cron, session_manager, call_spawn_ci_fixer } = make_ci_fixer_test_cron({
+    const { alert_router, session_manager, call_spawn_ci_fixer } = make_ci_fixer_test_cron({
       processed: {
         [`${entity_id}:42`]: {
           entity_id,
@@ -971,12 +977,12 @@ describe("PRReviewCron.spawn_ci_fixer", () => {
     expect(session_manager.spawn).not.toHaveBeenCalled();
 
     // Should alert about max attempts
-    const notify_alerts = (cron as unknown as Record<string, unknown>).notify_alerts as ReturnType<
-      typeof vi.fn
-    >;
-    expect(notify_alerts).toHaveBeenCalledWith(
-      entity_id,
-      expect.stringContaining("CI fix failed after 3 attempts"),
+    expect(alert_router.post_alert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity_id,
+        tier: "action_required",
+        body: expect.stringContaining("failed after 3 attempts"),
+      }),
     );
   });
 

--- a/packages/daemon/src/__tests__/sentry-triage.test.ts
+++ b/packages/daemon/src/__tests__/sentry-triage.test.ts
@@ -146,12 +146,20 @@ function make_discord(): DiscordBot {
   } as unknown as DiscordBot;
 }
 
+function make_alert_router() {
+  return {
+    post_alert: vi.fn().mockResolvedValue({ message_id: null }),
+    resolve_incident: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
 function make_context(overrides: Partial<SentryTriageContext> = {}): SentryTriageContext {
   return {
     session_manager: make_session_manager(),
     registry: make_registry(),
     discord: make_discord(),
     config: make_config(),
+    alert_router: make_alert_router() as unknown as SentryTriageContext["alert_router"],
     ...overrides,
   };
 }
@@ -560,13 +568,14 @@ describe("rate limiting", () => {
     // Still 2 spawned (no new spawn)
     expect(sm.spawn).toHaveBeenCalledTimes(2);
 
-    // Discord should have been alerted about the drop
-    const send = discord as unknown as { send_to_entity: ReturnType<typeof vi.fn> };
-    expect(send.send_to_entity).toHaveBeenCalledWith(
-      "test-entity",
-      "alerts",
-      expect.stringContaining("queue full"),
-      "system",
+    // Alert router should have been called about the drop
+    const alert_router = ctx.alert_router as unknown as { post_alert: ReturnType<typeof vi.fn> };
+    expect(alert_router.post_alert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity_id: "test-entity",
+        tier: "action_required",
+        title: expect.stringContaining("queue full"),
+      }),
     );
   });
 });

--- a/packages/daemon/src/__tests__/v2-review-completion.test.ts
+++ b/packages/daemon/src/__tests__/v2-review-completion.test.ts
@@ -141,6 +141,9 @@ function make_ctx(overrides: Partial<WebhookContext> = {}): WebhookContext {
     } as WebhookContext["config"],
     pool: null,
     pr_watches: null,
+    alert_router: {
+      post_alert: vi.fn(async () => ({ message_id: null })),
+    } as unknown as WebhookContext["alert_router"],
     ...overrides,
   };
 }
@@ -185,12 +188,13 @@ describe("handle_v2_review_completion — changes_requested", () => {
     const spawn_call = (ctx.session_manager as any).spawn.mock.calls[0]![0];
     expect(spawn_call.archetype).toBe("builder");
 
-    // Should alert
-    expect((ctx.discord as any).send_to_entity).toHaveBeenCalledWith(
-      ENTITY_ID,
-      "alerts",
-      expect.stringContaining("changes requested"),
-      expect.any(String),
+    // Should alert via alert_router
+    expect((ctx.alert_router as any).post_alert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity_id: ENTITY_ID,
+        tier: "routine",
+        title: expect.stringContaining("changes requested"),
+      }),
     );
 
     // Should NOT call the merge-gate
@@ -273,11 +277,12 @@ describe("handle_v2_review_completion — approved", () => {
     expect(cleanup_after_merge).toHaveBeenCalledWith(REPO_PATH, "feature/42-x");
 
     // Alert should mention merge
-    expect((ctx.discord as any).send_to_entity).toHaveBeenCalledWith(
-      ENTITY_ID,
-      "alerts",
-      expect.stringContaining("merged"),
-      expect.any(String),
+    expect((ctx.alert_router as any).post_alert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity_id: ENTITY_ID,
+        tier: "routine",
+        title: expect.stringContaining("merged"),
+      }),
     );
   });
 
@@ -301,11 +306,12 @@ describe("handle_v2_review_completion — approved", () => {
     );
 
     expect(cleanup_after_merge).not.toHaveBeenCalled();
-    expect((ctx.discord as any).send_to_entity).toHaveBeenCalledWith(
-      ENTITY_ID,
-      "alerts",
-      expect.stringContaining("CI regressed"),
-      expect.any(String),
+    expect((ctx.alert_router as any).post_alert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity_id: ENTITY_ID,
+        tier: "action_required",
+        title: expect.stringContaining("CI regressed"),
+      }),
     );
   });
 
@@ -329,8 +335,8 @@ describe("handle_v2_review_completion — approved", () => {
     );
 
     expect(cleanup_after_merge).not.toHaveBeenCalled();
-    // sha_changed is a log, not an alert — discord should NOT be called for alerts
-    expect((ctx.discord as any).send_to_entity).not.toHaveBeenCalled();
+    // sha_changed is a log, not an alert — alert_router should NOT be called
+    expect((ctx.alert_router as any).post_alert).not.toHaveBeenCalled();
   });
 
   it("alerts on rebase_conflict", async () => {
@@ -353,11 +359,12 @@ describe("handle_v2_review_completion — approved", () => {
     );
 
     expect(cleanup_after_merge).not.toHaveBeenCalled();
-    expect((ctx.discord as any).send_to_entity).toHaveBeenCalledWith(
-      ENTITY_ID,
-      "alerts",
-      expect.stringContaining("rebase conflict"),
-      expect.any(String),
+    expect((ctx.alert_router as any).post_alert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity_id: ENTITY_ID,
+        tier: "action_required",
+        title: expect.stringContaining("Rebase conflict"),
+      }),
     );
   });
 
@@ -379,11 +386,12 @@ describe("handle_v2_review_completion — approved", () => {
     expect(fetch_pr_mergeability).not.toHaveBeenCalled();
     expect(run_merge_gate).not.toHaveBeenCalled();
     expect(cleanup_after_merge).not.toHaveBeenCalled();
-    expect((ctx.discord as any).send_to_entity).toHaveBeenCalledWith(
-      ENTITY_ID,
-      "alerts",
-      expect.stringContaining("no GH token"),
-      expect.any(String),
+    expect((ctx.alert_router as any).post_alert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity_id: ENTITY_ID,
+        tier: "action_required",
+        title: expect.stringContaining("No GH token"),
+      }),
     );
   });
 
@@ -407,11 +415,12 @@ describe("handle_v2_review_completion — approved", () => {
     );
 
     expect(cleanup_after_merge).not.toHaveBeenCalled();
-    expect((ctx.discord as any).send_to_entity).toHaveBeenCalledWith(
-      ENTITY_ID,
-      "alerts",
-      expect.stringContaining("merge-gate failed"),
-      expect.any(String),
+    expect((ctx.alert_router as any).post_alert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity_id: ENTITY_ID,
+        tier: "action_required",
+        title: expect.stringContaining("Merge failed"),
+      }),
     );
   });
 
@@ -435,11 +444,12 @@ describe("handle_v2_review_completion — approved", () => {
     );
 
     expect(cleanup_after_merge).not.toHaveBeenCalled();
-    expect((ctx.discord as any).send_to_entity).toHaveBeenCalledWith(
-      ENTITY_ID,
-      "alerts",
-      expect.stringContaining("branch protection"),
-      expect.any(String),
+    expect((ctx.alert_router as any).post_alert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity_id: ENTITY_ID,
+        tier: "action_required",
+        title: expect.stringContaining("Branch protected"),
+      }),
     );
   });
 
@@ -461,7 +471,7 @@ describe("handle_v2_review_completion — approved", () => {
 
     expect(cleanup_after_merge).not.toHaveBeenCalled();
     // rebased_awaiting_ci is a log, not an alert
-    expect((ctx.discord as any).send_to_entity).not.toHaveBeenCalled();
+    expect((ctx.alert_router as any).post_alert).not.toHaveBeenCalled();
   });
 
   it("handles ci_pending — alerts, no merge", async () => {
@@ -483,11 +493,12 @@ describe("handle_v2_review_completion — approved", () => {
     expect(cleanup_after_merge).not.toHaveBeenCalled();
     // ci_pending alerts because dedup blocks re-dispatch on the same SHA —
     // without a new commit, the PR would be stuck forever
-    expect((ctx.discord as any).send_to_entity).toHaveBeenCalledWith(
-      ENTITY_ID,
-      "alerts",
-      expect.stringContaining("CI check is still running"),
-      expect.any(String),
+    expect((ctx.alert_router as any).post_alert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity_id: ENTITY_ID,
+        tier: "routine",
+        title: expect.stringContaining("CI pending"),
+      }),
     );
   });
 
@@ -508,7 +519,7 @@ describe("handle_v2_review_completion — approved", () => {
     );
 
     expect(cleanup_after_merge).not.toHaveBeenCalled();
-    expect((ctx.discord as any).send_to_entity).not.toHaveBeenCalled();
+    expect((ctx.alert_router as any).post_alert).not.toHaveBeenCalled();
   });
 
   // Note: the "returns early if fetch_pr_mergeability fails" test was removed —
@@ -532,11 +543,12 @@ describe("handle_v2_review_completion — pending", () => {
     );
 
     // Should alert but not spawn or merge
-    expect((ctx.discord as any).send_to_entity).toHaveBeenCalledWith(
-      ENTITY_ID,
-      "alerts",
-      expect.stringContaining("pending"),
-      expect.any(String),
+    expect((ctx.alert_router as any).post_alert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity_id: ENTITY_ID,
+        tier: "routine",
+        body: expect.stringContaining("pending"),
+      }),
     );
     expect(run_merge_gate).not.toHaveBeenCalled();
     expect((ctx.session_manager as any).spawn).not.toHaveBeenCalled();
@@ -558,12 +570,13 @@ describe("handle_v2_review_completion — dismissed", () => {
       ctx,
     );
 
-    // Should alert
-    expect((ctx.discord as any).send_to_entity).toHaveBeenCalledWith(
-      ENTITY_ID,
-      "alerts",
-      expect.stringContaining("all reviews dismissed"),
-      expect.any(String),
+    // Should alert via alert_router
+    expect((ctx.alert_router as any).post_alert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity_id: ENTITY_ID,
+        tier: "routine",
+        body: expect.stringContaining("all reviews dismissed"),
+      }),
     );
 
     // Should NOT spawn a builder or run the merge-gate

--- a/packages/daemon/src/alert-router.ts
+++ b/packages/daemon/src/alert-router.ts
@@ -1,0 +1,393 @@
+/**
+ * Tiered alert router for entity #alerts channels (#253).
+ *
+ * Routes notifications into three tiers:
+ *   - Tier 1 (action_required): top-level embeds — needs human attention
+ *   - Tier 2 (routine): daily activity thread — informational
+ *   - Tier 3 (incident_open / incident_update): per-incident threads
+ *
+ * Single entry point: `post_alert()`. All call sites that previously used
+ * `notify_alerts()` or `send_to_entity("alerts", ...)` go through here.
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import type { LobsterFarmConfig } from "@lobster-farm/shared";
+import { lobsterfarm_dir } from "@lobster-farm/shared";
+import { EmbedBuilder } from "discord.js";
+import type { DiscordBot } from "./discord.js";
+import * as sentry from "./sentry.js";
+
+// ── Types ──
+
+export type AlertTier = "action_required" | "routine" | "incident_open" | "incident_update";
+
+export interface AlertPayload {
+  entity_id: string;
+  tier: AlertTier;
+  title: string;
+  body: string;
+  /** For incident_update — which thread to post to. */
+  incident_id?: string;
+  /** Override the default tier color. */
+  embed_color?: number;
+}
+
+export interface AlertResult {
+  message_id: string | null;
+  thread_id?: string;
+}
+
+// ── Embed colors ──
+
+export const ALERT_COLOR_RED = 0xef4444;
+export const ALERT_COLOR_AMBER = 0xf59e0b;
+export const ALERT_COLOR_GREEN = 0x10b981;
+
+// ── Daily thread title format ──
+
+const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+const MONTHS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+] as const;
+
+/**
+ * Format the daily thread title: "📋 Activity — Mon DD"
+ * `now` is injectable for deterministic tests.
+ */
+export function daily_thread_title(now: Date = new Date()): string {
+  const weekday = WEEKDAYS[now.getDay()]!;
+  const month = MONTHS[now.getMonth()]!;
+  const day = now.getDate();
+  return `\u{1f4cb} Activity \u2014 ${weekday} ${month} ${String(day)}`;
+}
+
+/**
+ * Date key for daily thread cache: "entity_id:YYYY-MM-DD".
+ * `now` is injectable for testing.
+ */
+function daily_cache_key(entity_id: string, now: Date = new Date()): string {
+  const yyyy = now.getFullYear();
+  const mm = String(now.getMonth() + 1).padStart(2, "0");
+  const dd = String(now.getDate()).padStart(2, "0");
+  return `${entity_id}:${String(yyyy)}-${mm}-${dd}`;
+}
+
+// ── Active incident persistence ──
+
+const ACTIVE_INCIDENTS_FILE = "active-incidents.json";
+
+export interface ActiveIncident {
+  entity_id: string;
+  thread_id: string;
+  message_id: string;
+  channel_id: string;
+  title: string;
+  created_at: string;
+}
+
+export type ActiveIncidentsState = Record<string, ActiveIncident>;
+
+function incidents_path(config: LobsterFarmConfig): string {
+  return join(lobsterfarm_dir(config.paths), "state", ACTIVE_INCIDENTS_FILE);
+}
+
+export async function load_active_incidents(
+  config: LobsterFarmConfig,
+): Promise<ActiveIncidentsState> {
+  const path = incidents_path(config);
+  try {
+    const content = await readFile(path, "utf-8");
+    const data: unknown = JSON.parse(content);
+    if (typeof data !== "object" || data === null || Array.isArray(data)) return {};
+    return data as ActiveIncidentsState;
+  } catch {
+    return {};
+  }
+}
+
+export async function save_active_incidents(
+  state: ActiveIncidentsState,
+  config: LobsterFarmConfig,
+): Promise<void> {
+  const path = incidents_path(config);
+  const tmp_path = `${path}.${randomUUID().slice(0, 8)}.tmp`;
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(tmp_path, JSON.stringify(state, null, 2), "utf-8");
+  await rename(tmp_path, path);
+}
+
+// ── Alert Router ──
+
+/** Options for testing internals without exposing them on the public API. */
+export interface AlertRouterTestOptions {
+  daily_threads?: Map<string, string>;
+}
+
+export class AlertRouter {
+  private discord: DiscordBot | null;
+  private config: LobsterFarmConfig;
+
+  /** In-memory cache: daily_cache_key → thread_id */
+  private daily_threads: Map<string, string>;
+
+  constructor(
+    discord: DiscordBot | null,
+    config: LobsterFarmConfig,
+    _testing?: AlertRouterTestOptions,
+  ) {
+    this.discord = discord;
+    this.config = config;
+    this.daily_threads = _testing?.daily_threads ?? new Map();
+  }
+
+  /**
+   * Route a notification to the correct tier in the entity's #alerts channel.
+   *
+   * Returns the message_id and optional thread_id for chaining (e.g., passing
+   * an incident thread_id to agent spawn prompts).
+   */
+  async post_alert(payload: AlertPayload): Promise<AlertResult> {
+    const { entity_id, tier } = payload;
+
+    // Always log regardless of Discord connectivity
+    console.log(`[alert-router] [${tier}] ${payload.title}: ${payload.body}`);
+
+    if (!this.discord) {
+      return { message_id: null };
+    }
+
+    const channel_id = this.discord.get_entity_channel_id(entity_id, "alerts");
+    if (!channel_id) {
+      console.log(`[alert-router] No alerts channel for entity ${entity_id}`);
+      return { message_id: null };
+    }
+
+    try {
+      switch (tier) {
+        case "action_required":
+          return await this.post_action_required(channel_id, payload);
+        case "routine":
+          return await this.post_routine(channel_id, entity_id, payload);
+        case "incident_open":
+          return await this.post_incident_open(channel_id, entity_id, payload);
+        case "incident_update":
+          return await this.post_incident_update(payload);
+        default: {
+          // Exhaustive check
+          const _never: never = tier;
+          console.error(`[alert-router] Unknown tier: ${String(_never)}`);
+          return { message_id: null };
+        }
+      }
+    } catch (err) {
+      console.error(`[alert-router] Failed to post ${tier} alert: ${String(err)}`);
+      sentry.captureException(err, {
+        tags: { module: "alert-router", tier, entity: entity_id },
+      });
+      return { message_id: null };
+    }
+  }
+
+  // ── Tier 1: Action Required ──
+
+  private async post_action_required(
+    channel_id: string,
+    payload: AlertPayload,
+  ): Promise<AlertResult> {
+    const color = payload.embed_color ?? ALERT_COLOR_RED;
+    const embed = new EmbedBuilder()
+      .setColor(color)
+      .setTitle(payload.title)
+      .setDescription(payload.body)
+      .setTimestamp();
+
+    const message_id = await this.discord!.send_embed(channel_id, embed);
+    return { message_id };
+  }
+
+  // ── Tier 2: Routine (daily thread) ──
+
+  private async post_routine(
+    channel_id: string,
+    entity_id: string,
+    payload: AlertPayload,
+  ): Promise<AlertResult> {
+    const thread_id = await this.resolve_daily_thread(channel_id, entity_id);
+
+    if (thread_id) {
+      const line = `**${payload.title}** ${payload.body}`;
+      await this.discord!.send_to_thread(thread_id, line);
+      return { message_id: null, thread_id };
+    }
+
+    // Fallback: if thread creation fails, post to channel directly (plain text)
+    console.warn("[alert-router] Daily thread unavailable, falling back to channel");
+    await this.discord!.send(channel_id, `${payload.title}: ${payload.body}`);
+    return { message_id: null };
+  }
+
+  /**
+   * Find or create today's daily activity thread.
+   * Checks in-memory cache first, then scans Discord, then creates.
+   */
+  private async resolve_daily_thread(
+    channel_id: string,
+    entity_id: string,
+    now: Date = new Date(),
+  ): Promise<string | null> {
+    const cache_key = daily_cache_key(entity_id, now);
+
+    // Evict stale entries from previous days to prevent unbounded growth.
+    // Key format: "entity_id:YYYY-MM-DD" — extract today's date and drop non-matching keys.
+    const today_date = cache_key.slice(cache_key.lastIndexOf(":"));
+    for (const key of this.daily_threads.keys()) {
+      if (!key.endsWith(today_date)) {
+        this.daily_threads.delete(key);
+      }
+    }
+
+    // In-memory cache hit
+    const cached = this.daily_threads.get(cache_key);
+    if (cached) return cached;
+
+    const title = daily_thread_title(now);
+
+    // Scan Discord for an existing thread with today's name
+    const existing_id = await this.discord!.find_thread_by_name(channel_id, title);
+    if (existing_id) {
+      this.daily_threads.set(cache_key, existing_id);
+      return existing_id;
+    }
+
+    // Create a new daily thread: post a placeholder message, then thread it
+    const placeholder_embed = new EmbedBuilder()
+      .setColor(0x6366f1) // indigo — neutral, distinct from alert colors
+      .setTitle(title)
+      .setDescription("Today's routine activity feed.")
+      .setTimestamp(now);
+
+    const msg_id = await this.discord!.send_embed(channel_id, placeholder_embed);
+    if (!msg_id) return null;
+
+    const thread_id = await this.discord!.create_thread_from_message(channel_id, msg_id, title);
+
+    if (thread_id) {
+      this.daily_threads.set(cache_key, thread_id);
+    }
+
+    return thread_id;
+  }
+
+  // ── Tier 3: Incident Open ──
+
+  private async post_incident_open(
+    channel_id: string,
+    entity_id: string,
+    payload: AlertPayload,
+  ): Promise<AlertResult> {
+    const color = payload.embed_color ?? ALERT_COLOR_RED;
+    const embed = new EmbedBuilder()
+      .setColor(color)
+      .setTitle(payload.title)
+      .setDescription(payload.body)
+      .setTimestamp();
+
+    const message_id = await this.discord!.send_embed(channel_id, embed);
+    if (!message_id) return { message_id: null };
+
+    // Create incident thread from the embed message
+    const thread_title = payload.title.slice(0, 100);
+    const thread_id = await this.discord!.create_thread_from_message(
+      channel_id,
+      message_id,
+      thread_title,
+    );
+
+    // Persist the incident so we can update it later (and across restarts)
+    if (thread_id) {
+      const incident: ActiveIncident = {
+        entity_id,
+        thread_id,
+        message_id,
+        channel_id,
+        title: payload.title,
+        created_at: new Date().toISOString(),
+      };
+
+      try {
+        const state = await load_active_incidents(this.config);
+        state[thread_id] = incident;
+        await save_active_incidents(state, this.config);
+      } catch (err) {
+        console.error(`[alert-router] Failed to persist incident: ${String(err)}`);
+      }
+    }
+
+    return { message_id, thread_id: thread_id ?? undefined };
+  }
+
+  // ── Tier 3: Incident Update ──
+
+  private async post_incident_update(payload: AlertPayload): Promise<AlertResult> {
+    const { incident_id, body } = payload;
+
+    if (!incident_id) {
+      console.warn("[alert-router] incident_update without incident_id — dropping");
+      return { message_id: null };
+    }
+
+    await this.discord!.send_to_thread(incident_id, body);
+    return { message_id: null, thread_id: incident_id };
+  }
+
+  /**
+   * Mark an incident as resolved: edit the original top-level embed to green
+   * with a resolved title and remove from persistent state.
+   */
+  async resolve_incident(incident_id: string, resolution_body: string): Promise<void> {
+    const state = await load_active_incidents(this.config);
+    const incident = state[incident_id];
+
+    if (!incident) {
+      console.log(`[alert-router] No active incident for thread ${incident_id} — may be stale`);
+      return;
+    }
+
+    // Edit the original top-level embed to green + resolved title
+    if (this.discord) {
+      const resolved_embed = new EmbedBuilder()
+        .setColor(ALERT_COLOR_GREEN)
+        .setTitle(
+          `\u2705 Resolved: ${incident.title.replace(/^[\p{Emoji}\p{Emoji_Component}]+\s*/u, "")}`,
+        )
+        .setDescription(resolution_body)
+        .setTimestamp();
+
+      await this.discord.edit_message_embed(
+        incident.channel_id,
+        incident.message_id,
+        resolved_embed,
+      );
+
+      // Post resolution to the incident thread
+      await this.discord.send_to_thread(incident_id, `\u2705 ${resolution_body}`);
+    }
+
+    // Remove from persistent state
+    delete state[incident_id];
+    await save_active_incidents(state, this.config);
+  }
+}

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -1263,7 +1263,7 @@ export class DiscordBot extends EventEmitter {
       if (match) return match.id;
 
       // Also check recently archived threads (covers daemon restart case)
-      const archived = await text_channel.threads.fetchArchived({ limit: 10 });
+      const archived = await text_channel.threads.fetchArchived({ limit: 50 });
       const archived_match = archived.threads.find((t) => t.name === name);
       if (archived_match) return archived_match.id;
 

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -1127,6 +1127,153 @@ export class DiscordBot extends EventEmitter {
     }
   }
 
+  // ── Alert router helpers ──
+  // These methods support the tiered alert system (alert-router.ts).
+  // They expose lower-level Discord primitives that the router composes.
+
+  /** Resolve the channel ID for a given entity and channel type. Returns null if not found. */
+  get_entity_channel_id(entity_id: string, channel_type: ChannelType): string | null {
+    const entity_map = this.entity_channels.get(entity_id);
+    if (!entity_map) return null;
+    return entity_map.get(channel_type) ?? null;
+  }
+
+  /** Send a Discord embed to a channel. Returns the message ID, or null on failure. */
+  async send_embed(channel_id: string, embed: EmbedBuilder): Promise<string | null> {
+    if (!this.connected) {
+      console.log(`[discord:offline] Would send embed to ${channel_id}`);
+      return null;
+    }
+
+    try {
+      const channel = await this.client.channels.fetch(channel_id);
+      if (channel?.isTextBased()) {
+        const msg = await (channel as TextChannel).send({ embeds: [embed] });
+        return msg.id;
+      }
+      return null;
+    } catch (err) {
+      console.error(`[discord] Failed to send embed to ${channel_id}: ${String(err)}`);
+      sentry.captureException(err, {
+        tags: { module: "discord", action: "send_embed" },
+      });
+      return null;
+    }
+  }
+
+  /** Create a thread from an existing message. Returns the thread ID, or null on failure. */
+  async create_thread_from_message(
+    channel_id: string,
+    message_id: string,
+    name: string,
+  ): Promise<string | null> {
+    if (!this.connected) {
+      console.log(`[discord:offline] Would create thread "${name}" from message ${message_id}`);
+      return null;
+    }
+
+    try {
+      const channel = await this.client.channels.fetch(channel_id);
+      if (!channel?.isTextBased()) return null;
+
+      const message = await (channel as TextChannel).messages.fetch(message_id);
+      const thread = await message.startThread({
+        name: name.slice(0, 100), // Discord thread name max 100 chars
+        autoArchiveDuration: 1440, // 24 hours
+      });
+      console.log(`[discord] Created thread "${name}" (${thread.id}) from message ${message_id}`);
+      return thread.id;
+    } catch (err) {
+      console.error(`[discord] Failed to create thread from message ${message_id}: ${String(err)}`);
+      sentry.captureException(err, {
+        tags: { module: "discord", action: "create_thread_from_message" },
+      });
+      return null;
+    }
+  }
+
+  /** Post a text message to a thread. */
+  async send_to_thread(thread_id: string, content: string): Promise<void> {
+    if (!this.connected) {
+      console.log(`[discord:offline] Would send to thread ${thread_id}: ${content}`);
+      return;
+    }
+
+    try {
+      const thread = await this.client.channels.fetch(thread_id);
+      if (thread?.isThread()) {
+        // Unarchive if archived so we can post
+        if (thread.archived) {
+          await thread.setArchived(false);
+        }
+        await thread.send(content);
+      }
+    } catch (err) {
+      console.error(`[discord] Failed to send to thread ${thread_id}: ${String(err)}`);
+      sentry.captureException(err, {
+        tags: { module: "discord", action: "send_to_thread" },
+      });
+    }
+  }
+
+  /** Edit an existing message's embed. Returns true on success. */
+  async edit_message_embed(
+    channel_id: string,
+    message_id: string,
+    embed: EmbedBuilder,
+  ): Promise<boolean> {
+    if (!this.connected) {
+      console.log(`[discord:offline] Would edit embed on message ${message_id}`);
+      return false;
+    }
+
+    try {
+      const channel = await this.client.channels.fetch(channel_id);
+      if (!channel?.isTextBased()) return false;
+
+      const message = await (channel as TextChannel).messages.fetch(message_id);
+      await message.edit({ embeds: [embed] });
+      return true;
+    } catch (err) {
+      console.error(
+        `[discord] Failed to edit message ${message_id} in ${channel_id}: ${String(err)}`,
+      );
+      sentry.captureException(err, {
+        tags: { module: "discord", action: "edit_message_embed" },
+      });
+      return false;
+    }
+  }
+
+  /**
+   * Find a thread in a channel by exact name match. Searches active (non-archived)
+   * threads first. Returns the thread ID, or null if not found.
+   */
+  async find_thread_by_name(channel_id: string, name: string): Promise<string | null> {
+    if (!this.connected) return null;
+
+    try {
+      const channel = await this.client.channels.fetch(channel_id);
+      if (!channel?.isTextBased()) return null;
+
+      // Search active threads in the channel
+      const text_channel = channel as TextChannel;
+      const active = await text_channel.threads.fetchActive();
+      const match = active.threads.find((t) => t.name === name);
+      if (match) return match.id;
+
+      // Also check recently archived threads (covers daemon restart case)
+      const archived = await text_channel.threads.fetchArchived({ limit: 10 });
+      const archived_match = archived.threads.find((t) => t.name === name);
+      if (archived_match) return archived_match.id;
+
+      return null;
+    } catch (err) {
+      console.error(`[discord] Failed to find thread "${name}" in ${channel_id}: ${String(err)}`);
+      return null;
+    }
+  }
+
   // ── Channel management ──
 
   /** Create a text channel under a category. Returns the channel ID, or null on failure. */

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -1,5 +1,6 @@
 import type { Server } from "node:http";
 import { set_discord_bot, set_pool } from "./actions.js";
+import { AlertRouter } from "./alert-router.js";
 import { CommanderProcess } from "./commander-process.js";
 import { load_config } from "./config.js";
 import { DiscordBot, resolve_bot_token } from "./discord.js";
@@ -247,6 +248,10 @@ async function main(): Promise<void> {
   const pr_watches = new PRWatchStore(config);
   await pr_watches.initialize();
 
+  // Initialize tiered alert router (#253)
+  const discord_for_routing = discord_connected ? discord : null;
+  const alert_router = new AlertRouter(discord_for_routing, config);
+
   // Start HTTP server
   const server = start_server(
     registry,
@@ -254,10 +259,11 @@ async function main(): Promise<void> {
     session_manager,
     queue,
     commander,
-    discord_connected ? discord : null,
+    discord_for_routing,
     pool,
     github_app,
     pr_watches,
+    alert_router,
   );
 
   // Start PR review cron (safety net — 30 min when webhooks are active, 5 min otherwise)
@@ -265,9 +271,10 @@ async function main(): Promise<void> {
     registry,
     session_manager,
     config,
-    discord_connected ? discord : null,
+    discord_for_routing,
     github_app,
     pr_watches,
+    alert_router,
   );
   const pr_cron_enabled = config.pr_cron?.enabled !== false; // default true for backward compat
   if (pr_cron_enabled) {

--- a/packages/daemon/src/pr-cron.ts
+++ b/packages/daemon/src/pr-cron.ts
@@ -1,9 +1,10 @@
 import { execFile } from "node:child_process";
 import { stat } from "node:fs/promises";
 import { promisify } from "node:util";
-import type { ArchetypeRole, EntityConfig, LobsterFarmConfig } from "@lobster-farm/shared";
+import type { EntityConfig, LobsterFarmConfig } from "@lobster-farm/shared";
 import { expand_home } from "@lobster-farm/shared";
 import { type ReviewOutcome, detect_review_outcome } from "./actions.js";
+import { ALERT_COLOR_AMBER, type AlertRouter } from "./alert-router.js";
 import type { DiscordBot } from "./discord.js";
 import { resolve_binary } from "./env.js";
 import type { GitHubAppAuth } from "./github-app.js";
@@ -115,9 +116,10 @@ export class PRReviewCron {
     private registry: EntityRegistry,
     private session_manager: ClaudeSessionManager,
     private config: LobsterFarmConfig,
-    private discord: DiscordBot | null = null,
+    _discord: DiscordBot | null = null,
     private github_app: GitHubAppAuth | null = null,
     private pr_watches: PRWatchStore | null = null,
+    private alert_router: AlertRouter | null = null,
   ) {}
 
   /** Start the polling cron. Loads persisted review state before first poll. */
@@ -599,17 +601,13 @@ export class PRReviewCron {
 
     if (review_state === "changes_requested") {
       await this.spawn_external_pr_fixer(entity_id, repo_path, pr, entity_config);
-      if (is_internal) {
-        await this.notify_alerts(
-          entity_id,
-          `PR #${String(pr.number)}: ${pr.title} — needs changes, spawning builder to fix`,
-        );
-      } else {
-        await this.notify_alerts(
-          entity_id,
-          `External PR #${String(pr.number)} from @${pr.author.login}: ${pr.title} — needs changes, spawning builder to fix`,
-        );
-      }
+      const prefix = is_internal ? "" : `External (from @${pr.author.login}) `;
+      await this.alert_router?.post_alert({
+        entity_id,
+        tier: "routine",
+        title: `${prefix}PR #${String(pr.number)} changes requested`,
+        body: `${pr.title} — spawning builder to fix`,
+      });
     } else if (review_state === "approved") {
       // Check if the reviewer already merged (they're instructed to merge on approval)
       const is_merged = await this.check_pr_merged(repo_path, pr.number, gh_token);
@@ -617,18 +615,13 @@ export class PRReviewCron {
       if (is_merged) {
         // Reviewer merged — close linked issues and notify
         await this.close_issues_for_merged_pr(entity_id, repo_path, pr, entity_config);
-
-        if (is_internal) {
-          await this.notify_alerts(
-            entity_id,
-            `PR #${String(pr.number)}: ${pr.title} — approved and merged to main`,
-          );
-        } else {
-          await this.notify_alerts(
-            entity_id,
-            `External PR #${String(pr.number)} from @${pr.author.login}: ${pr.title} — approved and merged to main`,
-          );
-        }
+        const prefix = is_internal ? "" : `External (from @${pr.author.login}) `;
+        await this.alert_router?.post_alert({
+          entity_id,
+          tier: "routine",
+          title: `${prefix}PR #${String(pr.number)} merged`,
+          body: `${pr.title} — approved and merged to main`,
+        });
 
         // Clean up local worktrees for the merged branch
         await try_cleanup_worktree(repo_path, pr.headRefName, pr.number);
@@ -656,26 +649,34 @@ export class PRReviewCron {
 
           if (result.merged) {
             await this.close_issues_for_merged_pr(entity_id, repo_path, pr, entity_config);
-            await this.notify_alerts(
+            await this.alert_router?.post_alert({
               entity_id,
-              `PR #${String(pr.number)}: ${pr.title} — approved, auto-rebased (${result.method}), and merged to main`,
-            );
+              tier: "routine",
+              title: `PR #${String(pr.number)} merged`,
+              body: `${pr.title} — approved, auto-rebased (${result.method}), and merged to main`,
+            });
 
             // Clean up local worktrees for the merged branch
             await try_cleanup_worktree(repo_path, pr.headRefName, pr.number);
           } else {
-            await this.notify_alerts(
+            await this.alert_router?.post_alert({
               entity_id,
-              `PR #${String(pr.number)}: ${pr.title} — approved but merge failed after rebase attempt. ${result.error ?? "Manual intervention needed."}`,
-            );
+              tier: "action_required",
+              title: `\u26a0\ufe0f Merge failed — PR #${String(pr.number)}`,
+              body: `${pr.title} — approved but merge failed. ${result.error ?? "Manual intervention needed."}`,
+              embed_color: ALERT_COLOR_AMBER,
+            });
           }
         }
       } else {
         // External, not yet merged — escalate to human
-        await this.notify_alerts(
+        await this.alert_router?.post_alert({
           entity_id,
-          `External PR #${String(pr.number)} from @${pr.author.login}: ${pr.title} — approved, awaiting human merge`,
-        );
+          tier: "action_required",
+          title: `\u26a0\ufe0f External PR awaiting merge — PR #${String(pr.number)}`,
+          body: `From @${pr.author.login}: ${pr.title} — approved, awaiting human merge`,
+          embed_color: ALERT_COLOR_AMBER,
+        });
       }
     } else if (review_state === "dismissed") {
       // All reviews were dismissed — PR needs a fresh review.
@@ -683,16 +684,20 @@ export class PRReviewCron {
       console.log(
         `[pr-cron] All reviews dismissed on PR #${String(pr.number)} — will be re-reviewed next cycle`,
       );
-      await this.notify_alerts(
+      await this.alert_router?.post_alert({
         entity_id,
-        `PR #${String(pr.number)}: "${pr.title}" — all reviews dismissed, will re-review next cycle`,
-      );
+        tier: "routine",
+        title: `PR #${String(pr.number)} reviews dismissed`,
+        body: `"${pr.title}" — all reviews dismissed, will re-review next cycle`,
+      });
     } else {
       // Notify completion without specific action
-      await this.notify_alerts(
+      await this.alert_router?.post_alert({
         entity_id,
-        `PR #${String(pr.number)} review completed: "${pr.title}"`,
-      );
+        tier: "routine",
+        title: `PR #${String(pr.number)} review completed`,
+        body: `"${pr.title}"`,
+      });
     }
   }
 
@@ -828,18 +833,23 @@ export class PRReviewCron {
         await save_pr_reviews(this.processed, this.config);
 
         await this.close_issues_for_merged_pr(entity_id, repo_path, pr, entity_config);
-        await this.notify_alerts(
+        await this.alert_router?.post_alert({
           entity_id,
-          `PR #${String(pr.number)}: ${pr.title} — CI passed, auto-merged (${result.method})`,
-        );
+          tier: "routine",
+          title: `PR #${String(pr.number)} merged`,
+          body: `${pr.title} — CI passed, auto-merged (${result.method})`,
+        });
 
         // Clean up local worktrees for the merged branch
         await try_cleanup_worktree(repo_path, pr.headRefName, pr.number);
       } else {
-        await this.notify_alerts(
+        await this.alert_router?.post_alert({
           entity_id,
-          `PR #${String(pr.number)}: ${pr.title} — approved, CI passed, but merge failed. ${result.error ?? "Manual intervention needed."}`,
-        );
+          tier: "action_required",
+          title: `\u26a0\ufe0f Merge failed — PR #${String(pr.number)}`,
+          body: `${pr.title} — approved, CI passed, but merge failed. ${result.error ?? "Manual intervention needed."}`,
+          embed_color: ALERT_COLOR_AMBER,
+        });
       }
     }
   }
@@ -927,10 +937,12 @@ export class PRReviewCron {
     const attempts = this.processed[key]?.ci_fix_attempts ?? 0;
 
     if (attempts >= MAX_CI_FIX_ATTEMPTS) {
-      await this.notify_alerts(
+      await this.alert_router?.post_alert({
         entity_id,
-        `PR #${String(pr.number)}: ${pr.title} — CI fix failed after ${String(MAX_CI_FIX_ATTEMPTS)} attempts. Needs human intervention. Failed checks: ${failed_checks.join(", ")}`,
-      );
+        tier: "action_required",
+        title: `\u{1f6d1} CI fix exhausted — PR #${String(pr.number)}`,
+        body: `${pr.title} — failed after ${String(MAX_CI_FIX_ATTEMPTS)} attempts. Needs human intervention. Failed: ${failed_checks.join(", ")}`,
+      });
       return true; // handled — cap reached, don't retry this failure set
     }
 
@@ -994,10 +1006,12 @@ export class PRReviewCron {
       `[pr-cron] Spawning CI fix builder for PR #${String(pr.number)} in ${entity_id} (attempt ${String(attempts + 1)}/${String(MAX_CI_FIX_ATTEMPTS)})`,
     );
 
-    await this.notify_alerts(
+    await this.alert_router?.post_alert({
       entity_id,
-      `PR #${String(pr.number)}: ${pr.title} — approved but CI failed (${failed_checks.join(", ")}), spawning builder to fix (attempt ${String(attempts + 1)}/${String(MAX_CI_FIX_ATTEMPTS)})`,
-    );
+      tier: "routine",
+      title: `PR #${String(pr.number)} CI fix spawned`,
+      body: `${pr.title} — CI failed (${failed_checks.join(", ")}), spawning builder (attempt ${String(attempts + 1)}/${String(MAX_CI_FIX_ATTEMPTS)})`,
+    });
 
     let fix_env: Record<string, string> | undefined;
     if (gh_token) {
@@ -1029,13 +1043,7 @@ export class PRReviewCron {
     return true;
   }
 
-  /** Send a notification to the entity's alerts channel. */
-  private async notify_alerts(entity_id: string, message: string): Promise<void> {
-    console.log(`[pr-cron:alerts] ${message}`);
-    if (this.discord) {
-      await this.discord.send_to_entity(entity_id, "alerts", message, "reviewer" as ArchetypeRole);
-    }
-  }
+  // notify_alerts removed — all call sites migrated to this.alert_router.post_alert()
 
   /** Check if a PR has been merged. */
   private async check_pr_merged(

--- a/packages/daemon/src/sentry-triage.ts
+++ b/packages/daemon/src/sentry-triage.ts
@@ -47,7 +47,7 @@ export interface SentryTriageContext {
   registry: EntityRegistry;
   discord: DiscordBot | null;
   config: LobsterFarmConfig;
-  alert_router?: AlertRouter | null;
+  alert_router: AlertRouter | null;
 }
 
 // ── Sentry webhook payload shapes ──

--- a/packages/daemon/src/sentry-triage.ts
+++ b/packages/daemon/src/sentry-triage.ts
@@ -24,6 +24,7 @@ import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { expand_home, lobsterfarm_dir } from "@lobster-farm/shared";
 import type { LobsterFarmConfig } from "@lobster-farm/shared";
+import type { AlertRouter } from "./alert-router.js";
 import type { DiscordBot } from "./discord.js";
 import type { EntityRegistry } from "./registry.js";
 import { MAX_SENTRY_FIX_ATTEMPTS, build_sentry_fix_prompt } from "./review-utils.js";
@@ -46,6 +47,7 @@ export interface SentryTriageContext {
   registry: EntityRegistry;
   discord: DiscordBot | null;
   config: LobsterFarmConfig;
+  alert_router?: AlertRouter | null;
 }
 
 // ── Sentry webhook payload shapes ──
@@ -840,16 +842,15 @@ export async function handle_sentry_triage_event(
         `[sentry-triage] Queue full (${String(MAX_QUEUE_DEPTH)} items) — ` +
           `dropping triage for ${sentry_issue_id}. Too many errors arriving simultaneously.`,
       );
-      if (ctx.discord) {
-        await ctx.discord
-          .send_to_entity(
+      if (ctx.alert_router) {
+        await ctx.alert_router
+          .post_alert({
             entity_id,
-            "alerts",
-            `Sentry triage queue full (${String(MAX_QUEUE_DEPTH)} items). ` +
-              `Dropping triage for: ${issue_details.title}\n${issue_details.web_url}`,
-            "system",
-          )
-          .catch((e) => console.error(`[sentry-triage] Discord alert error: ${String(e)}`));
+            tier: "action_required",
+            title: "\u26a0\ufe0f Sentry triage queue full",
+            body: `${String(MAX_QUEUE_DEPTH)} items queued. Dropping triage for: ${issue_details.title}\n${issue_details.web_url}`,
+          })
+          .catch((e) => console.error(`[sentry-triage] Alert router error: ${String(e)}`));
       }
       return;
     }

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -4,6 +4,7 @@ import type { LobsterFarmConfig } from "@lobster-farm/shared";
 import { DAEMON_PORT } from "@lobster-farm/shared";
 import { type ArchetypeRole, expand_home } from "@lobster-farm/shared";
 import { persist_entity_config } from "./actions.js";
+import { ALERT_COLOR_RED, type AlertRouter } from "./alert-router.js";
 import type { CommanderProcess } from "./commander-process.js";
 import { is_discord_snowflake } from "./discord.js";
 import type { DiscordBot } from "./discord.js";
@@ -38,6 +39,7 @@ interface ServerContext {
   pool: BotPool | null;
   github_app: GitHubAppAuth | null;
   pr_watches: PRWatchStore | null;
+  alert_router: AlertRouter | null;
 }
 
 type RouteHandler = (
@@ -146,6 +148,7 @@ const handle_webhook_github: RouteHandler = async (req, res, ctx) => {
     config: ctx.config,
     pool: ctx.pool,
     pr_watches: ctx.pr_watches,
+    alert_router: ctx.alert_router,
   };
 
   await handle_github_webhook(req, res, webhook_ctx);
@@ -286,6 +289,7 @@ async function process_sentry_webhook(
       registry: ctx.registry,
       discord: ctx.discord,
       config: ctx.config,
+      alert_router: ctx.alert_router,
     };
 
     // Fire-and-forget: triage runs async; failure is caught inside
@@ -326,11 +330,38 @@ async function process_sentry_webhook(
     issue_url,
   });
 
-  if (ctx.discord) {
+  // Route through the tiered alert system (#253).
+  // error/fatal + triage-worthy (created/regression) → incident_open (top-level embed + thread)
+  // warning/other or non-triage actions → routine (daily thread)
+  const sentry_level = (issue?.level as string) ?? "error";
+  const is_triage_worthy = triage_actions.includes(action ?? "");
+  const is_high_severity = sentry_level === "fatal" || sentry_level === "error";
+  const effective_entity_id = target_entity_id ?? ctx.registry.get_active()[0]?.entity.id ?? null;
+
+  if (ctx.alert_router && effective_entity_id) {
+    if (is_triage_worthy && is_high_severity) {
+      // Tier 3: incident thread for error/fatal triage events
+      await ctx.alert_router.post_alert({
+        entity_id: effective_entity_id,
+        tier: "incident_open",
+        title: `\u{1f534} Sentry [${sentry_level}]: ${error_title}`,
+        body: alert_message,
+        embed_color: ALERT_COLOR_RED,
+      });
+    } else {
+      // Tier 2: routine (resolved, unresolved, warnings, P2/P3)
+      await ctx.alert_router.post_alert({
+        entity_id: effective_entity_id,
+        tier: "routine",
+        title: `Sentry [${action ?? "event"}]`,
+        body: alert_message,
+      });
+    }
+  } else if (ctx.discord) {
+    // Fallback: no alert_router, use direct Discord send
     if (target_entity_id) {
       await ctx.discord.send_to_entity(target_entity_id, "alerts", alert_message, "system");
     } else {
-      // No entity mapping — post to first active entity's alerts as a catch-all
       const first_active = ctx.registry.get_active()[0];
       if (first_active) {
         await ctx.discord.send_to_entity(first_active.entity.id, "alerts", alert_message, "system");
@@ -776,6 +807,7 @@ export function start_server(
   pool: BotPool | null = null,
   github_app: GitHubAppAuth | null = null,
   pr_watches: PRWatchStore | null = null,
+  alert_router: AlertRouter | null = null,
   port: number = DAEMON_PORT,
 ): Server {
   const ctx: ServerContext = {
@@ -788,6 +820,7 @@ export function start_server(
     pool,
     github_app,
     pr_watches,
+    alert_router,
   };
 
   const server = createServer((req, res) => {

--- a/packages/daemon/src/webhook-handler.ts
+++ b/packages/daemon/src/webhook-handler.ts
@@ -16,6 +16,7 @@ import type { ArchetypeRole } from "@lobster-farm/shared";
 import { expand_home } from "@lobster-farm/shared";
 import type { LobsterFarmConfig } from "@lobster-farm/shared";
 import { type ReviewOutcome, detect_review_outcome } from "./actions.js";
+import { ALERT_COLOR_AMBER, ALERT_COLOR_RED, type AlertRouter } from "./alert-router.js";
 import {
   type CheckSuiteWebhookPayload,
   handle_check_suite,
@@ -71,6 +72,7 @@ export interface WebhookContext {
   config: LobsterFarmConfig;
   pool: BotPool | null;
   pr_watches: PRWatchStore | null;
+  alert_router: AlertRouter | null;
 }
 
 /** Minimal PR shape from webhook payload. */
@@ -735,11 +737,12 @@ async function handle_review_completion(
   if (outcome === "changes_requested") {
     // Spawn builder to fix
     await spawn_fixer(entity_id, repo_path, pr, ctx, installation_id);
-    await notify_alerts(
+    await ctx.alert_router?.post_alert({
       entity_id,
-      `PR #${String(pr.number)}: ${pr.title} — changes requested, spawning builder to fix`,
-      ctx,
-    );
+      tier: "routine",
+      title: `PR #${String(pr.number)} changes requested`,
+      body: `${pr.title} — spawning builder to fix`,
+    });
     // Informational: let the watching bot know review feedback arrived.
     // Not terminal — the fix loop will push new commits, triggering re-review.
     // The watch stays alive so the bot gets the final merged/closed event.
@@ -783,11 +786,12 @@ async function handle_review_completion(
 
           if (result.merged) {
             await post_auto_merge_cleanup(pr, entity_id, repo_path, ctx, installation_id);
-            await notify_alerts(
+            await ctx.alert_router?.post_alert({
               entity_id,
-              `PR #${String(pr.number)}: ${pr.title} — approved and merged (pr-cron disabled, CI pending bypassed)`,
-              ctx,
-            );
+              tier: "routine",
+              title: `PR #${String(pr.number)} merged`,
+              body: `${pr.title} — approved and merged (CI pending bypassed)`,
+            });
             await notify_pr_watcher(
               repo_full_name,
               pr.number,
@@ -796,11 +800,13 @@ async function handle_review_completion(
             );
           } else {
             const failure_tag = result.failure ? ` [${result.failure}]` : "";
-            await notify_alerts(
+            await ctx.alert_router?.post_alert({
               entity_id,
-              `PR #${String(pr.number)}: ${pr.title} — approved but CI checks pending and pr-cron is disabled. Merge failed${failure_tag}: ${result.error ?? "manual intervention needed."}`,
-              ctx,
-            );
+              tier: "action_required",
+              title: `\u26a0\ufe0f Merge failed — PR #${String(pr.number)}`,
+              body: `${pr.title} — CI pending, pr-cron disabled. Merge failed${failure_tag}: ${result.error ?? "manual intervention needed."}`,
+              embed_color: ALERT_COLOR_AMBER,
+            });
           }
         }
       } else if (ci.failures.length > 0) {
@@ -819,11 +825,12 @@ async function handle_review_completion(
         if (result.merged) {
           // Post-merge cleanup: close linked issues and clean up worktrees
           await post_auto_merge_cleanup(pr, entity_id, repo_path, ctx, installation_id);
-          await notify_alerts(
+          await ctx.alert_router?.post_alert({
             entity_id,
-            `PR #${String(pr.number)}: ${pr.title} — approved, auto-rebased (${result.method}), and merged`,
-            ctx,
-          );
+            tier: "routine",
+            title: `PR #${String(pr.number)} merged`,
+            body: `${pr.title} — approved, auto-rebased (${result.method}), and merged`,
+          });
           // Auto-merged — notify watching bot
           await notify_pr_watcher(
             repo_full_name,
@@ -833,19 +840,22 @@ async function handle_review_completion(
           );
         } else {
           const failure_tag = result.failure ? ` [${result.failure}]` : "";
-          await notify_alerts(
+          await ctx.alert_router?.post_alert({
             entity_id,
-            `PR #${String(pr.number)}: ${pr.title} — approved but merge failed${failure_tag}. ${result.error ?? "Manual intervention needed."}`,
-            ctx,
-          );
+            tier: "action_required",
+            title: `\u26a0\ufe0f Merge failed — PR #${String(pr.number)}`,
+            body: `${pr.title} — approved but merge failed${failure_tag}. ${result.error ?? "Manual intervention needed."}`,
+            embed_color: ALERT_COLOR_AMBER,
+          });
         }
       }
     } else {
-      await notify_alerts(
+      await ctx.alert_router?.post_alert({
         entity_id,
-        `PR #${String(pr.number)}: ${pr.title} — approved and merged`,
-        ctx,
-      );
+        tier: "routine",
+        title: `PR #${String(pr.number)} merged`,
+        body: `${pr.title} — approved and merged`,
+      });
       // Reviewer already merged — notify watching bot
       await notify_pr_watcher(
         repo_full_name,
@@ -863,17 +873,19 @@ async function handle_review_completion(
     console.log(
       `[webhook] All reviews dismissed on PR #${String(pr.number)} — will be re-reviewed next cycle`,
     );
-    await notify_alerts(
+    await ctx.alert_router?.post_alert({
       entity_id,
-      `PR #${String(pr.number)}: "${pr.title}" — all reviews dismissed, will re-review next cycle`,
-      ctx,
-    );
+      tier: "routine",
+      title: `PR #${String(pr.number)} reviews dismissed`,
+      body: `"${pr.title}" — all reviews dismissed, will re-review next cycle`,
+    });
   } else {
-    await notify_alerts(
+    await ctx.alert_router?.post_alert({
       entity_id,
-      `PR #${String(pr.number)} review completed: "${pr.title}" (${outcome})`,
-      ctx,
-    );
+      tier: "routine",
+      title: `PR #${String(pr.number)} review completed`,
+      body: `"${pr.title}" (${outcome})`,
+    });
   }
 }
 
@@ -1212,11 +1224,12 @@ async function spawn_ci_fixer(
   const attempts = entry?.ci_fix_attempts ?? 0;
 
   if (attempts >= MAX_CI_FIX_ATTEMPTS) {
-    await notify_alerts(
+    await ctx.alert_router?.post_alert({
       entity_id,
-      `PR #${String(pr.number)}: ${pr.title} — CI fix failed after ${String(MAX_CI_FIX_ATTEMPTS)} attempts. Needs human intervention. Failed checks: ${failed_checks.join(", ")}`,
-      ctx,
-    );
+      tier: "action_required",
+      title: `\u{1f6d1} CI fix exhausted — PR #${String(pr.number)}`,
+      body: `${pr.title} — failed after ${String(MAX_CI_FIX_ATTEMPTS)} attempts. Needs human intervention. Failed: ${failed_checks.join(", ")}`,
+    });
     return;
   }
 
@@ -1262,11 +1275,12 @@ async function spawn_ci_fixer(
     `[webhook] Spawning CI fix builder for PR #${String(pr.number)} in ${entity_id} (attempt ${String(attempts + 1)}/${String(MAX_CI_FIX_ATTEMPTS)})`,
   );
 
-  await notify_alerts(
+  await ctx.alert_router?.post_alert({
     entity_id,
-    `PR #${String(pr.number)}: ${pr.title} — approved but CI failed (${failed_checks.join(", ")}), spawning builder to fix (attempt ${String(attempts + 1)}/${String(MAX_CI_FIX_ATTEMPTS)})`,
-    ctx,
-  );
+    tier: "routine",
+    title: `PR #${String(pr.number)} CI fix spawned`,
+    body: `${pr.title} — CI failed (${failed_checks.join(", ")}), spawning builder (attempt ${String(attempts + 1)}/${String(MAX_CI_FIX_ATTEMPTS)})`,
+  });
 
   try {
     await ctx.session_manager.spawn({
@@ -1324,12 +1338,12 @@ async function spawn_deploy_triage(
       `[webhook] Deploy triage exhausted for ${triage_key} ` +
         `(${String(existing.fix_attempts)}/${String(MAX_DEPLOY_FIX_ATTEMPTS)}) — skipping`,
     );
-    await notify_alerts(
+    await ctx.alert_router?.post_alert({
       entity_id,
-      `Deploy fix loop exhausted for workflow "${workflow.name}" ` +
-        `(${String(MAX_DEPLOY_FIX_ATTEMPTS)} attempts). Manual intervention needed. ${workflow.html_url}`,
-      ctx,
-    );
+      tier: "action_required",
+      title: `\u{1f6d1} Deploy fix exhausted — ${workflow.name}`,
+      body: `${String(MAX_DEPLOY_FIX_ATTEMPTS)} attempts failed. Manual intervention needed. ${workflow.html_url}`,
+    });
     return;
   }
 
@@ -1349,12 +1363,12 @@ async function spawn_deploy_triage(
       `[webhook] Deploy safety valve triggered for ${entity_id} ` +
         `(${String(entity_attempts_24h)} attempts in 24h) — skipping`,
     );
-    await notify_alerts(
+    await ctx.alert_router?.post_alert({
       entity_id,
-      `Deploy auto-triage paused for ${entity_id}: ${String(entity_attempts_24h)} fix attempts ` +
-        `in 24h (safety valve = ${String(DEPLOY_SAFETY_VALVE)}). Manual intervention needed.`,
-      ctx,
-    );
+      tier: "action_required",
+      title: `\u{1f6d1} Deploy safety valve — ${entity_id}`,
+      body: `${String(entity_attempts_24h)} fix attempts in 24h (safety valve = ${String(DEPLOY_SAFETY_VALVE)}). Auto-triage paused. Manual intervention needed.`,
+    });
     return;
   }
 
@@ -1408,11 +1422,13 @@ async function spawn_deploy_triage(
       `(run ${String(workflow.id)}, attempt ${String(attempt)}/${String(MAX_DEPLOY_FIX_ATTEMPTS)})`,
   );
 
-  await notify_alerts(
+  await ctx.alert_router?.post_alert({
     entity_id,
-    `\u26a0\ufe0f Deploy failed on main — Gary triaging (attempt ${String(attempt)}/${String(MAX_DEPLOY_FIX_ATTEMPTS)}). ${workflow.html_url}`,
-    ctx,
-  );
+    tier: "action_required",
+    title: "\u26a0\ufe0f Deploy failed on main",
+    body: `Gary triaging "${workflow.name}" (attempt ${String(attempt)}/${String(MAX_DEPLOY_FIX_ATTEMPTS)}). ${workflow.html_url}`,
+    embed_color: ALERT_COLOR_RED,
+  });
 
   try {
     await ctx.session_manager.spawn({
@@ -1854,16 +1870,7 @@ async function handle_workflow_run(payload: WebhookPayload, ctx: WebhookContext)
 
 // ── Utility helpers ──
 
-async function notify_alerts(
-  entity_id: string,
-  message: string,
-  ctx: WebhookContext,
-): Promise<void> {
-  console.log(`[webhook:alerts] ${message}`);
-  if (ctx.discord) {
-    await ctx.discord.send_to_entity(entity_id, "alerts", message, "reviewer" as ArchetypeRole);
-  }
-}
+// notify_alerts removed — all call sites migrated to ctx.alert_router.post_alert()
 
 /**
  * Check if any bot is watching this PR and, if so, inject the event message

--- a/packages/daemon/src/webhook-handler.ts
+++ b/packages/daemon/src/webhook-handler.ts
@@ -949,11 +949,12 @@ export async function handle_v2_review_completion(
     }
 
     await spawn_fixer(entity_id, repo_path, pr, ctx, installation_id);
-    await notify_alerts(
+    await ctx.alert_router?.post_alert({
       entity_id,
-      `PR #${String(pr.number)}: ${pr.title} — changes requested, spawning builder to fix`,
-      ctx,
-    );
+      tier: "routine",
+      title: `PR #${String(pr.number)} changes requested`,
+      body: `${pr.title} — spawning builder to fix`,
+    });
     await notify_pr_watcher(
       repo_full_name,
       pr.number,
@@ -966,11 +967,13 @@ export async function handle_v2_review_completion(
 
   if (outcome === "approved") {
     if (!gh_token) {
-      await notify_alerts(
+      await ctx.alert_router?.post_alert({
         entity_id,
-        `PR #${String(pr.number)}: ${pr.title} — approved but no GH token available for merge-gate. Manual intervention needed.`,
-        ctx,
-      );
+        tier: "action_required",
+        title: `\u26a0\ufe0f No GH token — PR #${String(pr.number)}`,
+        body: `${pr.title} — approved but no GH token available for merge-gate. Manual intervention needed.`,
+        embed_color: ALERT_COLOR_AMBER,
+      });
       return;
     }
 
@@ -994,11 +997,12 @@ export async function handle_v2_review_completion(
     switch (gate_outcome.kind) {
       case "merged":
         await post_auto_merge_cleanup(pr, entity_id, repo_path, ctx, installation_id);
-        await notify_alerts(
+        await ctx.alert_router?.post_alert({
           entity_id,
-          `PR #${String(pr.number)}: ${pr.title} — approved, merge-gate passed, merged (${gate_outcome.method})`,
-          ctx,
-        );
+          tier: "routine",
+          title: `PR #${String(pr.number)} merged`,
+          body: `${pr.title} — approved, merge-gate passed, merged (${gate_outcome.method})`,
+        });
         await notify_pr_watcher(
           repo_full_name,
           pr.number,
@@ -1008,22 +1012,25 @@ export async function handle_v2_review_completion(
         return;
 
       case "ci_regressed":
-        await notify_alerts(
+        await ctx.alert_router?.post_alert({
           entity_id,
-          `PR #${String(pr.number)}: ${pr.title} — approved but CI regressed on gate check (${gate_outcome.failures.join(", ")}). A new commit on this PR is required to re-enter the review cycle.`,
-          ctx,
-        );
+          tier: "action_required",
+          title: `\u26a0\ufe0f CI regressed — PR #${String(pr.number)}`,
+          body: `${pr.title} — CI regressed on gate check (${gate_outcome.failures.join(", ")}). A new commit is required to re-enter the review cycle.`,
+          embed_color: ALERT_COLOR_AMBER,
+        });
         return;
 
       case "ci_pending":
         console.log(
           `[webhook:v2] merge-gate: CI pending for PR #${String(pr.number)} — dedup blocks re-dispatch on same SHA`,
         );
-        await notify_alerts(
+        await ctx.alert_router?.post_alert({
           entity_id,
-          `PR #${String(pr.number)}: ${pr.title} — approved but a CI check is still running on the reviewed SHA. Auto-merge is blocked until a new commit is pushed to re-enter the review cycle.`,
-          ctx,
-        );
+          tier: "routine",
+          title: `PR #${String(pr.number)} CI pending`,
+          body: `${pr.title} — approved but CI still running on reviewed SHA. Auto-merge blocked until new commit.`,
+        });
         return;
 
       case "sha_changed":
@@ -1044,19 +1051,23 @@ export async function handle_v2_review_completion(
         return;
 
       case "rebase_conflict":
-        await notify_alerts(
+        await ctx.alert_router?.post_alert({
           entity_id,
-          `PR #${String(pr.number)}: ${pr.title} — rebase conflict, manual resolution required. ${gate_outcome.error}`,
-          ctx,
-        );
+          tier: "action_required",
+          title: `\u26a0\ufe0f Rebase conflict — PR #${String(pr.number)}`,
+          body: `${pr.title} — rebase conflict, manual resolution required. ${gate_outcome.error}`,
+          embed_color: ALERT_COLOR_AMBER,
+        });
         return;
 
       case "branch_protected":
-        await notify_alerts(
+        await ctx.alert_router?.post_alert({
           entity_id,
-          `PR #${String(pr.number)}: ${pr.title} — blocked by branch protection (${gate_outcome.merge_state_status}). Human eyes required.`,
-          ctx,
-        );
+          tier: "action_required",
+          title: `\u{1f6d1} Branch protected — PR #${String(pr.number)}`,
+          body: `${pr.title} — blocked by branch protection (${gate_outcome.merge_state_status}). Human eyes required.`,
+          embed_color: ALERT_COLOR_RED,
+        });
         return;
 
       case "mergeable_unknown":
@@ -1066,11 +1077,13 @@ export async function handle_v2_review_completion(
         return;
 
       case "merge_failed":
-        await notify_alerts(
+        await ctx.alert_router?.post_alert({
           entity_id,
-          `PR #${String(pr.number)}: ${pr.title} — merge-gate failed: ${gate_outcome.error}`,
-          ctx,
-        );
+          tier: "action_required",
+          title: `\u26a0\ufe0f Merge failed — PR #${String(pr.number)}`,
+          body: `${pr.title} — merge-gate failed: ${gate_outcome.error}`,
+          embed_color: ALERT_COLOR_AMBER,
+        });
         return;
     }
   }
@@ -1081,20 +1094,22 @@ export async function handle_v2_review_completion(
     console.log(
       `[webhook:v2] All reviews dismissed on PR #${String(pr.number)} — will be re-reviewed next cycle`,
     );
-    await notify_alerts(
+    await ctx.alert_router?.post_alert({
       entity_id,
-      `PR #${String(pr.number)}: "${pr.title}" — all reviews dismissed, will re-review next cycle`,
-      ctx,
-    );
+      tier: "routine",
+      title: `PR #${String(pr.number)} reviews dismissed`,
+      body: `"${pr.title}" — all reviews dismissed, will re-review next cycle`,
+    });
     return;
   }
 
   // outcome === "pending"
-  await notify_alerts(
+  await ctx.alert_router?.post_alert({
     entity_id,
-    `PR #${String(pr.number)} review completed: "${pr.title}" (${outcome})`,
-    ctx,
-  );
+    tier: "routine",
+    title: `PR #${String(pr.number)} review completed`,
+    body: `"${pr.title}" (${outcome})`,
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary
- Introduce `AlertRouter` class with `post_alert()` as single entry point routing notifications into three tiers: `action_required` (top-level embeds with red/amber color), `routine` (daily activity threads titled "Activity — Mon DD"), and `incident_open`/`incident_update` (per-incident threads with lifecycle tracking)
- Migrate all 24 `notify_alerts()` / `send_to_entity("alerts", ...)` call sites across `webhook-handler.ts`, `pr-cron.ts`, `sentry-triage.ts`, and `server.ts` to the new router
- Add 6 new Discord.js primitives to `DiscordBot`: `send_embed`, `create_thread_from_message`, `send_to_thread`, `edit_message_embed`, `find_thread_by_name`, `get_entity_channel_id`
- Persist active incident thread IDs to `~/.lobsterfarm/state/active-incidents.json` (atomic write-to-temp-then-rename)
- Daily thread IDs cached in-memory with Discord scan fallback on restart

Closes #253

## Test plan
- [x] 17 new tests in `alert-router.test.ts` covering all tiers, persistence round-trip, edge cases (no Discord, no channel, missing incident_id)
- [x] Updated assertions in 6 existing test files (`ci-gating`, `ci-fix-loop`, `deploy-triage`, `pr-cron`, `pr-cron-author`, `sentry-triage`) to verify alerts flow through `alert_router.post_alert()` instead of removed `notify_alerts`/`send_to_entity`
- [x] All 855 tests pass (`pnpm test`)
- [x] TypeScript compiles clean (`pnpm typecheck`)
- [x] Biome lint/format clean (`pnpm exec biome check packages/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)