### PR TITLE
fix: wire GH_TOKEN into sentry triage and auto-fix sessions

### DIFF
--- a/packages/daemon/src/__tests__/sentry-triage.test.ts
+++ b/packages/daemon/src/__tests__/sentry-triage.test.ts
@@ -152,6 +152,7 @@ function make_context(overrides: Partial<SentryTriageContext> = {}): SentryTriag
     registry: make_registry(),
     discord: make_discord(),
     config: make_config(),
+    github_app: null,
     ...overrides,
   };
 }

--- a/packages/daemon/src/__tests__/sentry-triage.test.ts
+++ b/packages/daemon/src/__tests__/sentry-triage.test.ts
@@ -43,6 +43,7 @@ vi.mock("../sentry-api.js", async (importOriginal) => {
 
 import type { LobsterFarmConfig } from "@lobster-farm/shared";
 import type { DiscordBot } from "../discord.js";
+import type { GitHubAppAuth } from "../github-app.js";
 import type { EntityRegistry } from "../registry.js";
 import { build_sentry_fix_prompt } from "../review-utils.js";
 import { format_stack_trace } from "../sentry-api.js";
@@ -144,6 +145,15 @@ function make_discord(): DiscordBot {
   return {
     send_to_entity: vi.fn().mockResolvedValue(undefined),
   } as unknown as DiscordBot;
+}
+
+function make_github_app(): GitHubAppAuth {
+  return {
+    get_token: vi.fn().mockResolvedValue("ghs_mock_token"),
+    get_token_for_installation: vi
+      .fn()
+      .mockImplementation((id: string) => Promise.resolve(`ghs_install_${id}`)),
+  } as unknown as GitHubAppAuth;
 }
 
 function make_context(overrides: Partial<SentryTriageContext> = {}): SentryTriageContext {
@@ -1205,5 +1215,146 @@ describe("build_sentry_fix_prompt", () => {
     expect(prompt).toContain("**Culprit:** src/handler.ts in process");
     expect(prompt).toContain("at handler.ts:99");
     expect(prompt).toContain("Do NOT merge the PR");
+  });
+});
+
+// ── GH_TOKEN injection tests ──
+
+describe("GH_TOKEN injection", () => {
+  it("passes GH_TOKEN to spawned Ray triage session", async () => {
+    const github_app = make_github_app();
+    const ctx = make_context({ github_app });
+    const sm = ctx.session_manager as unknown as { spawn: ReturnType<typeof vi.fn> };
+
+    await handle_sentry_triage_event("ISSUE-GH", "test-backend", "created", ctx);
+
+    expect(sm.spawn).toHaveBeenCalledTimes(1);
+    const triage_spawn = sm.spawn.mock.calls[0]![0] as { env: Record<string, string> };
+    expect(triage_spawn.env).toEqual({ GH_TOKEN: "ghs_mock_token" });
+  });
+
+  it("passes GH_TOKEN to spawned Bob fix session", async () => {
+    const github_app = make_github_app();
+    const session_manager = make_session_manager();
+    const ctx = make_context({ github_app, session_manager });
+    const sm = session_manager as unknown as { spawn: ReturnType<typeof vi.fn> };
+
+    let spawn_count = 0;
+    sm.spawn.mockImplementation(async () => {
+      spawn_count++;
+      return {
+        session_id: `session-${String(spawn_count)}`,
+        entity_id: "test-entity",
+        feature_id: spawn_count === 1 ? "sentry-triage-ISSUE-FIX-GH" : "sentry-fix-ISSUE-FIX-GH",
+        archetype: spawn_count === 1 ? "operator" : "builder",
+        started_at: new Date(),
+        pid: 10000 + spawn_count,
+      };
+    });
+
+    // Trigger triage
+    await handle_sentry_triage_event("ISSUE-FIX-GH", "test-backend", "created", ctx);
+    expect(sm.spawn).toHaveBeenCalledTimes(1);
+
+    // Complete triage with auto-fixable verdict
+    (session_manager as unknown as EventEmitter).emit("session:completed", {
+      session_id: "session-1",
+      exit_code: 0,
+      output_lines: [
+        'SENTRY_TRIAGE_VERDICT:{"severity":"P1","auto_fixable":true,"github_issue":42,"fix_approach":"Fix null check"}',
+      ],
+    });
+
+    // Wait for async fix spawn
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    // Should have spawned 2 sessions: triage + fix
+    expect(sm.spawn).toHaveBeenCalledTimes(2);
+
+    // Verify the fix session (second spawn) got GH_TOKEN
+    const fix_spawn = sm.spawn.mock.calls[1]![0] as { env: Record<string, string> };
+    expect(fix_spawn.env).toEqual({ GH_TOKEN: "ghs_mock_token" });
+  });
+
+  it("spawns without GH_TOKEN when token resolution fails", async () => {
+    const github_app = make_github_app();
+    const ga = github_app as unknown as { get_token: ReturnType<typeof vi.fn> };
+    ga.get_token.mockRejectedValue(new Error("token refresh failed"));
+
+    const ctx = make_context({ github_app });
+    const sm = ctx.session_manager as unknown as { spawn: ReturnType<typeof vi.fn> };
+
+    await handle_sentry_triage_event("ISSUE-NO-GH", "test-backend", "created", ctx);
+
+    // Should still spawn — just without the token
+    expect(sm.spawn).toHaveBeenCalledTimes(1);
+    const triage_spawn = sm.spawn.mock.calls[0]![0] as { env: undefined };
+    expect(triage_spawn.env).toBeUndefined();
+  });
+
+  it("does not set env when github_app is null", async () => {
+    const ctx = make_context({ github_app: null });
+    const sm = ctx.session_manager as unknown as { spawn: ReturnType<typeof vi.fn> };
+
+    await handle_sentry_triage_event("ISSUE-NO-APP", "test-backend", "created", ctx);
+
+    expect(sm.spawn).toHaveBeenCalledTimes(1);
+    const triage_spawn = sm.spawn.mock.calls[0]![0] as { env: undefined };
+    expect(triage_spawn.env).toBeUndefined();
+  });
+
+  it("uses entity-specific installation ID when configured", async () => {
+    const github_app = make_github_app();
+    const registry = {
+      get_active: vi.fn().mockReturnValue([
+        {
+          entity: {
+            id: "test-entity",
+            name: "Test Entity",
+            accounts: {
+              sentry: {
+                projects: [{ slug: "test-backend", type: "backend", repo: "test-repo" }],
+              },
+              github: {
+                github_app_installation_id: "67890",
+              },
+            },
+            repos: [
+              {
+                name: "test-repo",
+                url: "https://github.com/test-org/test-repo.git",
+                path: "/tmp/test-repo",
+              },
+            ],
+          },
+        },
+      ]),
+      get: vi.fn().mockReturnValue({
+        entity: {
+          id: "test-entity",
+          name: "Test Entity",
+          accounts: {
+            github: {
+              github_app_installation_id: "67890",
+            },
+          },
+        },
+      }),
+    } as unknown as EntityRegistry;
+
+    const ctx = make_context({ github_app, registry });
+    const sm = ctx.session_manager as unknown as { spawn: ReturnType<typeof vi.fn> };
+
+    await handle_sentry_triage_event("ISSUE-INSTALL", "test-backend", "created", ctx);
+
+    expect(sm.spawn).toHaveBeenCalledTimes(1);
+    const triage_spawn = sm.spawn.mock.calls[0]![0] as { env: Record<string, string> };
+    expect(triage_spawn.env).toEqual({ GH_TOKEN: "ghs_install_67890" });
+
+    // Verify get_token_for_installation was called with the entity's override ID
+    const ga = github_app as unknown as {
+      get_token_for_installation: ReturnType<typeof vi.fn>;
+    };
+    expect(ga.get_token_for_installation).toHaveBeenCalledWith("67890");
   });
 });

--- a/packages/daemon/src/sentry-triage.ts
+++ b/packages/daemon/src/sentry-triage.ts
@@ -489,7 +489,10 @@ async function resolve_gh_token(
       ? await github_app.get_token_for_installation(override_id)
       : await github_app.get_token();
   } catch (err) {
-    console.warn(`[sentry-triage] Failed to resolve GH token for ${entity_id}: ${String(err)}`);
+    console.error(`[sentry-triage] Failed to resolve GH token for ${entity_id}: ${String(err)}`);
+    sentry.captureException(err, {
+      tags: { module: "sentry-triage", entity: entity_id },
+    });
     return undefined;
   }
 }

--- a/packages/daemon/src/sentry-triage.ts
+++ b/packages/daemon/src/sentry-triage.ts
@@ -25,6 +25,7 @@ import { dirname, join } from "node:path";
 import { expand_home, lobsterfarm_dir } from "@lobster-farm/shared";
 import type { LobsterFarmConfig } from "@lobster-farm/shared";
 import type { DiscordBot } from "./discord.js";
+import type { GitHubAppAuth } from "./github-app.js";
 import type { EntityRegistry } from "./registry.js";
 import { MAX_SENTRY_FIX_ATTEMPTS, build_sentry_fix_prompt } from "./review-utils.js";
 import { get_cached_issue_details } from "./sentry-alert-format.js";
@@ -46,6 +47,7 @@ export interface SentryTriageContext {
   registry: EntityRegistry;
   discord: DiscordBot | null;
   config: LobsterFarmConfig;
+  github_app: GitHubAppAuth | null;
 }
 
 // ── Sentry webhook payload shapes ──
@@ -465,6 +467,33 @@ Rules for auto_fixable:
 Do NOT attempt to fix the code yourself. Diagnose only.`;
 }
 
+// ── GitHub token resolution ──
+
+/**
+ * Resolve a GitHub App installation token for the given entity.
+ * Uses the entity's `github_app_installation_id` if configured,
+ * otherwise falls back to the default installation from env.
+ *
+ * Same pattern as pr-cron's resolve_entity_token, extracted as a
+ * standalone function since sentry-triage doesn't live in a class.
+ */
+async function resolve_gh_token(
+  github_app: GitHubAppAuth,
+  entity_id: string,
+  registry: EntityRegistry,
+): Promise<string | undefined> {
+  const entry = registry.get(entity_id);
+  const override_id = entry?.entity.accounts?.github?.github_app_installation_id;
+  try {
+    return override_id
+      ? await github_app.get_token_for_installation(override_id)
+      : await github_app.get_token();
+  } catch (err) {
+    console.warn(`[sentry-triage] Failed to resolve GH token for ${entity_id}: ${String(err)}`);
+    return undefined;
+  }
+}
+
 // ── Queue processing ──
 
 async function process_queue(ctx: SentryTriageContext): Promise<void> {
@@ -521,6 +550,15 @@ async function spawn_triage_session(
 
   const prompt = build_triage_prompt(entity_name, project_info, issue_details, action);
 
+  // Resolve GitHub token so Ray can use `gh` CLI (issue creation, PR listing)
+  let spawn_env: Record<string, string> | undefined;
+  if (ctx.github_app) {
+    const gh_token = await resolve_gh_token(ctx.github_app, entity_id, ctx.registry);
+    if (gh_token) {
+      spawn_env = { GH_TOKEN: gh_token };
+    }
+  }
+
   let session: ActiveSession;
   try {
     session = await ctx.session_manager.spawn({
@@ -532,6 +570,7 @@ async function spawn_triage_session(
       worktree_path: repo_path,
       prompt,
       interactive: false,
+      env: spawn_env,
     });
   } catch (err) {
     console.error(
@@ -693,6 +732,15 @@ async function spawn_sentry_fix(
     culprit: issue_details.culprit,
   });
 
+  // Resolve GitHub token so Bob can push branches and open PRs
+  let spawn_env: Record<string, string> | undefined;
+  if (ctx.github_app) {
+    const gh_token = await resolve_gh_token(ctx.github_app, entity_id, ctx.registry);
+    if (gh_token) {
+      spawn_env = { GH_TOKEN: gh_token };
+    }
+  }
+
   console.log(
     `[sentry-triage] Spawning Bob for Sentry fix in ${entity_id} ` +
       `(issue ${sentry_issue_id}, attempt ${String(attempt)}/${String(MAX_SENTRY_FIX_ATTEMPTS)})`,
@@ -709,6 +757,7 @@ async function spawn_sentry_fix(
       worktree_path: repo_path,
       prompt,
       interactive: false,
+      env: spawn_env,
     });
   } catch (err) {
     console.error(

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -286,6 +286,7 @@ async function process_sentry_webhook(
       registry: ctx.registry,
       discord: ctx.discord,
       config: ctx.config,
+      github_app: ctx.github_app,
     };
 
     // Fire-and-forget: triage runs async; failure is caught inside


### PR DESCRIPTION
## Summary

- Add `github_app` to `SentryTriageContext` and pass it from `server.ts`
- Add `resolve_gh_token()` helper (mirrors pr-cron's `resolve_entity_token` pattern) to resolve per-entity GitHub App installation tokens
- Inject `GH_TOKEN` into both Ray (triage) and Bob (auto-fix) spawn environments so `gh` CLI works for issue creation and PR pushing

## Why

The sentry auto-heal pipeline spawns Ray and Bob sessions without `GH_TOKEN`, so `gh issue create`, `gh pr list`, and `git push` all fail silently. The auto-fix gate (`verdict.github_issue != null`) is never satisfied because Ray can't create the issue.

## Test plan

- [x] TypeScript: `tsc --noEmit` clean (0 errors)
- [x] Tests: 859/859 pass, including all 45 sentry-triage tests
- [x] Biome: clean on all changed files