### PR TITLE
fix: daemon drain completes before launchd kills process

### DIFF
--- a/packages/cli/src/__tests__/launchd.test.ts
+++ b/packages/cli/src/__tests__/launchd.test.ts
@@ -223,6 +223,12 @@ describe("generate_plist", () => {
     expect(result).toContain("com.lobsterfarm.daemon");
   });
 
+  it("includes ExitTimeout of 300 for graceful drain", () => {
+    const result = generate_plist("/w.sh", "/l.log", "/d");
+    expect(result).toContain("<key>ExitTimeout</key>");
+    expect(result).toContain("<integer>300</integer>");
+  });
+
   it("is synchronous (returns string, not Promise)", () => {
     const result = generate_plist("/w.sh", "/l.log", "/d");
 

--- a/packages/cli/src/commands/restart.ts
+++ b/packages/cli/src/commands/restart.ts
@@ -1,11 +1,14 @@
 import { execFileSync } from "node:child_process";
 import { chmod, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
 import { join } from "node:path";
-import { LAUNCHD_LABEL, pid_file_path } from "@lobster-farm/shared";
+import { LAUNCHD_LABEL, daemon_log_path, expand_home, pid_file_path } from "@lobster-farm/shared";
 import { Command } from "commander";
-import { generate_plist, generate_wrapper_sh, plist_path } from "../lib/launchd.js";
-import { is_service_loaded } from "../lib/launchd.js";
+import {
+  generate_plist,
+  generate_wrapper_sh,
+  is_service_loaded,
+  plist_path,
+} from "../lib/launchd.js";
 import { is_process_running, read_pid_file } from "../lib/process.js";
 import { resolve_daemon_path } from "./start.js";
 
@@ -33,10 +36,9 @@ export const restart_command = new Command("restart")
     // Regenerate the wrapper script and plist before restarting so the new
     // process picks up any changes (heap size, op run integration, daemon
     // path, ExitTimeout for graceful drain).
-    const home = homedir();
-    const wrapper_path = join(home, ".lobsterfarm", "bin", "start-daemon.sh");
-    const log_path = join(home, ".lobsterfarm", "logs", "daemon.log");
-    const working_dir = join(home, ".lobsterfarm");
+    const wrapper_path = join(expand_home("~/.lobsterfarm"), "bin", "start-daemon.sh");
+    const log_path = daemon_log_path();
+    const working_dir = expand_home("~/.lobsterfarm");
 
     const wrapper_content = generate_wrapper_sh(resolve_node_path(), resolve_daemon_path());
     await writeFile(wrapper_path, wrapper_content, { encoding: "utf-8", mode: 0o755 });
@@ -51,7 +53,7 @@ export const restart_command = new Command("restart")
     // starts a fresh one after ExitTimeout.  The daemon's shutdown handler
     // drains active sessions before exiting — pool bots survive the restart
     // and are rediscovered on startup via pool-state.json + tmux checks.
-    // Send a second SIGTERM (kill the PID) to force immediate shutdown.
+    // To force immediate shutdown, send SIGTERM directly: kill <pid>.
     const uid = process.getuid?.() ?? 501;
     execFileSync("launchctl", ["kickstart", "-k", `gui/${uid}/${LAUNCHD_LABEL}`]);
 

--- a/packages/cli/src/commands/restart.ts
+++ b/packages/cli/src/commands/restart.ts
@@ -4,7 +4,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { LAUNCHD_LABEL, pid_file_path } from "@lobster-farm/shared";
 import { Command } from "commander";
-import { generate_wrapper_sh } from "../lib/launchd.js";
+import { generate_plist, generate_wrapper_sh, plist_path } from "../lib/launchd.js";
 import { is_service_loaded } from "../lib/launchd.js";
 import { is_process_running, read_pid_file } from "../lib/process.js";
 import { resolve_daemon_path } from "./start.js";
@@ -30,23 +30,32 @@ export const restart_command = new Command("restart")
       return;
     }
 
-    // Regenerate the wrapper script before restarting so the new process
-    // picks up any changes (heap size, op run integration, daemon path).
+    // Regenerate the wrapper script and plist before restarting so the new
+    // process picks up any changes (heap size, op run integration, daemon
+    // path, ExitTimeout for graceful drain).
     const home = homedir();
     const wrapper_path = join(home, ".lobsterfarm", "bin", "start-daemon.sh");
+    const log_path = join(home, ".lobsterfarm", "logs", "daemon.log");
+    const working_dir = join(home, ".lobsterfarm");
+
     const wrapper_content = generate_wrapper_sh(resolve_node_path(), resolve_daemon_path());
     await writeFile(wrapper_path, wrapper_content, { encoding: "utf-8", mode: 0o755 });
     await chmod(wrapper_path, 0o755);
-    console.log("Regenerated wrapper script.");
+
+    const plist_content = generate_plist(wrapper_path, log_path, working_dir);
+    await writeFile(plist_path(), plist_content, { encoding: "utf-8" });
+
+    console.log("Regenerated wrapper script and plist.");
 
     // launchctl kickstart -k sends SIGTERM to the running process and
-    // immediately starts a fresh one.  Because the daemon's shutdown handler
-    // no longer kills tmux sessions, pool bots survive the restart and are
-    // rediscovered on startup via pool-state.json + tmux has-session checks.
+    // starts a fresh one after ExitTimeout.  The daemon's shutdown handler
+    // drains active sessions before exiting — pool bots survive the restart
+    // and are rediscovered on startup via pool-state.json + tmux checks.
+    // Send a second SIGTERM (kill the PID) to force immediate shutdown.
     const uid = process.getuid?.() ?? 501;
     execFileSync("launchctl", ["kickstart", "-k", `gui/${uid}/${LAUNCHD_LABEL}`]);
 
-    console.log("Daemon restarting... tmux sessions preserved.");
+    console.log("Daemon restarting — draining active sessions (up to 5 min)...");
 
     // Poll for the new process to start and write its PID file.
     const POLL_INTERVAL_MS = 500;

--- a/packages/cli/src/lib/launchd.ts
+++ b/packages/cli/src/lib/launchd.ts
@@ -174,6 +174,8 @@ export function generate_plist(
   <true/>
   <key>RunAtLoad</key>
   <true/>
+  <key>ExitTimeout</key>
+  <integer>300</integer>
 </dict>
 </plist>`;
 }


### PR DESCRIPTION
## Summary

- Add `ExitTimeout` (300s) to the launchd plist so the daemon's graceful drain has time to wait for active sessions to finish before launchd sends SIGKILL
- Regenerate the plist on `lf restart` so existing installs pick up the change automatically
- Update restart console output to reflect drain behavior

**Root cause:** launchd's default exit timeout (~5s) was killing the daemon before its drain loop could complete, interrupting active agent sessions mid-work.

Closes #276

## Test plan

- [ ] `pnpm -r run build` passes
- [ ] `pnpm -r run test` passes (780/780)
- [ ] Active sessions drain before daemon exits on restart
- [ ] Second SIGTERM still force-quits immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)