### PR TITLE
fix(pool): bridge_first_message retries with health-check drain fallback

### DIFF
--- a/packages/daemon/src/__tests__/bridge-drain.test.ts
+++ b/packages/daemon/src/__tests__/bridge-drain.test.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
 import type { LobsterFarmConfig } from "@lobster-farm/shared";
 import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { PoolBot } from "../pool.js";
+import { type PoolBot, pending_file_path } from "../pool.js";
 import { BotPoolTestBase } from "./helpers/test-bot-pool-base.js";
 
 // ── Mocks ──
@@ -164,7 +164,7 @@ describe("drain_pending_files (issue #278)", () => {
 
     // Pending file exists for this bot
     (access as Mock).mockImplementation(async (path: unknown) => {
-      if (path === "/tmp/lf-pending-pool-1.txt") return;
+      if (path === pending_file_path("pool-1")) return;
       throw new Error("ENOENT");
     });
 
@@ -173,9 +173,9 @@ describe("drain_pending_files (issue #278)", () => {
     // Verify delivery via tmux
     expect(mock_send_via_tmux).toHaveBeenCalledWith(
       "pool-1",
-      expect.stringContaining("/tmp/lf-pending-pool-1.txt"),
+      expect.stringContaining(pending_file_path("pool-1")),
     );
-    // Note: unlink is now delayed (setTimeout 30s) to give Claude time to read
+    // Note: unlink is now delayed (setTimeout 5s) to give Claude time to read
     // the file — not called synchronously after send_via_tmux
   });
 
@@ -206,7 +206,7 @@ describe("drain_pending_files (issue #278)", () => {
     pool.inject_bots([bot]);
 
     (access as Mock).mockImplementation(async (path: unknown) => {
-      if (path === "/tmp/lf-pending-pool-3.txt") return;
+      if (path === pending_file_path("pool-3")) return;
       throw new Error("ENOENT");
     });
     mock_is_at_prompt.mockReturnValue(false);
@@ -221,7 +221,7 @@ describe("drain_pending_files (issue #278)", () => {
         (c[1] as string).includes("lf-pending"),
     );
     expect(drain_calls).toHaveLength(0);
-    expect(unlink).not.toHaveBeenCalledWith("/tmp/lf-pending-pool-3.txt");
+    expect(unlink).not.toHaveBeenCalledWith(pending_file_path("pool-3"));
   });
 
   it("does not deliver when tmux session is dead", async () => {
@@ -236,7 +236,7 @@ describe("drain_pending_files (issue #278)", () => {
     pool.inject_bots([bot]);
 
     (access as Mock).mockImplementation(async (path: unknown) => {
-      if (path === "/tmp/lf-pending-pool-4.txt") return;
+      if (path === pending_file_path("pool-4")) return;
       throw new Error("ENOENT");
     });
     // Session dead — regular health check will try to restart, but drain won't fire
@@ -281,7 +281,7 @@ describe("drain_pending_files (issue #278)", () => {
       (c: unknown[]) => typeof c[1] === "string" && (c[1] as string).includes("lf-pending"),
     );
     expect(drain_calls).toHaveLength(0);
-    expect(unlink).not.toHaveBeenCalledWith("/tmp/lf-pending-pool-5.txt");
+    expect(unlink).not.toHaveBeenCalledWith(pending_file_path("pool-5"));
   });
 
   it("handles send_via_tmux failure gracefully", async () => {
@@ -296,7 +296,7 @@ describe("drain_pending_files (issue #278)", () => {
     pool.inject_bots([bot]);
 
     (access as Mock).mockImplementation(async (path: unknown) => {
-      if (path === "/tmp/lf-pending-pool-6.txt") return;
+      if (path === pending_file_path("pool-6")) return;
       throw new Error("ENOENT");
     });
     mock_send_via_tmux.mockImplementation(() => {

--- a/packages/daemon/src/__tests__/bridge-drain.test.ts
+++ b/packages/daemon/src/__tests__/bridge-drain.test.ts
@@ -1,0 +1,309 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
+import type { LobsterFarmConfig } from "@lobster-farm/shared";
+import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PoolBot } from "../pool.js";
+import { BotPoolTestBase } from "./helpers/test-bot-pool-base.js";
+
+// ── Mocks ──
+
+// Mock actions.ts — notify is imported by pool.ts for alerting
+vi.mock("../actions.js", () => ({
+  notify: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock persistence to avoid filesystem side effects
+vi.mock("../persistence.js", () => ({
+  save_pool_state: vi.fn().mockResolvedValue(undefined),
+  load_pool_state: vi.fn().mockResolvedValue({
+    bots: [],
+    session_history: {},
+    avatar_state: {},
+  }),
+}));
+
+// Mock sentry
+vi.mock("../sentry.js", () => ({
+  captureException: vi.fn(),
+  addBreadcrumb: vi.fn(),
+}));
+
+// Mock rate-limit-recovery (imported by pool.ts)
+vi.mock("../rate-limit-recovery.js", () => ({
+  scan_and_recover: vi.fn().mockReturnValue([]),
+}));
+
+// Mock node:fs/promises — we need control over access() and unlink()
+vi.mock("node:fs/promises", async () => {
+  const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+  return {
+    ...actual,
+    access: vi.fn().mockRejectedValue(new Error("ENOENT")),
+    unlink: vi.fn().mockResolvedValue(undefined),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    readFile: vi.fn().mockResolvedValue("{}"),
+    readdir: vi.fn().mockResolvedValue([]),
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    stat: vi.fn().mockRejectedValue(new Error("ENOENT")),
+  };
+});
+
+import { access, unlink } from "node:fs/promises";
+
+// ── Test helpers ──
+
+let temp_dir: string;
+
+function make_config(): LobsterFarmConfig {
+  return LobsterFarmConfigSchema.parse({
+    user: { name: "Test" },
+    paths: { lobsterfarm_dir: temp_dir },
+  });
+}
+
+function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
+  return {
+    state: "free",
+    channel_id: null,
+    entity_id: null,
+    archetype: null,
+    channel_type: null,
+    session_id: null,
+    session_confirmed: true,
+    tmux_session: `pool-${String(overrides.id)}`,
+    last_active: null,
+    assigned_at: null,
+    state_dir: `/tmp/test-pool-${String(overrides.id)}`,
+    model: null,
+    effort: null,
+    last_avatar_archetype: null,
+    last_avatar_set_at: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Test-friendly subclass that exposes internals for health check testing.
+ */
+class TestBotPool extends BotPoolTestBase {
+  inject_bots(bots: PoolBot[]): void {
+    (this as unknown as { bots: PoolBot[] }).bots = bots;
+  }
+
+  get_bots(): PoolBot[] {
+    return (this as unknown as { bots: PoolBot[] }).bots;
+  }
+
+  /** Expose protected method for direct testing. */
+  async run_health_check(): Promise<void> {
+    return this.check_assigned_health();
+  }
+}
+
+// ── Tests ──
+
+describe("drain_pending_files (issue #278)", () => {
+  let config: LobsterFarmConfig;
+  let pool: TestBotPool;
+  let mock_is_tmux_alive: ReturnType<typeof vi.fn>;
+  let mock_is_at_prompt: ReturnType<typeof vi.fn>;
+  let mock_send_via_tmux: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    temp_dir = join(tmpdir(), `bridge-drain-test-${Date.now()}`);
+    config = make_config();
+    pool = new TestBotPool(config);
+
+    // Stub side effects that check_assigned_health calls
+    vi.spyOn(pool as unknown as Record<string, unknown>, "kill_tmux" as never).mockImplementation(
+      () => {},
+    );
+
+    // Default: all tmux sessions are alive
+    mock_is_tmux_alive = vi
+      .spyOn(pool as unknown as Record<string, unknown>, "is_tmux_alive" as never)
+      .mockReturnValue(true) as unknown as ReturnType<typeof vi.fn>;
+
+    // Default: bot is at prompt (ready to receive)
+    mock_is_at_prompt = vi
+      .spyOn(pool as unknown as Record<string, unknown>, "is_at_prompt" as never)
+      .mockReturnValue(true) as unknown as ReturnType<typeof vi.fn>;
+
+    // Spy on send_via_tmux to verify delivery
+    mock_send_via_tmux = vi
+      .spyOn(pool as unknown as Record<string, unknown>, "send_via_tmux" as never)
+      .mockImplementation(() => {}) as unknown as ReturnType<typeof vi.fn>;
+
+    // Stub check_cwd_health to prevent real filesystem work
+    vi.spyOn(
+      pool as unknown as Record<string, unknown>,
+      "check_cwd_health" as never,
+    ).mockResolvedValue(undefined);
+
+    // Default: no pending files exist
+    (access as Mock).mockRejectedValue(new Error("ENOENT"));
+    (unlink as Mock).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("delivers pending file when bot is assigned, alive, and at prompt", async () => {
+    const bot = make_bot({
+      id: 1,
+      state: "assigned",
+      channel_id: "ch-1",
+      entity_id: "e1",
+      archetype: "planner",
+      session_id: "sess-1",
+    });
+    pool.inject_bots([bot]);
+
+    // Pending file exists for this bot
+    (access as Mock).mockImplementation(async (path: unknown) => {
+      if (path === "/tmp/lf-pending-pool-1.txt") return;
+      throw new Error("ENOENT");
+    });
+
+    await pool.run_health_check();
+
+    // Verify delivery via tmux
+    expect(mock_send_via_tmux).toHaveBeenCalledWith(
+      "pool-1",
+      expect.stringContaining("/tmp/lf-pending-pool-1.txt"),
+    );
+    // Verify cleanup
+    expect(unlink).toHaveBeenCalledWith("/tmp/lf-pending-pool-1.txt");
+  });
+
+  it("does not deliver when bot is not assigned", async () => {
+    const bot = make_bot({ id: 2, state: "free" });
+    pool.inject_bots([bot]);
+
+    (access as Mock).mockResolvedValue(undefined);
+
+    await pool.run_health_check();
+
+    // send_via_tmux should not have been called for this bot at all
+    const calls_for_bot = mock_send_via_tmux.mock.calls.filter(
+      (c: unknown[]) => (c[0] as string) === "pool-2",
+    );
+    expect(calls_for_bot).toHaveLength(0);
+  });
+
+  it("does not deliver when bot is not at prompt", async () => {
+    const bot = make_bot({
+      id: 3,
+      state: "assigned",
+      channel_id: "ch-3",
+      entity_id: "e1",
+      archetype: "planner",
+      session_id: "sess-3",
+    });
+    pool.inject_bots([bot]);
+
+    (access as Mock).mockImplementation(async (path: unknown) => {
+      if (path === "/tmp/lf-pending-pool-3.txt") return;
+      throw new Error("ENOENT");
+    });
+    mock_is_at_prompt.mockReturnValue(false);
+
+    await pool.run_health_check();
+
+    // send_via_tmux should not have been called for drain delivery
+    const drain_calls = mock_send_via_tmux.mock.calls.filter(
+      (c: unknown[]) =>
+        (c[0] as string) === "pool-3" &&
+        typeof c[1] === "string" &&
+        (c[1] as string).includes("lf-pending"),
+    );
+    expect(drain_calls).toHaveLength(0);
+    expect(unlink).not.toHaveBeenCalledWith("/tmp/lf-pending-pool-3.txt");
+  });
+
+  it("does not deliver when tmux session is dead", async () => {
+    const bot = make_bot({
+      id: 4,
+      state: "assigned",
+      channel_id: "ch-4",
+      entity_id: "e1",
+      archetype: "planner",
+      session_id: "sess-4",
+    });
+    pool.inject_bots([bot]);
+
+    (access as Mock).mockImplementation(async (path: unknown) => {
+      if (path === "/tmp/lf-pending-pool-4.txt") return;
+      throw new Error("ENOENT");
+    });
+    // Session dead — regular health check will try to restart, but drain won't fire
+    mock_is_tmux_alive.mockReturnValue(false);
+
+    // Stub restart path to avoid hitting real tmux
+    vi.spyOn(
+      pool as unknown as Record<string, unknown>,
+      "restart_crashed_session" as never,
+    ).mockResolvedValue(undefined);
+
+    await pool.run_health_check();
+
+    // send_via_tmux should not have been called for drain delivery
+    const drain_calls = mock_send_via_tmux.mock.calls.filter(
+      (c: unknown[]) =>
+        (c[0] as string) === "pool-4" &&
+        typeof c[1] === "string" &&
+        (c[1] as string).includes("lf-pending"),
+    );
+    expect(drain_calls).toHaveLength(0);
+  });
+
+  it("does not attempt delivery when no pending file exists", async () => {
+    const bot = make_bot({
+      id: 5,
+      state: "assigned",
+      channel_id: "ch-5",
+      entity_id: "e1",
+      archetype: "planner",
+      session_id: "sess-5",
+    });
+    pool.inject_bots([bot]);
+
+    // No pending files (access always throws)
+    (access as Mock).mockRejectedValue(new Error("ENOENT"));
+
+    await pool.run_health_check();
+
+    // send_via_tmux should not have been called for drain delivery
+    const drain_calls = mock_send_via_tmux.mock.calls.filter(
+      (c: unknown[]) => typeof c[1] === "string" && (c[1] as string).includes("lf-pending"),
+    );
+    expect(drain_calls).toHaveLength(0);
+    expect(unlink).not.toHaveBeenCalledWith("/tmp/lf-pending-pool-5.txt");
+  });
+
+  it("handles send_via_tmux failure gracefully", async () => {
+    const bot = make_bot({
+      id: 6,
+      state: "assigned",
+      channel_id: "ch-6",
+      entity_id: "e1",
+      archetype: "planner",
+      session_id: "sess-6",
+    });
+    pool.inject_bots([bot]);
+
+    (access as Mock).mockImplementation(async (path: unknown) => {
+      if (path === "/tmp/lf-pending-pool-6.txt") return;
+      throw new Error("ENOENT");
+    });
+    mock_send_via_tmux.mockImplementation(() => {
+      throw new Error("tmux send failed");
+    });
+
+    // Should not throw — error is caught internally
+    await expect(pool.run_health_check()).resolves.toBeUndefined();
+  });
+});

--- a/packages/daemon/src/__tests__/bridge-drain.test.ts
+++ b/packages/daemon/src/__tests__/bridge-drain.test.ts
@@ -175,8 +175,8 @@ describe("drain_pending_files (issue #278)", () => {
       "pool-1",
       expect.stringContaining("/tmp/lf-pending-pool-1.txt"),
     );
-    // Verify cleanup
-    expect(unlink).toHaveBeenCalledWith("/tmp/lf-pending-pool-1.txt");
+    // Note: unlink is now delayed (setTimeout 30s) to give Claude time to read
+    // the file — not called synchronously after send_via_tmux
   });
 
   it("does not deliver when bot is not assigned", async () => {

--- a/packages/daemon/src/__tests__/bridge-drain.test.ts
+++ b/packages/daemon/src/__tests__/bridge-drain.test.ts
@@ -175,8 +175,9 @@ describe("drain_pending_files (issue #278)", () => {
       "pool-1",
       expect.stringContaining(pending_file_path("pool-1")),
     );
-    // Note: unlink is now delayed (setTimeout 5s) to give Claude time to read
-    // the file — not called synchronously after send_via_tmux
+    // unlink is delayed (setTimeout 5s) to give Claude time to read the file —
+    // verify it's not called synchronously after send_via_tmux
+    expect(unlink).not.toHaveBeenCalled();
   });
 
   it("does not deliver when bot is not assigned", async () => {

--- a/packages/daemon/src/__tests__/bridge-retry.test.ts
+++ b/packages/daemon/src/__tests__/bridge-retry.test.ts
@@ -1,0 +1,252 @@
+import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocks ──
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    execFileSync: vi.fn().mockImplementation(() => {
+      throw new Error("not mocked");
+    }),
+    spawn: vi.fn(),
+  };
+});
+
+import { execFileSync } from "node:child_process";
+import { wait_for_bot_ready, wait_for_bot_ready_with_retries } from "../pool.js";
+
+// ── Tests ──
+
+describe("wait_for_bot_ready", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns true when bot shows ready indicators", async () => {
+    (execFileSync as Mock).mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "tmux" && args[0] === "capture-pane") {
+        return "Listening for channel messages\n❯ ";
+      }
+      return "";
+    });
+
+    const result_promise = wait_for_bot_ready("pool-0", { timeout_ms: 5000, poll_ms: 100 });
+    await vi.advanceTimersByTimeAsync(500);
+    const result = await result_promise;
+    expect(result).toBe(true);
+  });
+
+  it("returns true when bot shows bypass permissions indicator", async () => {
+    (execFileSync as Mock).mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "tmux" && args[0] === "capture-pane") {
+        return "Listening for channel messages\nbypass permissions";
+      }
+      return "";
+    });
+
+    const result_promise = wait_for_bot_ready("pool-0", { timeout_ms: 5000, poll_ms: 100 });
+    await vi.advanceTimersByTimeAsync(500);
+    const result = await result_promise;
+    expect(result).toBe(true);
+  });
+
+  it("returns false when bot never becomes ready", async () => {
+    (execFileSync as Mock).mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "tmux" && args[0] === "capture-pane") {
+        return "Loading conversation history...";
+      }
+      return "";
+    });
+
+    const result_promise = wait_for_bot_ready("pool-0", { timeout_ms: 2000, poll_ms: 100 });
+    await vi.advanceTimersByTimeAsync(3000);
+    const result = await result_promise;
+    expect(result).toBe(false);
+  });
+
+  it("returns false when tmux capture-pane keeps throwing", async () => {
+    (execFileSync as Mock).mockImplementation(() => {
+      throw new Error("tmux not found");
+    });
+
+    const result_promise = wait_for_bot_ready("pool-0", { timeout_ms: 2000, poll_ms: 100 });
+    await vi.advanceTimersByTimeAsync(3000);
+    const result = await result_promise;
+    expect(result).toBe(false);
+  });
+
+  it("uses 500ms poll and 30s timeout by default", async () => {
+    let poll_count = 0;
+    (execFileSync as Mock).mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "tmux" && args[0] === "capture-pane") {
+        poll_count++;
+        // Become ready after ~5 polls
+        if (poll_count >= 5) {
+          return "Listening for channel messages\n❯ ";
+        }
+        return "Loading...";
+      }
+      return "";
+    });
+
+    const result_promise = wait_for_bot_ready("pool-0");
+    await vi.advanceTimersByTimeAsync(5000);
+    const result = await result_promise;
+    expect(result).toBe(true);
+    // With 500ms polling, ~5 polls means the bot was checked at 500, 1000, 1500, 2000, 2500ms
+    expect(poll_count).toBeGreaterThanOrEqual(5);
+  });
+
+  it("requires both Listening and prompt indicators", async () => {
+    // Only prompt, no "Listening for channel messages"
+    (execFileSync as Mock).mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "tmux" && args[0] === "capture-pane") {
+        return "❯ ";
+      }
+      return "";
+    });
+
+    const result_promise = wait_for_bot_ready("pool-0", { timeout_ms: 1000, poll_ms: 100 });
+    await vi.advanceTimersByTimeAsync(1500);
+    const result = await result_promise;
+    expect(result).toBe(false);
+  });
+});
+
+describe("wait_for_bot_ready_with_retries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("succeeds on first attempt when bot is ready", async () => {
+    (execFileSync as Mock).mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "tmux" && args[0] === "capture-pane") {
+        return "Listening for channel messages\n❯ ";
+      }
+      return "";
+    });
+
+    const result_promise = wait_for_bot_ready_with_retries("pool-0", {
+      timeout_ms: 2000,
+      poll_ms: 100,
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await result_promise;
+    expect(result).toBe(true);
+  });
+
+  it("retries and succeeds on second attempt", async () => {
+    let attempt = 0;
+    (execFileSync as Mock).mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "tmux" && args[0] === "capture-pane") {
+        // First attempt (~2s timeout): never ready. Second attempt: ready.
+        if (attempt >= 1) {
+          return "Listening for channel messages\n❯ ";
+        }
+        return "Loading...";
+      }
+      if (cmd === "tmux" && args[0] === "has-session") {
+        // Session is alive — allow retry
+        return "";
+      }
+      return "";
+    });
+
+    const result_promise = wait_for_bot_ready_with_retries("pool-0", {
+      timeout_ms: 2000,
+      poll_ms: 100,
+      max_attempts: 3,
+    });
+
+    // Advance past first attempt timeout
+    await vi.advanceTimersByTimeAsync(2500);
+    // After first timeout, the code checks has-session and logs retry
+    attempt = 1;
+    // Advance through second attempt
+    await vi.advanceTimersByTimeAsync(1000);
+
+    const result = await result_promise;
+    expect(result).toBe(true);
+  });
+
+  it("bails early when tmux session dies between retries", async () => {
+    (execFileSync as Mock).mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "tmux" && args[0] === "capture-pane") {
+        return "Loading...";
+      }
+      if (cmd === "tmux" && args[0] === "has-session") {
+        // Session died
+        throw new Error("no session");
+      }
+      return "";
+    });
+
+    const result_promise = wait_for_bot_ready_with_retries("pool-0", {
+      timeout_ms: 2000,
+      poll_ms: 100,
+      max_attempts: 3,
+    });
+    // Advance past first attempt + bail check
+    await vi.advanceTimersByTimeAsync(3000);
+    const result = await result_promise;
+    expect(result).toBe(false);
+  });
+
+  it("returns false after all attempts exhausted", async () => {
+    (execFileSync as Mock).mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "tmux" && args[0] === "capture-pane") {
+        return "Loading...";
+      }
+      if (cmd === "tmux" && args[0] === "has-session") {
+        return ""; // Session alive — allow all retries
+      }
+      return "";
+    });
+
+    const result_promise = wait_for_bot_ready_with_retries("pool-0", {
+      timeout_ms: 1000,
+      poll_ms: 100,
+      max_attempts: 3,
+    });
+    // Need enough time for 3 attempts of 1s each
+    await vi.advanceTimersByTimeAsync(5000);
+    const result = await result_promise;
+    expect(result).toBe(false);
+  });
+
+  it("defaults to 3 max_attempts", async () => {
+    let has_session_calls = 0;
+    (execFileSync as Mock).mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "tmux" && args[0] === "capture-pane") {
+        return "Loading...";
+      }
+      if (cmd === "tmux" && args[0] === "has-session") {
+        has_session_calls++;
+        return "";
+      }
+      return "";
+    });
+
+    const result_promise = wait_for_bot_ready_with_retries("pool-0", {
+      timeout_ms: 500,
+      poll_ms: 100,
+    });
+    await vi.advanceTimersByTimeAsync(5000);
+    const result = await result_promise;
+    expect(result).toBe(false);
+    // has-session is called between retries (after attempt 1, after attempt 2)
+    // Not called after last attempt
+    expect(has_session_calls).toBe(2);
+  });
+});

--- a/packages/daemon/src/__tests__/resume-nudge.test.ts
+++ b/packages/daemon/src/__tests__/resume-nudge.test.ts
@@ -370,11 +370,13 @@ describe("resume nudge (issue #156)", () => {
     // With has-session throwing, it bails after the first 30s attempt.
     await vi.advanceTimersByTimeAsync(35_000);
 
+    // Pending file IS written (before readiness check) so drain_pending_files
+    // can recover it later if the bot becomes ready on a subsequent health tick
     const write_calls = (writeFile as Mock).mock.calls;
     const nudge_call = write_calls.find((c: unknown[]) =>
       (c[0] as string).includes("lf-pending-pool-4"),
     );
-    expect(nudge_call).toBeUndefined();
+    expect(nudge_call).toBeDefined();
 
     // send-keys should NOT have been called for this bot
     const send_calls = (execFileSync as Mock).mock.calls.filter(

--- a/packages/daemon/src/__tests__/resume-nudge.test.ts
+++ b/packages/daemon/src/__tests__/resume-nudge.test.ts
@@ -4,7 +4,7 @@ import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
 import type { LobsterFarmConfig } from "@lobster-farm/shared";
 import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PersistedPoolBot } from "../persistence.js";
-import type { PoolBot } from "../pool.js";
+import { type PoolBot, pending_file_path } from "../pool.js";
 import { BotPoolTestBase } from "./helpers/test-bot-pool-base.js";
 
 // ── Mocks ──
@@ -180,7 +180,7 @@ describe("resume nudge (issue #156)", () => {
     await vi.advanceTimersByTimeAsync(25_000);
 
     expect(writeFile).toHaveBeenCalledWith(
-      "/tmp/lf-pending-pool-3.txt",
+      pending_file_path("pool-3"),
       expect.stringContaining("daemon restarted"),
       "utf-8",
     );
@@ -188,7 +188,7 @@ describe("resume nudge (issue #156)", () => {
     // The actual delivery mechanism: tmux send-keys injects the prompt
     expect(execFileSync).toHaveBeenCalledWith(
       "tmux",
-      ["send-keys", "-t", "pool-3", expect.stringContaining("/tmp/lf-pending-pool-3.txt"), "Enter"],
+      ["send-keys", "-t", "pool-3", expect.stringContaining(pending_file_path("pool-3")), "Enter"],
       expect.objectContaining({ stdio: "ignore", timeout: 5000 }),
     );
   });
@@ -235,7 +235,7 @@ describe("resume nudge (issue #156)", () => {
         "send-keys",
         "-t",
         "pool-0",
-        expect.stringContaining("Read /tmp/lf-pending-pool-0.txt"),
+        expect.stringContaining(`Read ${pending_file_path("pool-0")}`),
         "Enter",
       ],
       expect.objectContaining({ stdio: "ignore", timeout: 5000 }),
@@ -269,7 +269,7 @@ describe("resume nudge (issue #156)", () => {
     await vi.advanceTimersByTimeAsync(25_000);
 
     expect(writeFile).toHaveBeenCalledWith(
-      "/tmp/lf-pending-pool-7.txt",
+      pending_file_path("pool-7"),
       expect.any(String),
       "utf-8",
     );
@@ -277,7 +277,7 @@ describe("resume nudge (issue #156)", () => {
     // send-keys targets the correct tmux session
     expect(execFileSync).toHaveBeenCalledWith(
       "tmux",
-      ["send-keys", "-t", "pool-7", expect.stringContaining("/tmp/lf-pending-pool-7.txt"), "Enter"],
+      ["send-keys", "-t", "pool-7", expect.stringContaining(pending_file_path("pool-7")), "Enter"],
       expect.objectContaining({ stdio: "ignore", timeout: 5000 }),
     );
   });

--- a/packages/daemon/src/__tests__/resume-nudge.test.ts
+++ b/packages/daemon/src/__tests__/resume-nudge.test.ts
@@ -353,7 +353,8 @@ describe("resume nudge (issue #156)", () => {
       },
     ]);
 
-    // tmux capture-pane never returns the ready indicator
+    // tmux capture-pane never returns the ready indicator.
+    // has-session throws — simulates dead session, causing early bail after first attempt.
     (execFileSync as Mock).mockImplementation((cmd: string, args: string[]) => {
       if (cmd === "tmux" && args[0] === "capture-pane") {
         return "Loading conversation history...";
@@ -365,7 +366,9 @@ describe("resume nudge (issue #156)", () => {
     });
 
     await pool.resume_parked_bots();
-    await vi.advanceTimersByTimeAsync(25_000);
+    // wait_for_bot_ready_with_retries uses 30s timeout per attempt (3 attempts max).
+    // With has-session throwing, it bails after the first 30s attempt.
+    await vi.advanceTimersByTimeAsync(35_000);
 
     const write_calls = (writeFile as Mock).mock.calls;
     const nudge_call = write_calls.find((c: unknown[]) =>

--- a/packages/daemon/src/__tests__/resume-nudge.test.ts
+++ b/packages/daemon/src/__tests__/resume-nudge.test.ts
@@ -14,6 +14,7 @@ vi.mock("node:fs/promises", async () => {
   const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
   return {
     ...actual,
+    access: vi.fn().mockResolvedValue(undefined),
     writeFile: vi.fn().mockResolvedValue(undefined),
     readFile: vi.fn().mockResolvedValue("{}"),
     readdir: vi.fn().mockResolvedValue([]),
@@ -34,7 +35,7 @@ vi.mock("node:child_process", async () => {
 });
 
 import { execFileSync } from "node:child_process";
-import { writeFile } from "node:fs/promises";
+import { access, writeFile } from "node:fs/promises";
 
 // ── Test helpers ──
 
@@ -384,6 +385,66 @@ describe("resume nudge (issue #156)", () => {
         c[0] === "tmux" &&
         (c[1] as string[])[0] === "send-keys" &&
         (c[1] as string[])[2] === "pool-4",
+    );
+    expect(send_calls).toHaveLength(0);
+  });
+
+  it("skips send-keys when drain already claimed the pending file", async () => {
+    // Scenario: bridge writes the pending file, starts readiness polling.
+    // Meanwhile, drain_pending_files (health-check timer) claims and delivers
+    // the file. When bridge's readiness wait succeeds, the file is gone.
+    // Bridge should bail silently — no double-delivery.
+    const bot = make_bot({
+      id: 5,
+      state: "parked",
+      channel_id: "ch-5",
+      entity_id: "e1",
+      archetype: "planner",
+      session_id: "sess-drained",
+    });
+    pool.inject_bots([bot]);
+    pool.inject_resume_candidates([
+      {
+        id: 5,
+        state: "assigned",
+        channel_id: "ch-5",
+        entity_id: "e1",
+        archetype: "planner",
+        channel_type: null,
+        session_id: "sess-drained",
+        last_active: new Date().toISOString(),
+      },
+    ]);
+
+    // Bot becomes ready — wait_for_bot_ready_with_retries will return true
+    (execFileSync as Mock).mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "tmux" && args[0] === "capture-pane") {
+        return "Listening for channel messages\n❯ ";
+      }
+      return "";
+    });
+
+    // Simulate drain having already deleted the pending file:
+    // writeFile succeeds (bridge writes it), but access() fails (file gone by
+    // the time bridge checks after readiness wait completes).
+    (access as Mock).mockRejectedValue(new Error("ENOENT"));
+
+    await pool.resume_parked_bots();
+    await vi.advanceTimersByTimeAsync(25_000);
+
+    // Pending file was written (before readiness check)
+    const write_calls = (writeFile as Mock).mock.calls;
+    const nudge_call = write_calls.find((c: unknown[]) =>
+      (c[0] as string).includes("lf-pending-pool-5"),
+    );
+    expect(nudge_call).toBeDefined();
+
+    // send-keys should NOT have been called — drain already delivered
+    const send_calls = (execFileSync as Mock).mock.calls.filter(
+      (c: unknown[]) =>
+        c[0] === "tmux" &&
+        (c[1] as string[])[0] === "send-keys" &&
+        (c[1] as string[])[2] === "pool-5",
     );
     expect(send_calls).toHaveLength(0);
   });

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -2362,11 +2362,16 @@ export class DiscordBot extends EventEmitter {
       console.log(`[discord] Bridged first message to ${tmux_session}`);
 
       // Clean up shortly after — Claude has the prompt and will read it within seconds.
-      // Keep this well under the 30s health-check interval to prevent drain_pending_files
-      // from re-delivering the same message after Claude finishes processing.
-      setTimeout(() => {
-        void unlink(pending_path).catch(() => {});
-      }, 5_000);
+      // Mark as draining to prevent drain_pending_files from re-delivering during
+      // the cleanup window.
+      if (this._pool) {
+        const cleanup = this._pool.mark_draining(tmux_session, pending_path);
+        setTimeout(cleanup, 5_000);
+      } else {
+        setTimeout(() => {
+          void unlink(pending_path).catch(() => {});
+        }, 5_000);
+      }
     } catch (err) {
       console.error(`[discord] Bridge failed: ${String(err)}`);
       sentry.captureException(err, {

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -33,7 +33,11 @@ import {
   type Webhook,
 } from "discord.js";
 import { PAT_TMUX_SESSION } from "./commander-process.js";
-import { is_tmux_session_idle, wait_for_bot_ready_with_retries } from "./pool.js";
+import {
+  is_tmux_session_idle,
+  pending_file_path,
+  wait_for_bot_ready_with_retries,
+} from "./pool.js";
 import type { BotPool, PoolBot } from "./pool.js";
 import type { TaskQueue } from "./queue.js";
 import type { EntityRegistry } from "./registry.js";
@@ -2314,7 +2318,7 @@ export class DiscordBot extends EventEmitter {
   ): Promise<void> {
     const { execFileSync } = await import("node:child_process");
     const { writeFile: writeFileAsync, unlink } = await import("node:fs/promises");
-    const pending_path = `/tmp/lf-pending-${tmux_session}.txt`;
+    const pending_path = pending_file_path(tmux_session);
 
     try {
       // Write the message to a file (avoids tmux escaping issues)

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -2336,7 +2336,7 @@ export class DiscordBot extends EventEmitter {
           try {
             await this.send(
               channel_id,
-              "Your message may not have been delivered — the bot is still starting up. Please wait a moment and resend if needed.",
+              "Your message will be delivered once the bot finishes starting up. If you don't get a response within a few minutes, please resend.",
             );
           } catch {
             /* best effort */

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -33,7 +33,7 @@ import {
   type Webhook,
 } from "discord.js";
 import { PAT_TMUX_SESSION } from "./commander-process.js";
-import { is_tmux_session_idle } from "./pool.js";
+import { is_tmux_session_idle, wait_for_bot_ready_with_retries } from "./pool.js";
 import type { BotPool, PoolBot } from "./pool.js";
 import type { TaskQueue } from "./queue.js";
 import type { EntityRegistry } from "./registry.js";
@@ -1903,6 +1903,7 @@ export class DiscordBot extends EventEmitter {
             result.tmux_session,
             message.content,
             message.author.displayName,
+            message.channelId,
           );
           try {
             await message.reactions.cache.get("⏳")?.users.remove(this.client.user!.id);
@@ -2297,11 +2298,19 @@ export class DiscordBot extends EventEmitter {
     }
   }
 
-  /** Bridge a message to a freshly spawned pool bot via tmux send-keys. */
+  /**
+   * Bridge a message to a freshly spawned pool bot via tmux send-keys.
+   *
+   * Uses wait_for_bot_ready_with_retries for robust readiness detection
+   * (3 attempts, 30s each = ~90s total). If all retries fail, the pending
+   * file is left in place for the health-check drain to recover, and a
+   * fallback message is posted to the Discord channel so the user knows.
+   */
   private async bridge_first_message(
     tmux_session: string,
     content: string,
     author_name: string,
+    channel_id?: string,
   ): Promise<void> {
     const { execFileSync } = await import("node:child_process");
     const { writeFile: writeFileAsync, unlink } = await import("node:fs/promises");
@@ -2311,30 +2320,28 @@ export class DiscordBot extends EventEmitter {
       // Write the message to a file (avoids tmux escaping issues)
       await writeFileAsync(pending_path, `${author_name}: ${content}`, "utf-8");
 
-      // Wait for the bot to be ready (polling for the ❯ prompt + Listening)
-      const start = Date.now();
-      const timeout = 20000;
-      let ready = false;
-      while (Date.now() - start < timeout) {
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-        try {
-          const output = execFileSync("tmux", ["capture-pane", "-t", tmux_session, "-p"], {
-            encoding: "utf-8",
-            timeout: 2000,
-          });
-          if (output.includes("Listening for channel messages") && output.includes("❯")) {
-            ready = true;
-            break;
-          }
-        } catch {
-          /* ignore */
-        }
-      }
+      // Wait for the bot to be ready with retries (~90s total coverage)
+      const ready = await wait_for_bot_ready_with_retries(tmux_session);
 
       if (!ready) {
         console.log(
-          `[discord] Bot ${tmux_session} not ready after ${String(timeout)}ms — message not bridged`,
+          `[discord] Bot ${tmux_session} not ready after all retries — message not bridged`,
         );
+
+        // Pending file stays in place — health check drain_pending_files()
+        // will deliver it if the bot becomes ready later.
+
+        // Post a fallback message so the user knows something went wrong
+        if (channel_id) {
+          try {
+            await this.send(
+              channel_id,
+              "Your message may not have been delivered — the bot is still starting up. Please wait a moment and resend if needed.",
+            );
+          } catch {
+            /* best effort */
+          }
+        }
         return;
       }
 
@@ -2513,7 +2520,12 @@ export class DiscordBot extends EventEmitter {
 
       // Bridge initial context if provided
       if (context) {
-        await this.bridge_first_message(assignment.tmux_session, context, target.author_name);
+        await this.bridge_first_message(
+          assignment.tmux_session,
+          context,
+          target.author_name,
+          channel_id,
+        );
       }
     }
   }

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -2317,7 +2317,11 @@ export class DiscordBot extends EventEmitter {
     channel_id?: string,
   ): Promise<void> {
     const { execFileSync } = await import("node:child_process");
-    const { writeFile: writeFileAsync, unlink } = await import("node:fs/promises");
+    const {
+      access: accessAsync,
+      writeFile: writeFileAsync,
+      unlink,
+    } = await import("node:fs/promises");
     const pending_path = pending_file_path(tmux_session);
 
     try {
@@ -2346,6 +2350,18 @@ export class DiscordBot extends EventEmitter {
             /* best effort */
           }
         }
+        return;
+      }
+
+      // Guard against drain having already delivered while we were polling.
+      // drain_pending_files runs on the 30s health-check timer and may have
+      // claimed and sent the file during the ~90s readiness wait.
+      try {
+        await accessAsync(pending_path);
+      } catch {
+        console.log(
+          `[discord] Pending file already claimed by drain for ${tmux_session} — skipping bridge send`,
+        );
         return;
       }
 

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -2357,10 +2357,12 @@ export class DiscordBot extends EventEmitter {
 
       console.log(`[discord] Bridged first message to ${tmux_session}`);
 
-      // Clean up after a delay
+      // Clean up shortly after — Claude has the prompt and will read it within seconds.
+      // Keep this well under the 30s health-check interval to prevent drain_pending_files
+      // from re-delivering the same message after Claude finishes processing.
       setTimeout(() => {
         void unlink(pending_path).catch(() => {});
-      }, 30000);
+      }, 5_000);
     } catch (err) {
       console.error(`[discord] Bridge failed: ${String(err)}`);
       sentry.captureException(err, {

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -115,6 +115,84 @@ export function is_tmux_session_idle(tmux_session: string): boolean {
   }
 }
 
+// ── Bot readiness polling ──
+
+/**
+ * Poll a tmux pane until the Claude Code bot is ready (prompt + plugin indicators).
+ *
+ * Ready when the pane output contains "❯" OR "bypass permissions" — these indicate
+ * the Claude process is at the prompt and the MCP plugin is connected.
+ *
+ * Returns true if the bot became ready within the timeout, false otherwise.
+ */
+export async function wait_for_bot_ready(
+  tmux_session: string,
+  opts?: { timeout_ms?: number; poll_ms?: number },
+): Promise<boolean> {
+  const timeout = opts?.timeout_ms ?? 30_000;
+  const poll = opts?.poll_ms ?? 500;
+  const start = Date.now();
+
+  while (Date.now() - start < timeout) {
+    await new Promise((resolve) => setTimeout(resolve, poll));
+    try {
+      const output = execFileSync("tmux", ["capture-pane", "-t", tmux_session, "-p"], {
+        encoding: "utf-8",
+        timeout: 2000,
+      });
+      if (
+        output.includes("Listening for channel messages") &&
+        (output.includes("❯") || output.includes("bypass permissions"))
+      ) {
+        return true;
+      }
+    } catch {
+      /* tmux pane not ready yet */
+    }
+  }
+  return false;
+}
+
+/**
+ * Wait for a bot to be ready with retries and tmux liveness checks.
+ *
+ * Calls wait_for_bot_ready up to `max_attempts` times. Between attempts,
+ * checks if the tmux session is still alive — bails early if it died.
+ *
+ * Returns true if the bot became ready, false if all attempts were exhausted
+ * or the tmux session died.
+ */
+export async function wait_for_bot_ready_with_retries(
+  tmux_session: string,
+  opts?: { timeout_ms?: number; poll_ms?: number; max_attempts?: number },
+): Promise<boolean> {
+  const max_attempts = opts?.max_attempts ?? 3;
+
+  for (let attempt = 1; attempt <= max_attempts; attempt++) {
+    const ready = await wait_for_bot_ready(tmux_session, {
+      timeout_ms: opts?.timeout_ms,
+      poll_ms: opts?.poll_ms,
+    });
+    if (ready) return true;
+
+    // Between retries, check if the tmux session is still alive
+    if (attempt < max_attempts) {
+      try {
+        execFileSync("tmux", ["has-session", "-t", tmux_session], { stdio: "ignore" });
+      } catch {
+        // Session died — no point retrying
+        console.log(`[pool] Tmux session ${tmux_session} died during readiness wait — bailing`);
+        return false;
+      }
+      console.log(
+        `[pool] Bot ${tmux_session} not ready after attempt ${String(attempt)}/${String(max_attempts)} — retrying`,
+      );
+    }
+  }
+
+  return false;
+}
+
 // ── Claude Code JSONL session tracking ──
 
 /**
@@ -1366,6 +1444,11 @@ export class BotPool extends EventEmitter {
       // Deliver any queued messages to bots that are now at the prompt
       this.drain_pending_injections();
 
+      // Safety net: recover undelivered pending files left by failed bridge attempts.
+      // If bridge_first_message or bridge_resume_nudge timed out but the bot later
+      // became ready, deliver the pending file content via tmux send-keys.
+      await this.drain_pending_files();
+
       for (const bot of this.bots) {
         if (bot.state !== "assigned") continue;
 
@@ -2302,12 +2385,48 @@ export class BotPool extends EventEmitter {
   }
 
   /**
+   * Safety net for failed bridge attempts.
+   *
+   * Scans assigned bots for orphaned /tmp/lf-pending-{session}.txt files.
+   * If the bot is alive and at the prompt, delivers the message via tmux
+   * send-keys and removes the file. This catches the case where
+   * bridge_first_message or bridge_resume_nudge timed out but the bot
+   * became ready later.
+   */
+  private async drain_pending_files(): Promise<void> {
+    for (const bot of this.bots) {
+      if (bot.state !== "assigned") continue;
+
+      const pending_path = `/tmp/lf-pending-${bot.tmux_session}.txt`;
+      try {
+        await access(pending_path);
+      } catch {
+        continue; // No pending file — normal case
+      }
+
+      // File exists — check if the bot is alive and ready
+      if (!this.is_tmux_alive(bot.tmux_session)) continue;
+      if (!this.is_at_prompt(bot.tmux_session)) continue;
+
+      // Bot is ready with an undelivered pending file — deliver it
+      try {
+        const prompt = `A user messaged you earlier but the message wasn't delivered. Read ${pending_path} for their message and respond to them.`;
+        this.send_via_tmux(bot.tmux_session, prompt);
+        await unlink(pending_path);
+        console.log(`[pool] Drained pending file for ${bot.tmux_session} via health check`);
+      } catch (err) {
+        console.warn(`[pool] Failed to drain pending file for ${bot.tmux_session}: ${String(err)}`);
+      }
+    }
+  }
+
+  /**
    * Bridge a continuation nudge to a resumed bot's Claude Code process.
    * Writes a pending message file that the MCP Discord plugin picks up,
    * using the same mechanism as bridge_first_message in discord.ts.
    *
-   * Waits for the Claude process to be ready (prompt indicator visible in
-   * the tmux pane) before writing the file, so the plugin is listening.
+   * Uses wait_for_bot_ready_with_retries for robust readiness detection
+   * with up to 3 attempts (~90s total coverage).
    */
   private async bridge_resume_nudge(bot: PoolBot): Promise<void> {
     const pending_path = `/tmp/lf-pending-${bot.tmux_session}.txt`;
@@ -2315,32 +2434,11 @@ export class BotPool extends EventEmitter {
       "The daemon restarted and your session was resumed. " +
       "Check where you left off and continue any in-progress work.";
 
-    // Poll the tmux pane for the ready indicator — same pattern as
-    // bridge_first_message in discord.ts. The Claude process needs time
-    // to load history via --resume before it starts the MCP plugin.
-    const start = Date.now();
-    const timeout = 20_000;
-    let ready = false;
-
-    while (Date.now() - start < timeout) {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      try {
-        const output = execFileSync("tmux", ["capture-pane", "-t", bot.tmux_session, "-p"], {
-          encoding: "utf-8",
-          timeout: 2000,
-        });
-        if (output.includes("Listening for channel messages") && output.includes("❯")) {
-          ready = true;
-          break;
-        }
-      } catch {
-        /* tmux pane not ready yet */
-      }
-    }
+    const ready = await wait_for_bot_ready_with_retries(bot.tmux_session);
 
     if (!ready) {
       console.log(
-        `[pool] Bot ${bot.tmux_session} not ready after ${String(timeout)}ms — resume nudge not sent`,
+        `[pool] Bot ${bot.tmux_session} not ready after all retries — resume nudge not sent`,
       );
       return;
     }

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -2412,8 +2412,11 @@ export class BotPool extends EventEmitter {
       try {
         const prompt = `A user messaged you earlier but the message wasn't delivered. Read ${pending_path} for their message and respond to them.`;
         this.send_via_tmux(bot.tmux_session, prompt);
-        await unlink(pending_path);
         console.log(`[pool] Drained pending file for ${bot.tmux_session} via health check`);
+        // Delay cleanup to give Claude time to read the file after tmux send-keys
+        setTimeout(() => {
+          void unlink(pending_path).catch(() => {});
+        }, 30_000);
       } catch (err) {
         console.warn(`[pool] Failed to drain pending file for ${bot.tmux_session}: ${String(err)}`);
       }
@@ -2434,19 +2437,21 @@ export class BotPool extends EventEmitter {
       "The daemon restarted and your session was resumed. " +
       "Check where you left off and continue any in-progress work.";
 
+    // Write file first so drain_pending_files can recover it if readiness times out
+    await writeFile(pending_path, nudge, "utf-8");
+
     const ready = await wait_for_bot_ready_with_retries(bot.tmux_session);
 
     if (!ready) {
       console.log(
         `[pool] Bot ${bot.tmux_session} not ready after all retries — resume nudge not sent`,
       );
+      // pending_path stays in place for drain_pending_files to recover
       return;
     }
 
     // Small extra delay for the MCP plugin to fully connect
     await new Promise((resolve) => setTimeout(resolve, 2000));
-
-    await writeFile(pending_path, nudge, "utf-8");
 
     // Deliver the nudge via tmux send-keys — the file alone is not enough.
     // The send-keys call injects a prompt into Claude's stdin telling it

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -2413,10 +2413,12 @@ export class BotPool extends EventEmitter {
         const prompt = `A user messaged you earlier but the message wasn't delivered. Read ${pending_path} for their message and respond to them.`;
         this.send_via_tmux(bot.tmux_session, prompt);
         console.log(`[pool] Drained pending file for ${bot.tmux_session} via health check`);
-        // Delay cleanup to give Claude time to read the file after tmux send-keys
+        // Clean up shortly after — Claude has the prompt and will read it within seconds.
+        // Keep this well under the 30s health-check interval to prevent self-re-delivery
+        // on the next tick.
         setTimeout(() => {
           void unlink(pending_path).catch(() => {});
-        }, 30_000);
+        }, 5_000);
       } catch (err) {
         console.warn(`[pool] Failed to drain pending file for ${bot.tmux_session}: ${String(err)}`);
       }
@@ -2470,10 +2472,12 @@ export class BotPool extends EventEmitter {
 
     console.log(`[pool] Bridged resume nudge to ${bot.tmux_session}`);
 
-    // Clean up the pending file after a delay
+    // Clean up shortly after — Claude has the prompt and will read it within seconds.
+    // Keep this well under the 30s health-check interval to prevent drain_pending_files
+    // from re-delivering the same message after Claude finishes processing.
     setTimeout(() => {
       void unlink(pending_path).catch(() => {});
-    }, 30_000);
+    }, 5_000);
   }
 
   /**

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -115,6 +115,13 @@ export function is_tmux_session_idle(tmux_session: string): boolean {
   }
 }
 
+// ── Pending file path ──
+
+/** Canonical path for the pending-message file used by bridge and drain. */
+export function pending_file_path(tmux_session: string): string {
+  return `/tmp/lf-pending-${tmux_session}.txt`;
+}
+
 // ── Bot readiness polling ──
 
 /**
@@ -2397,7 +2404,7 @@ export class BotPool extends EventEmitter {
     for (const bot of this.bots) {
       if (bot.state !== "assigned") continue;
 
-      const pending_path = `/tmp/lf-pending-${bot.tmux_session}.txt`;
+      const pending_path = pending_file_path(bot.tmux_session);
       try {
         await access(pending_path);
       } catch {
@@ -2434,7 +2441,7 @@ export class BotPool extends EventEmitter {
    * with up to 3 attempts (~90s total coverage).
    */
   private async bridge_resume_nudge(bot: PoolBot): Promise<void> {
-    const pending_path = `/tmp/lf-pending-${bot.tmux_session}.txt`;
+    const pending_path = pending_file_path(bot.tmux_session);
     const nudge =
       "The daemon restarted and your session was resumed. " +
       "Check where you left off and continue any in-progress work.";

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -2360,7 +2360,13 @@ export class BotPool extends EventEmitter {
     return false;
   }
 
-  /** Check if a bot's tmux pane shows the Claude prompt indicator (❯). */
+  /** Check if a bot's tmux pane shows the Claude prompt indicator (❯).
+   *
+   * Note: This uses a simpler check than wait_for_bot_ready (which also
+   * requires "Listening for channel messages"). The ❯ prompt is sufficient
+   * for drain — if the bot is at the prompt, it can read a file regardless
+   * of MCP plugin state. wait_for_bot_ready's stricter check is for the
+   * initial bridge path where we need the plugin connected for Discord I/O. */
   private is_at_prompt(session_name: string): boolean {
     try {
       const output = execFileSync("tmux", ["capture-pane", "-t", session_name, "-p"], {
@@ -2478,6 +2484,18 @@ export class BotPool extends EventEmitter {
         `[pool] Bot ${bot.tmux_session} not ready after all retries — resume nudge not sent`,
       );
       // pending_path stays in place for drain_pending_files to recover
+      return;
+    }
+
+    // Guard against drain having already delivered while we were polling.
+    // drain_pending_files runs on the 30s health-check timer and may have
+    // claimed and sent the file during the ~90s readiness wait.
+    try {
+      await access(pending_path);
+    } catch {
+      console.log(
+        `[pool] Pending file already claimed by drain for ${bot.tmux_session} — skipping nudge send`,
+      );
       return;
     }
 

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -345,6 +345,9 @@ export class BotPool extends EventEmitter {
   private assigning_channels = new Set<string>();
   /** In-flight lock: channels currently being released. Prevents double-release races. */
   private releasing_channels = new Set<string>();
+  /** In-flight lock: tmux sessions with a pending file delivery in progress.
+   * Prevents drain_pending_files from re-delivering during the 5s cleanup window. */
+  private draining_sessions = new Set<string>();
   private bot_user_ids = new Map<number, string>();
   private nickname_handler: NicknameHandler | null = null;
   private avatar_handler: AvatarHandler | null = null;
@@ -1128,6 +1131,10 @@ export class BotPool extends EventEmitter {
       this.kill_tmux(bot.tmux_session);
       this.cancel_session_watcher(bot_id);
 
+      // Clear any orphaned pending file when releasing a bot — prevents stale
+      // message content from a previous assignment leaking into a future one.
+      void unlink(pending_file_path(bot.tmux_session)).catch(() => {});
+
       bot.state = "free";
       bot.channel_id = null;
       bot.entity_id = null;
@@ -1187,6 +1194,17 @@ export class BotPool extends EventEmitter {
       this.session_history_ts.delete(key);
       console.log(`[pool] Cleared session history for ${key}`);
     }
+  }
+
+  /** Mark a tmux session as having an in-flight pending file delivery.
+   * Prevents drain_pending_files from re-delivering during the cleanup window.
+   * Returns a cleanup function that unmarks the session and deletes the file. */
+  mark_draining(tmux_session: string, pending_path: string): () => void {
+    this.draining_sessions.add(tmux_session);
+    return () => {
+      void unlink(pending_path).catch(() => {});
+      this.draining_sessions.delete(tmux_session);
+    };
   }
 
   /** Check if an assigned bot's tmux session is still alive.
@@ -1742,6 +1760,7 @@ export class BotPool extends EventEmitter {
         `[pool] Crash loop for pool-${String(bot.id)} with no channel_id — force-freeing`,
       );
       this.kill_tmux(bot.tmux_session);
+      void unlink(pending_file_path(bot.tmux_session)).catch(() => {});
       bot.state = "free";
       bot.channel_id = null;
       bot.entity_id = null;
@@ -2411,6 +2430,10 @@ export class BotPool extends EventEmitter {
         continue; // No pending file — normal case
       }
 
+      // Skip if a bridge or previous drain is already handling this session's
+      // pending file — prevents double-delivery during the 5s cleanup window.
+      if (this.draining_sessions.has(bot.tmux_session)) continue;
+
       // File exists — check if the bot is alive and ready
       if (!this.is_tmux_alive(bot.tmux_session)) continue;
       if (!this.is_at_prompt(bot.tmux_session)) continue;
@@ -2423,9 +2446,8 @@ export class BotPool extends EventEmitter {
         // Clean up shortly after — Claude has the prompt and will read it within seconds.
         // Keep this well under the 30s health-check interval to prevent self-re-delivery
         // on the next tick.
-        setTimeout(() => {
-          void unlink(pending_path).catch(() => {});
-        }, 5_000);
+        const cleanup = this.mark_draining(bot.tmux_session, pending_path);
+        setTimeout(cleanup, 5_000);
       } catch (err) {
         console.warn(`[pool] Failed to drain pending file for ${bot.tmux_session}: ${String(err)}`);
       }
@@ -2482,9 +2504,8 @@ export class BotPool extends EventEmitter {
     // Clean up shortly after — Claude has the prompt and will read it within seconds.
     // Keep this well under the 30s health-check interval to prevent drain_pending_files
     // from re-delivering the same message after Claude finishes processing.
-    setTimeout(() => {
-      void unlink(pending_path).catch(() => {});
-    }, 5_000);
+    const cleanup = this.mark_draining(bot.tmux_session, pending_path);
+    setTimeout(cleanup, 5_000);
   }
 
   /**


### PR DESCRIPTION
## Summary

- Extract shared `wait_for_bot_ready()` / `wait_for_bot_ready_with_retries()` helpers in pool.ts, eliminating duplicate readiness polling in `bridge_first_message` (discord.ts) and `bridge_resume_nudge` (pool.ts)
- Add retry logic: 3 attempts x 30s timeout = ~90s total coverage (up from 20s), with 500ms poll interval (down from 1000ms) and `bypass permissions` as additional ready indicator
- Add tmux liveness check between retries — bail early if the session died
- Add `drain_pending_files()` in the health check loop — recovers orphaned pending files left by timed-out bridge attempts when the bot later becomes ready
- Post a fallback Discord message on permanent bridge failure so users know to resend

## Test plan

- [x] 11 unit tests for `wait_for_bot_ready` and `wait_for_bot_ready_with_retries` (bridge-retry.test.ts)
- [x] 6 unit tests for `drain_pending_files` health-check integration (bridge-drain.test.ts)
- [x] Updated resume-nudge.test.ts timing for new retry structure
- [x] All 995 existing tests pass
- [x] TypeScript clean, Biome clean

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)