### PR TITLE
fix: compaction count detection + extra usage dollar amounts

### DIFF
--- a/packages/daemon/src/__tests__/session-context.test.ts
+++ b/packages/daemon/src/__tests__/session-context.test.ts
@@ -303,6 +303,123 @@ describe("session-context", () => {
       expect(result!.used_tokens).toBe(30_000);
     });
 
+    it("detects compaction via compact_boundary JSONL entries", async () => {
+      const session_id = "boundary-1234-5678-9012-123456789012";
+      const file_path = join(tmp_dir, ".claude", "projects", "test-project", `${session_id}.jsonl`);
+
+      // Simulate a session where Claude Code writes a compact_boundary marker
+      // between assistant turns. The marker should be counted as a compaction
+      // even if no token-drop is visible yet (e.g., checked before the next
+      // assistant turn lands).
+      const lines = [
+        // Turn 1: 100k context
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            usage: {
+              input_tokens: 80000,
+              cache_creation_input_tokens: 10000,
+              cache_read_input_tokens: 10000,
+              output_tokens: 500,
+            },
+          },
+        }),
+        // Compact boundary marker — written by Claude Code on /compact
+        JSON.stringify({
+          type: "system",
+          subtype: "compact_boundary",
+          content: "Conversation compacted",
+          timestamp: "2026-04-14T11:34:09.276Z",
+          compactMetadata: {
+            trigger: "auto",
+            preTokens: 167153,
+            postTokens: 8287,
+            durationMs: 132766,
+          },
+        }),
+      ];
+      await writeFile(file_path, lines.join("\n"));
+
+      const result = await read_session_context(session_id);
+      expect(result).not.toBeNull();
+      expect(result!.compactions).toBe(1);
+      // used_tokens is still from the last assistant turn (100k)
+      expect(result!.used_tokens).toBe(100_000);
+    });
+
+    it("counts both compact_boundary markers and token-drop compactions", async () => {
+      const session_id = "both-det-1234-5678-9012-123456789012";
+      const file_path = join(tmp_dir, ".claude", "projects", "test-project", `${session_id}.jsonl`);
+
+      // Session with one compact_boundary marker AND one token-drop compaction.
+      // The compact_boundary is the primary detection; the token-drop is fallback
+      // for older transcripts. Both should count independently.
+      const lines = [
+        // Turn 1: 100k context
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            usage: {
+              input_tokens: 80000,
+              cache_creation_input_tokens: 10000,
+              cache_read_input_tokens: 10000,
+              output_tokens: 500,
+            },
+          },
+        }),
+        // Explicit compact_boundary — compaction #1
+        JSON.stringify({
+          type: "system",
+          subtype: "compact_boundary",
+          content: "Conversation compacted",
+          timestamp: "2026-04-14T11:34:09.276Z",
+        }),
+        // Turn 2: post-compaction, much smaller — but this is an expected drop
+        // after a compact_boundary, so the token-drop heuristic also fires
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            usage: {
+              input_tokens: 8000,
+              cache_creation_input_tokens: 1000,
+              cache_read_input_tokens: 1000,
+              output_tokens: 200,
+            },
+          },
+        }),
+        // Turn 3: grows to 80k
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            usage: {
+              input_tokens: 60000,
+              cache_creation_input_tokens: 10000,
+              cache_read_input_tokens: 10000,
+              output_tokens: 400,
+            },
+          },
+        }),
+        // Turn 4: drops to 15k — token-drop compaction #2 (no boundary marker)
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            usage: {
+              input_tokens: 10000,
+              cache_creation_input_tokens: 2500,
+              cache_read_input_tokens: 2500,
+              output_tokens: 150,
+            },
+          },
+        }),
+      ];
+      await writeFile(file_path, lines.join("\n"));
+
+      const result = await read_session_context(session_id);
+      expect(result).not.toBeNull();
+      // 1 from compact_boundary + 1 from token-drop after turn 2 + 1 from token-drop after turn 4 = 3
+      expect(result!.compactions).toBe(3);
+    });
+
     it("does not count minor token decreases as compactions", async () => {
       const session_id = "no-cmpact-1234-5678-9012-123456789012";
       const file_path = join(tmp_dir, ".claude", "projects", "test-project", `${session_id}.jsonl`);

--- a/packages/daemon/src/__tests__/session-context.test.ts
+++ b/packages/daemon/src/__tests__/session-context.test.ts
@@ -416,8 +416,9 @@ describe("session-context", () => {
 
       const result = await read_session_context(session_id);
       expect(result).not.toBeNull();
-      // 1 from compact_boundary + 1 from token-drop after turn 2 + 1 from token-drop after turn 4 = 3
-      expect(result!.compactions).toBe(3);
+      // 1 from compact_boundary + 1 from token-drop at turn 4 = 2
+      // (turn 2's token drop is NOT counted — prev_total resets on boundary detection)
+      expect(result!.compactions).toBe(2);
     });
 
     it("does not count minor token decreases as compactions", async () => {

--- a/packages/daemon/src/__tests__/usage-api.test.ts
+++ b/packages/daemon/src/__tests__/usage-api.test.ts
@@ -184,7 +184,7 @@ describe("fetch_subscription_usage", () => {
     expect(result).toBeNull();
   });
 
-  it("includes extra usage when enabled", async () => {
+  it("includes extra usage when enabled (cents to dollars)", async () => {
     keychain_result = {
       stdout: JSON.stringify({
         claudeAiOauth: { accessToken: "test-token", expiresAt: "2099-01-01T00:00:00Z" },
@@ -192,9 +192,15 @@ describe("fetch_subscription_usage", () => {
       error: null,
     };
 
+    // API returns used_credits and monthly_limit in cents
     const api_response: SubscriptionUsageResponse = {
       five_hour: { utilization: 10, resets_at: new Date(Date.now() + 3_600_000).toISOString() },
-      extra_usage: { is_enabled: true, monthly_limit: 100, used_credits: 23.5, utilization: 23.5 },
+      extra_usage: {
+        is_enabled: true,
+        monthly_limit: 10000, // 10000 cents = $100
+        used_credits: 2350, // 2350 cents = $23.50
+        utilization: 23.5,
+      },
     };
 
     fetch_spy.mockResolvedValueOnce(
@@ -207,6 +213,36 @@ describe("fetch_subscription_usage", () => {
     const result = await fetch_subscription_usage();
     expect(result).not.toBeNull();
     expect(result!.summary).toContain("Extra: $23.50/$100");
+  });
+
+  it("formats extra usage with small cent amounts correctly", async () => {
+    keychain_result = {
+      stdout: JSON.stringify({
+        claudeAiOauth: { accessToken: "test-token", expiresAt: "2099-01-01T00:00:00Z" },
+      }),
+      error: null,
+    };
+
+    // Verify that 523 cents shows as $5.23, not $523.00
+    const api_response: SubscriptionUsageResponse = {
+      extra_usage: {
+        is_enabled: true,
+        monthly_limit: 10000, // $100
+        used_credits: 523, // $5.23
+        utilization: 5.23,
+      },
+    };
+
+    fetch_spy.mockResolvedValueOnce(
+      new Response(JSON.stringify(api_response), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const result = await fetch_subscription_usage();
+    expect(result).not.toBeNull();
+    expect(result!.summary).toContain("Extra: $5.23/$100");
   });
 
   it("formats resets_in for weekly usage", async () => {

--- a/packages/daemon/src/session-context.ts
+++ b/packages/daemon/src/session-context.ts
@@ -115,6 +115,7 @@ async function parse_session_usage(
       // without waiting for the next assistant turn's token drop.
       if (entry.type === "system" && entry.subtype === "compact_boundary") {
         compactions++;
+        prev_total = 0; // reset so the subsequent token drop doesn't double-count
         continue;
       }
 

--- a/packages/daemon/src/session-context.ts
+++ b/packages/daemon/src/session-context.ts
@@ -109,6 +109,15 @@ async function parse_session_usage(
   for (const line of lines) {
     try {
       const entry = JSON.parse(line) as Record<string, unknown>;
+
+      // Detect explicit compaction markers written by Claude Code.
+      // These appear immediately when /compact runs, so we catch compactions
+      // without waiting for the next assistant turn's token drop.
+      if (entry.type === "system" && entry.subtype === "compact_boundary") {
+        compactions++;
+        continue;
+      }
+
       if (entry.type !== "assistant") continue;
 
       const message = entry.message as Record<string, unknown> | undefined;

--- a/packages/daemon/src/usage-api.ts
+++ b/packages/daemon/src/usage-api.ts
@@ -136,8 +136,9 @@ function format_usage_summary(data: SubscriptionUsageResponse): string {
   }
 
   if (data.extra_usage?.is_enabled) {
-    const spent = data.extra_usage.used_credits.toFixed(2);
-    const limit = data.extra_usage.monthly_limit.toFixed(0);
+    // API returns used_credits and monthly_limit in cents — convert to dollars
+    const spent = (data.extra_usage.used_credits / 100).toFixed(2);
+    const limit = (data.extra_usage.monthly_limit / 100).toFixed(0);
     parts.push(`Extra: $${spent}/$${limit}`);
   }
 


### PR DESCRIPTION
## Summary

- **Compaction detection**: Added scanning for `type:"system" subtype:"compact_boundary"` JSONL entries in `session-context.ts`. Claude Code writes these markers immediately when `/compact` runs, so compactions are detected without waiting for the next assistant turn's token drop. The existing token-drop heuristic is preserved as fallback for older transcripts.
- **Extra usage formatting**: Fixed cent-to-dollar conversion in `usage-api.ts` — `used_credits` and `monthly_limit` from the Anthropic API are in cents, now divided by 100 before display (e.g. `$5.23/$100` instead of `$523.00/$10000`).

## Test plan

- [x] Added test: `compact_boundary` marker detected as compaction even without subsequent assistant turn
- [x] Added test: both `compact_boundary` markers and token-drop heuristic count independently
- [x] Updated test: extra usage inputs changed from dollars to cents, expected output unchanged
- [x] Added test: small cent amounts format correctly (`523 cents → $5.23`)
- [x] All 25 tests pass (14 session-context + 11 usage-api)
- [x] Biome lint clean, no TypeScript errors in changed files

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)