### PR TITLE
refactor(reviewer): move static review mechanics to initialPrompt

### DIFF
--- a/config/claude/agents/reviewer.md
+++ b/config/claude/agents/reviewer.md
@@ -6,6 +6,45 @@ description: >
   building the feature. Fresh eyes every time.
 model: sonnet
 allowed-tools: Read, Glob, Grep, Bash
+initialPrompt: |
+  You are performing a pull-request review as the LobsterFarm Reviewer GitHub
+  App. The PR-specific context follows this message — read it carefully
+  before acting.
+
+  ## How to post your review
+
+  Use the `gh` CLI. Substitute the PR number from the context below:
+
+      gh pr review <N> --request-changes --body "<review body>"
+      gh pr review <N> --approve --body "<review body>"
+
+  Decision rule: if there is ANY actionable code-quality feedback (🔴 or 🟡),
+  request changes. Only approve if the code is genuinely clean with no
+  improvements needed. Every review ends with a clear verdict — approved or
+  changes requested. Never ambiguous.
+
+  ## Non-negotiable posting rules
+
+  - Post your review exactly ONCE. `gh pr review` produces no stdout on
+    success; check the exit code, not the output. Do not retry if the
+    command exited 0.
+  - Append `&& echo "✓ Review posted"` so you can see the success marker.
+  - Never dismiss, delete, or modify reviews you have already posted. If
+    you accidentally post duplicate reviews, leave them — do not try to
+    clean up.
+  - After posting, verify the review landed by asking the API for the most
+    recent bot review on this PR. If the state is CHANGES_REQUESTED or
+    APPROVED, your review is confirmed. If the state is DISMISSED or the
+    review is missing, something went wrong — stop, do not retry.
+
+  ## What comes next
+
+  The dynamic context below identifies the PR (number, title, branch, repo),
+  provides any linked-issue spec, and describes the specific review
+  procedure for this invocation (two-pass spec-compliance gate,
+  prior-feedback verification, CI handling, merge instructions, etc.).
+  Follow that procedure exactly — it is authoritative and may differ
+  between PR lifecycles.
 ---
 
 # Reviewer — Soul

--- a/packages/daemon/src/__tests__/check-suite-handler.test.ts
+++ b/packages/daemon/src/__tests__/check-suite-handler.test.ts
@@ -701,10 +701,11 @@ describe("build_v2_reviewer_prompt", () => {
     expect(prompt).toContain("Do NOT run `gh pr merge`");
   });
 
-  it("emits approve and request-changes gh commands with the PR number", () => {
+  it("includes PR header with number for dynamic context", () => {
     const prompt = build_v2_reviewer_prompt(pr, REPO_PATH, "");
-    expect(prompt).toContain("gh pr review 42 --request-changes");
-    expect(prompt).toContain("gh pr review 42 --approve");
+    // gh pr review command templates now live in the agent's initialPrompt
+    // frontmatter — the dynamic prefix only needs to identify which PR.
+    expect(prompt).toContain("PR #42");
   });
 
   it("includes prior feedback section when provided (Decision 5)", () => {

--- a/packages/daemon/src/__tests__/webhook-handler.test.ts
+++ b/packages/daemon/src/__tests__/webhook-handler.test.ts
@@ -1503,8 +1503,16 @@ describe("handle_github_webhook", () => {
     });
   });
 
-  describe("reviewer prompt content", () => {
-    it("includes pre-existing review check instruction", async () => {
+  // Issue #287 — the static review mechanics (identity, posting rules,
+  // echo-marker, verify-landing, never-dismiss) now live in the reviewer
+  // agent's `initialPrompt` frontmatter at `config/claude/agents/reviewer.md`.
+  // The dynamic per-PR prefix emitted by `build_reviewer_prompt` is piped via
+  // stdin and is prepended by `initialPrompt` at session start. These tests
+  // cover what's genuinely dynamic: the pre-existing-review dedup check
+  // (which references the repo / PR number) and the PR-numbered commands in
+  // the two-pass and merge sections.
+  describe("reviewer prompt content (dynamic per-PR prefix)", () => {
+    it("includes pre-existing review check instruction with correct API URL", async () => {
       const body = make_pr_payload("opened", 300, "test-org/lobster-farm");
       const req = make_request(body, {
         "x-github-event": "pull_request",
@@ -1525,14 +1533,12 @@ describe("handle_github_webhook", () => {
       const spawn_args = (ctx.session_manager as any).spawn.mock.calls[0]![0];
       const prompt: string = spawn_args.prompt;
 
-      // Pre-existing review check (suggestion 2 from review)
-      expect(prompt).toContain("Before posting your review, check for any existing reviews");
+      expect(prompt).toContain("Before posting, check for any existing reviews");
       expect(prompt).toContain('select(.user.login | endswith("[bot]"))');
-      // API URL uses correct PR number
       expect(prompt).toContain("gh api repos/test-org/lobster-farm/pulls/300/reviews");
     });
 
-    it("includes echo verification in review commands", async () => {
+    it("references the PR number in the two-pass review commands", async () => {
       const body = make_pr_payload("opened", 301, "test-org/lobster-farm");
       const req = make_request(body, {
         "x-github-event": "pull_request",
@@ -1553,14 +1559,14 @@ describe("handle_github_webhook", () => {
       const spawn_args = (ctx.session_manager as any).spawn.mock.calls[0]![0];
       const prompt: string = spawn_args.prompt;
 
-      expect(prompt).toContain('&& echo "✓ Review posted"');
-      expect(prompt).toContain("Post your review ONCE. Do not retry if the command exits 0.");
-      expect(prompt).toContain("Never dismiss, delete, or modify reviews you have already posted.");
-      // Review commands use correct PR number
-      expect(prompt).toContain("gh pr review 301 --");
+      // The dynamic prefix identifies the PR for the review workflow.
+      expect(prompt).toContain("PR #301");
+      // The prompt instructs the reviewer to use the initial-instruction
+      // commands for the combined Pass 2 posting (no PR-numbered duplicates).
+      expect(prompt).toContain("from your initial instructions");
     });
 
-    it("includes post-review verification API call", async () => {
+    it("includes merge instructions with PR number", async () => {
       const body = make_pr_payload("opened", 302, "test-org/lobster-farm");
       const req = make_request(body, {
         "x-github-event": "pull_request",
@@ -1581,11 +1587,8 @@ describe("handle_github_webhook", () => {
       const spawn_args = (ctx.session_manager as any).spawn.mock.calls[0]![0];
       const prompt: string = spawn_args.prompt;
 
-      expect(prompt).toContain(
-        `gh api repos/test-org/lobster-farm/pulls/302/reviews --jq '[.[] | select(.user.login | endswith("[bot]"))] | last | .state // "NOT_FOUND"'`,
-      );
-      expect(prompt).toContain("your review is confirmed. Move on.");
-      expect(prompt).toContain("If the state is DISMISSED or NOT_FOUND, something went wrong");
+      expect(prompt).toContain("gh pr merge 302 --squash --delete-branch");
+      expect(prompt).toContain("gh pr checks 302 --required");
     });
   });
 

--- a/packages/daemon/src/check-suite-handler.ts
+++ b/packages/daemon/src/check-suite-handler.ts
@@ -594,7 +594,13 @@ interface PriorReviewFeedback {
 }
 
 /**
- * Build the v2 reviewer prompt.
+ * Build the v2 reviewer prompt (dynamic per-PR prefix).
+ *
+ * The reviewer agent's `initialPrompt` (see `config/claude/agents/reviewer.md`)
+ * carries the static mechanics — identity, posting rules, verdict format,
+ * echo / verify-landing safety. This function emits only the per-PR prefix:
+ * header, optional prior-feedback block, optional linked-issue context, and
+ * v2-specific procedural notes (CI already green, don't merge, run /review).
  *
  * Differences from the v1 prompt:
  *
@@ -620,22 +626,13 @@ export function build_v2_reviewer_prompt(
     "",
     "Run /ultrareview to do a comprehensive code review.",
     "",
-    "Post your review on the PR using gh cli.",
-    "You are authenticated as the LobsterFarm Reviewer GitHub App.",
-    "",
-    "Review standards:",
-    "- Every piece of actionable feedback should be included.",
-    "- If there is ANY actionable feedback, request changes:",
-    `  gh pr review ${String(pr.number)} --request-changes --body "<your review>"`,
-    "- If the code is genuinely clean with no improvements needed, approve:",
-    `  gh pr review ${String(pr.number)} --approve --body "Looks good."`,
-    "",
     "CI status: GREEN. CI has already completed successfully against this exact",
     "head SHA. Do NOT run `gh pr checks` or attempt to gate on CI yourself —",
     "the check_suite-driven lifecycle has already verified it.",
     "",
     "Do NOT run `gh pr merge`. The merge-gate handles merging after approval —",
-    "your job is the review, not the merge.",
+    `your job is the review, not the merge. Post using PR #${String(pr.number)}`,
+    "with the commands from your initial instructions.",
   ];
 
   if (prior_feedback) {

--- a/packages/daemon/src/pr-cron.ts
+++ b/packages/daemon/src/pr-cron.ts
@@ -430,19 +430,15 @@ export class PRReviewCron {
       issue_context = contexts.filter(Boolean).join("\n\n---\n\n");
     }
 
+    // Dynamic per-PR prefix. Static mechanics (identity, posting rules,
+    // verdict format, echo / verify-landing safety) live in the reviewer
+    // agent's `initialPrompt` at `config/claude/agents/reviewer.md`.
     const prompt_lines = [
       `Review PR #${String(pr.number)}: "${pr.title}" on branch ${pr.headRefName}.`,
       `Repository: ${repo_path}`,
       "",
-      "Run /ultrareview to do a comprehensive code review.",
-      "Post your review on the PR using gh cli.",
-      "",
-      "Review standards:",
-      "- Every piece of actionable feedback should be included.",
-      "- If there is ANY actionable feedback, request changes:",
-      `  gh pr review ${String(pr.number)} --request-changes --body "<your review>"`,
-      "- If the code is genuinely clean with no improvements needed, approve:",
-      `  gh pr review ${String(pr.number)} --approve --body "Looks good."`,
+      "Run /ultrareview to do a comprehensive code review, then post using the",
+      `commands from your initial instructions with PR #${String(pr.number)}.`,
       "",
       "Before merging, check CI status:",
       `  gh pr checks ${String(pr.number)} --required`,

--- a/packages/daemon/src/webhook-handler.ts
+++ b/packages/daemon/src/webhook-handler.ts
@@ -1470,6 +1470,19 @@ async function spawn_deploy_triage(
 
 // ── Prompt building ──
 
+/**
+ * Builds the dynamic per-PR prefix for the v1 (pull_request webhook) reviewer
+ * lifecycle. The reviewer agent's `initialPrompt` (see
+ * `config/claude/agents/reviewer.md`) carries the static mechanics — identity,
+ * posting rules, verdict format, echo / verify-landing safety. This function
+ * emits only what changes per PR: header, pre-existing-review dedup check,
+ * linked-issue context, the two-pass procedure, and v1-specific merge steps.
+ *
+ * The effective first user turn the reviewer sees is:
+ *     <initialPrompt from frontmatter>  ← prepended automatically
+ *     <blank line>
+ *     <this builder's output, piped via stdin>
+ */
 export function build_reviewer_prompt(
   pr: WebhookPR,
   repo_path: string,
@@ -1485,10 +1498,7 @@ export function build_reviewer_prompt(
     `Review PR #${pr_num}: "${pr.title}" on branch ${pr.head.ref}.`,
     `Repository: ${repo_path}`,
     "",
-    "You are authenticated as the LobsterFarm Reviewer GitHub App.",
-    "Post your review via `gh` CLI.",
-    "",
-    "Before posting your review, check for any existing reviews you've already posted:",
+    "Before posting, check for any existing reviews you've already posted:",
     `  gh api repos/${repo_full_name}/pulls/${pr_num}/reviews --jq '[.[] | select(.user.login | endswith("[bot]"))] | { count: length, reviews: map({state, submitted_at}) }'`,
     "If a review already exists with state APPROVED or CHANGES_REQUESTED, skip posting",
     "and go directly to the merge step (if approved) or stop (if changes requested).",
@@ -1623,23 +1633,10 @@ export function build_reviewer_prompt(
   }
 
   lines.push(
-    "Post the combined review using the existing approve / request-changes",
-    "logic:",
-    "",
-    "- If there is ANY actionable code-quality feedback, request changes:",
-    `    gh pr review ${pr_num} --request-changes --body "<combined body>" && echo "✓ Review posted"`,
-    "- If the code is genuinely clean with no improvements needed, approve:",
-    `    gh pr review ${pr_num} --approve --body "<combined body>" && echo "✓ Review posted"`,
-    "",
-    "After posting your review, verify it landed:",
-    `  gh api repos/${repo_full_name}/pulls/${pr_num}/reviews --jq '[.[] | select(.user.login | endswith("[bot]"))] | last | .state // "NOT_FOUND"'`,
-    "If the state is CHANGES_REQUESTED or APPROVED, your review is confirmed. Move on.",
-    "If the state is DISMISSED or NOT_FOUND, something went wrong — do NOT retry, just stop.",
-    "",
-    "IMPORTANT:",
-    "- Post your review ONCE. Do not retry if the command exits 0.",
-    "- Never dismiss, delete, or modify reviews you have already posted.",
-    "- If you accidentally post duplicate reviews, leave them — do not try to clean up.",
+    "Post the combined review using the approve / request-changes commands",
+    "from your initial instructions — one post, echo marker, verify it",
+    `landed. Use PR #${pr_num} in the command and \`${repo_full_name}\` in`,
+    "the verify API call.",
     "",
     "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
     "### CI status & merge (only relevant if Pass 2 approved)",


### PR DESCRIPTION
## Summary

- Relocate the static review mechanics (identity, posting rules, echo marker, never-dismiss rule, verify-landing) from the three per-spawn prompt builders into the reviewer agent's `initialPrompt` YAML frontmatter.
- Claude Code 2.1.84+ auto-prepends `initialPrompt` as the first user turn when the agent is the main thread, so the effective prompt the reviewer sees is unchanged.
- Builders now emit only what's genuinely dynamic per PR: header, pre-existing-review dedup check, linked-issue spec, and lifecycle-specific procedure (two-pass / CI handling / merge).

## Investigation

Reverse-engineered Claude Code's `initialPrompt` handling before implementing:
- Schema: `y.string().optional().describe("Auto-submitted as the first user turn when this agent is the main thread agent. Slash commands are processed. Prepended to any user-provided prompt.")`
- Runtime path: `if(R.initialPrompt) $.prependUserMessage(R.initialPrompt)`
- Empirical test with a scratch agent confirmed: `initialPrompt` is PREPENDED to stdin, so the frontmatter content runs first and references "the context below".

This inverted the ordering assumption in the issue spec (which said initialPrompt runs after piped context). Adjusted the content so the frontmatter refers forward to the dynamic context rather than backward.

## Scope decision

The issue listed the two-pass procedure as a candidate for `initialPrompt`. Dropped that from the frontmatter move: `pr-cron` and `check-suite-handler` (v2) don't use two-pass and moving it would silently bolt two-pass onto those lifecycles. Kept the frontmatter to **shared** mechanics only (posting rules, gh command templates, verdict rule, safety rails). Each builder still owns its own procedure.

## Changes

- `config/claude/agents/reviewer.md` — added `initialPrompt` with auth identity, gh CLI command formats (with `<N>` placeholder), verdict decision rule, echo marker, never-dismiss rules, verify-landing-via-API, pointer to dynamic context.
- `packages/daemon/src/webhook-handler.ts` — reduced `build_reviewer_prompt` (v1 two-pass). Kept: header, pre-existing review dedup check, linked issue context, two-pass procedure, three-case CI handling, merge instructions. Removed: redundant auth statement, post-once/never-dismiss/echo/verify-landing block. Now references "your initial instructions" for the combined Pass 2 posting commands.
- `packages/daemon/src/check-suite-handler.ts` — reduced `build_v2_reviewer_prompt`. Kept: header, head SHA, "Run /review", CI-green assurance, do-not-merge, prior feedback, linked issue context. Removed: auth statement, "Review standards" block with gh pr review commands.
- `packages/daemon/src/pr-cron.ts` — reduced inline `spawn_reviewer` prompt. Removed the "Review standards" block that duplicated the gh pr review command templates.
- Updated tests in `__tests__/webhook-handler.test.ts` and `__tests__/check-suite-handler.test.ts` to assert on what actually remains in the stdin prefix. Dropped assertions for strings that moved into frontmatter.

## Note on deployment

The source is `config/claude/agents/reviewer.md`; it's deployed to `~/.claude/agents/reviewer.md` via `lf init`. Operators need to re-run `lf init` (or equivalent) after this merges for the frontmatter change to take effect on the host where reviewer sessions spawn.

## Test plan

- [x] `pnpm --filter daemon run test` — 1006/1006 passing
- [x] `pnpm biome check` — clean
- [ ] After merge: run `lf init` on the daemon host so the deployed agent file picks up the new `initialPrompt`
- [ ] Observe the next real PR review cycle to confirm the reviewer still posts with the echo marker and verifies landing

Closes #287