### PR TITLE
feat(daemon): SessionStart hook injection replaces tmux bridging (#290)

### DIFF
--- a/config/claude/hooks/session-start-inject.sh
+++ b/config/claude/hooks/session-start-inject.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# SessionStart hook — inject a pending Discord message as initial context.
+#
+# The LobsterFarm daemon writes a pending-message JSON file to disk before
+# spawning `claude`, and passes its path via the LF_PENDING_FILE env var.
+# This hook reads that file during Claude's SessionStart event (fires on
+# both fresh sessions and --resume), emits the message as additionalContext
+# via hookSpecificOutput, and unlinks the file.
+#
+# Replaces the old tmux send-keys "bridge" approach which raced against the
+# MCP plugin's subscription readiness. Hooks fire deterministically during
+# Claude init, eliminating the race entirely.
+#
+# Contract:
+#   - Read LF_PENDING_FILE (path to JSON file). No-op if unset or missing.
+#   - File format: {"user": "...", "channel_id": "...", "message_id": "...",
+#                   "content": "...", "ts": "..."}
+#   - Emit {"hookSpecificOutput": {"hookEventName": "SessionStart",
+#           "additionalContext": "<formatted message>"}} on stdout.
+#   - Unlink the file after successful read.
+#   - Exit 0 always — never block session start.
+#
+# Requires: jq (present in every lobster-farm environment).
+
+set -u
+
+PENDING_FILE="${LF_PENDING_FILE:-}"
+
+# No pending file configured — quietly no-op.
+if [ -z "$PENDING_FILE" ]; then
+  exit 0
+fi
+
+# File missing — quietly no-op. Could be stale env var on --resume when the
+# daemon didn't write a fresh pending file, or a race where another hook
+# invocation already consumed it.
+if [ ! -f "$PENDING_FILE" ]; then
+  exit 0
+fi
+
+# Read the file. If read fails (permissions, disk error), no-op silently
+# rather than blocking session start.
+RAW="$(cat "$PENDING_FILE" 2>/dev/null)" || exit 0
+if [ -z "$RAW" ]; then
+  rm -f "$PENDING_FILE" 2>/dev/null || true
+  exit 0
+fi
+
+# Parse fields via jq. On parse failure, no-op but still try to unlink so
+# we don't get stuck on a malformed file.
+USER_NAME="$(printf '%s' "$RAW" | jq -r '.user // "a user"' 2>/dev/null)" || USER_NAME="a user"
+CONTENT="$(printf '%s' "$RAW" | jq -r '.content // ""' 2>/dev/null)" || CONTENT=""
+CHANNEL_ID="$(printf '%s' "$RAW" | jq -r '.channel_id // ""' 2>/dev/null)" || CHANNEL_ID=""
+TS="$(printf '%s' "$RAW" | jq -r '.ts // ""' 2>/dev/null)" || TS=""
+
+if [ -z "$CONTENT" ]; then
+  rm -f "$PENDING_FILE" 2>/dev/null || true
+  exit 0
+fi
+
+# Build the additional-context string. jq's -Rs read + tojson escapes the
+# full multi-line content safely for JSON embedding.
+CTX_HEADER="A user just messaged you in Discord. Respond to them via the Discord reply tool (the channel plugin is already loaded)."
+if [ -n "$CHANNEL_ID" ]; then
+  CTX_HEADER="$CTX_HEADER Channel: $CHANNEL_ID."
+fi
+if [ -n "$TS" ]; then
+  CTX_HEADER="$CTX_HEADER Sent at: $TS."
+fi
+
+ADDITIONAL_CONTEXT="$(printf '%s\n\nFrom %s:\n%s\n' "$CTX_HEADER" "$USER_NAME" "$CONTENT")"
+
+# Emit the hook output JSON. jq --arg safely escapes the context string.
+jq -cn \
+  --arg ctx "$ADDITIONAL_CONTEXT" \
+  '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $ctx}}'
+
+# Unlink after successful emit so a later --resume doesn't re-inject stale
+# content. Best-effort — a failure here just means drain_pending_files or
+# the next run will clean it up.
+rm -f "$PENDING_FILE" 2>/dev/null || true
+
+exit 0

--- a/packages/cli/src/commands/init/generate.ts
+++ b/packages/cli/src/commands/init/generate.ts
@@ -1,5 +1,5 @@
 import { statSync } from "node:fs";
-import { copyFile, mkdir, readdir, writeFile } from "node:fs/promises";
+import { chmod, copyFile, mkdir, readdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -7,6 +7,7 @@ import {
   type PathConfig,
   type TemplateVariables,
   agents_dir,
+  claude_hooks_dir,
   claude_md_path,
   claude_settings_path,
   dna_versions_dir,
@@ -121,11 +122,41 @@ export async function generate_config_files(
     // skills directory might not exist — not fatal
   }
 
+  // ── Hooks: copy all hook scripts and chmod +x ──
+  // Hooks are tiny shell scripts invoked by Claude Code during lifecycle
+  // events (SessionStart, PreToolUse, Stop, etc.). See generate_settings()
+  // for the settings.json registration that wires them up.
+  const hooks_src = join(config_dir, "claude", "hooks");
+  try {
+    const hook_entries = await readdir(hooks_src, { withFileTypes: true });
+    const dest_hooks_dir = claude_hooks_dir(path_overrides);
+    await mkdir(dest_hooks_dir, { recursive: true });
+    for (const entry of hook_entries) {
+      if (!entry.isFile()) continue;
+      const src_file = join(hooks_src, entry.name);
+      const dest_file = join(dest_hooks_dir, entry.name);
+      await copyFile(src_file, dest_file);
+      // Preserve executability — copyFile doesn't always carry perms across
+      // filesystems, so set +x explicitly on shell scripts.
+      if (entry.name.endsWith(".sh")) {
+        await chmod(dest_file, 0o755);
+      }
+      created.push(dest_file);
+    }
+  } catch {
+    // hooks directory might not exist — not fatal
+  }
+
   return created;
 }
 
 /** Generate the ~/.claude/settings.json with bypass permissions and hooks. */
 export async function generate_settings(path_overrides?: Partial<PathConfig>): Promise<string> {
+  // Absolute path to the deployed SessionStart hook. We use an absolute path
+  // rather than relying on $HOME expansion because Claude Code's hook runner
+  // doesn't guarantee a shell wrapper.
+  const session_start_hook = join(claude_hooks_dir(path_overrides), "session-start-inject.sh");
+
   const settings = {
     permissions: {
       defaultMode: "bypassPermissions",
@@ -133,6 +164,23 @@ export async function generate_settings(path_overrides?: Partial<PathConfig>): P
     effortLevel: "high",
     skipDangerousModePermissionPrompt: true,
     hooks: {
+      SessionStart: [
+        {
+          matcher: "",
+          hooks: [
+            {
+              type: "command",
+              // Deployed by generate_config_files() from
+              // config/claude/hooks/session-start-inject.sh. Reads the
+              // LF_PENDING_FILE env var (set by the daemon before spawn)
+              // and emits the pending Discord message as additionalContext.
+              // No-ops if the env var is unset or the file is missing.
+              command: session_start_hook,
+              timeout: 5,
+            },
+          ],
+        },
+      ],
       PreToolUse: [
         {
           matcher: "Edit|Write",
@@ -191,6 +239,7 @@ export async function create_directory_structure(
     dna_versions_dir(path_overrides),
     agents_dir(path_overrides),
     skills_dir(path_overrides),
+    claude_hooks_dir(path_overrides),
   ];
 
   for (const dir of dirs) {

--- a/packages/daemon/src/__tests__/resume-nudge.test.ts
+++ b/packages/daemon/src/__tests__/resume-nudge.test.ts
@@ -4,12 +4,14 @@ import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
 import type { LobsterFarmConfig } from "@lobster-farm/shared";
 import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PersistedPoolBot } from "../persistence.js";
-import { type PoolBot, pending_file_path } from "../pool.js";
+import { type PoolBot, pending_json_path } from "../pool.js";
 import { BotPoolTestBase } from "./helpers/test-bot-pool-base.js";
 
 // ── Mocks ──
 
-// Mock node:fs/promises — writeFile is the key assertion target
+// Mock node:fs/promises — writeFile is the key assertion target. The hook
+// contract is "daemon writes JSON pending file before spawn, sets env var" —
+// that's what we verify here.
 vi.mock("node:fs/promises", async () => {
   const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
   return {
@@ -22,25 +24,23 @@ vi.mock("node:fs/promises", async () => {
   };
 });
 
-// Mock node:child_process — controls tmux readiness simulation
+// Mock node:child_process — we assert send-keys is NOT called for message
+// bridging (the whole point of #290). execFileSync is still used by other
+// code paths (capture-pane, has-session) so we keep a no-op default.
 vi.mock("node:child_process", async () => {
   const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
   return {
     ...actual,
-    execFileSync: vi.fn().mockImplementation(() => {
-      throw new Error("not mocked");
-    }),
+    execFileSync: vi.fn().mockReturnValue(""),
     spawn: vi.fn(),
   };
 });
 
 import { execFileSync } from "node:child_process";
-import { access, writeFile } from "node:fs/promises";
+import { writeFile } from "node:fs/promises";
 
 // ── Test helpers ──
 
-// Use a static temp path per test run — mkdtemp is not mocked but we use a
-// unique-enough path since fs writes are already mocked in this file.
 let temp_dir: string;
 
 function make_config(): LobsterFarmConfig {
@@ -71,6 +71,18 @@ function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
   };
 }
 
+/** Find the start_tmux call for a given bot and return the extra_env arg. */
+function extra_env_from_start_tmux_calls(
+  start_tmux: Mock,
+  tmux_session: string,
+): Record<string, string> | undefined {
+  const call = start_tmux.mock.calls.find((c: unknown[]) => {
+    const bot = c[0] as { tmux_session: string } | undefined;
+    return bot?.tmux_session === tmux_session;
+  });
+  return call?.[6] as Record<string, string> | undefined;
+}
+
 /**
  * Test-friendly BotPool subclass. Stubs tmux/filesystem side effects
  * and exposes internals for resume_parked_bots testing.
@@ -95,18 +107,15 @@ class TestBotPool extends BotPoolTestBase {
 
 // ── Tests ──
 
-describe("resume nudge (issue #156)", () => {
+describe("resume nudge via SessionStart hook (issue #290)", () => {
   let config: LobsterFarmConfig;
   let pool: TestBotPool;
+  let start_tmux_spy: Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // Use fake timers so we can skip the readiness polling delays
     vi.useFakeTimers({ shouldAdvanceTime: true });
 
-    // Use a unique temp path to isolate config from production ~/.lobsterfarm.
-    // mkdtemp is not available here (fs mocked), but mkdir is also mocked so
-    // the directory doesn't need to actually exist — we just need a non-production path.
     temp_dir = join(tmpdir(), `resume-nudge-test-${Date.now()}`);
     config = make_config();
     pool = new TestBotPool(config);
@@ -127,33 +136,22 @@ describe("resume nudge (issue #156)", () => {
       pool as unknown as Record<string, unknown>,
       "set_bot_avatar" as never,
     ).mockResolvedValue(undefined);
-    vi.spyOn(pool as unknown as Record<string, unknown>, "start_tmux" as never).mockResolvedValue(
-      undefined,
-    );
+    start_tmux_spy = vi
+      .spyOn(pool as unknown as Record<string, unknown>, "start_tmux" as never)
+      .mockResolvedValue(undefined) as unknown as Mock;
     vi.spyOn(pool as unknown as Record<string, unknown>, "is_tmux_alive" as never).mockReturnValue(
       false,
     );
     vi.spyOn(pool as unknown as Record<string, unknown>, "persist" as never).mockResolvedValue(
       undefined,
     );
-
-    // Default: tmux capture-pane returns a ready prompt (bot is ready)
-    (execFileSync as Mock).mockImplementation((cmd: string, args: string[]) => {
-      if (cmd === "tmux" && args[0] === "capture-pane") {
-        return "Listening for channel messages\n❯ ";
-      }
-      if (cmd === "tmux" && args[0] === "has-session") {
-        throw new Error("no session");
-      }
-      return "";
-    });
   });
 
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it("writes nudge file after successful resume", async () => {
+  it("writes a JSON pending nudge file before spawn", async () => {
     const bot = make_bot({
       id: 3,
       state: "parked",
@@ -177,24 +175,16 @@ describe("resume nudge (issue #156)", () => {
     ]);
 
     await pool.resume_parked_bots();
-    // Let the fire-and-forget nudge promise settle
-    await vi.advanceTimersByTimeAsync(25_000);
 
+    // JSON pending file was written with the nudge content
     expect(writeFile).toHaveBeenCalledWith(
-      pending_file_path("pool-3"),
+      pending_json_path("pool-3"),
       expect.stringContaining("daemon restarted"),
       "utf-8",
     );
-
-    // The actual delivery mechanism: tmux send-keys injects the prompt
-    expect(execFileSync).toHaveBeenCalledWith(
-      "tmux",
-      ["send-keys", "-t", "pool-3", expect.stringContaining(pending_file_path("pool-3")), "Enter"],
-      expect.objectContaining({ stdio: "ignore", timeout: 5000 }),
-    );
   });
 
-  it("nudge content includes instruction to continue work", async () => {
+  it("passes LF_PENDING_FILE to start_tmux for the resumed bot", async () => {
     const bot = make_bot({
       id: 0,
       state: "parked",
@@ -218,32 +208,54 @@ describe("resume nudge (issue #156)", () => {
     ]);
 
     await pool.resume_parked_bots();
-    await vi.advanceTimersByTimeAsync(25_000);
+
+    const extra_env = extra_env_from_start_tmux_calls(start_tmux_spy, "pool-0");
+    expect(extra_env).toBeDefined();
+    expect(extra_env?.LF_PENDING_FILE).toBe(pending_json_path("pool-0"));
+  });
+
+  it("nudge JSON payload includes continue-work instruction", async () => {
+    const bot = make_bot({
+      id: 6,
+      state: "parked",
+      channel_id: "ch-6",
+      entity_id: "e1",
+      archetype: "builder",
+      session_id: "sess-6",
+    });
+    pool.inject_bots([bot]);
+    pool.inject_resume_candidates([
+      {
+        id: 6,
+        state: "assigned",
+        channel_id: "ch-6",
+        entity_id: "e1",
+        archetype: "builder",
+        channel_type: null,
+        session_id: "sess-6",
+        last_active: new Date().toISOString(),
+      },
+    ]);
+
+    await pool.resume_parked_bots();
 
     const write_calls = (writeFile as Mock).mock.calls;
     const nudge_call = write_calls.find((c: unknown[]) =>
-      (c[0] as string).includes("lf-pending-pool-0"),
+      (c[0] as string).includes("lf-pending-pool-6"),
     );
     expect(nudge_call).toBeDefined();
 
-    const content = nudge_call![1] as string;
-    expect(content).toContain("continue any in-progress work");
-
-    // send-keys must also be called to deliver the nudge
-    expect(execFileSync).toHaveBeenCalledWith(
-      "tmux",
-      [
-        "send-keys",
-        "-t",
-        "pool-0",
-        expect.stringContaining(`Read ${pending_file_path("pool-0")}`),
-        "Enter",
-      ],
-      expect.objectContaining({ stdio: "ignore", timeout: 5000 }),
-    );
+    // Body is JSON — parse it and assert on the content field
+    const payload = JSON.parse((nudge_call![1] as string).trim());
+    expect(payload).toMatchObject({
+      user: "lobsterfarm-daemon",
+      channel_id: "ch-6",
+    });
+    expect(payload.content).toContain("continue any in-progress work");
+    expect(typeof payload.ts).toBe("string");
   });
 
-  it("nudge file path matches bot ID", async () => {
+  it("JSON file path matches bot ID", async () => {
     const bot = make_bot({
       id: 7,
       state: "assigned",
@@ -267,23 +279,64 @@ describe("resume nudge (issue #156)", () => {
     ]);
 
     await pool.resume_parked_bots();
-    await vi.advanceTimersByTimeAsync(25_000);
 
     expect(writeFile).toHaveBeenCalledWith(
-      pending_file_path("pool-7"),
+      pending_json_path("pool-7"),
       expect.any(String),
       "utf-8",
     );
 
-    // send-keys targets the correct tmux session
-    expect(execFileSync).toHaveBeenCalledWith(
-      "tmux",
-      ["send-keys", "-t", "pool-7", expect.stringContaining(pending_file_path("pool-7")), "Enter"],
-      expect.objectContaining({ stdio: "ignore", timeout: 5000 }),
-    );
+    const extra_env = extra_env_from_start_tmux_calls(start_tmux_spy, "pool-7");
+    expect(extra_env?.LF_PENDING_FILE).toBe(pending_json_path("pool-7"));
   });
 
-  it("does not write nudge file if start_tmux fails", async () => {
+  it("does NOT invoke tmux send-keys for message bridging (the whole point of #290)", async () => {
+    const bot = make_bot({
+      id: 9,
+      state: "parked",
+      channel_id: "ch-9",
+      entity_id: "e1",
+      archetype: "planner",
+      session_id: "sess-9",
+    });
+    pool.inject_bots([bot]);
+    pool.inject_resume_candidates([
+      {
+        id: 9,
+        state: "assigned",
+        channel_id: "ch-9",
+        entity_id: "e1",
+        archetype: "planner",
+        channel_type: null,
+        session_id: "sess-9",
+        last_active: new Date().toISOString(),
+      },
+    ]);
+
+    await pool.resume_parked_bots();
+    // Let any fire-and-forget promises settle — there shouldn't be any
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    // Filter specifically for send-keys targeting the resumed bot's session.
+    // Other send-keys calls (trust dialog auto-accept after start_tmux) are
+    // fine — we just forbid the legacy message-injection pattern.
+    const send_keys_calls = (execFileSync as Mock).mock.calls.filter(
+      (c: unknown[]) =>
+        c[0] === "tmux" &&
+        Array.isArray(c[1]) &&
+        (c[1] as string[])[0] === "send-keys" &&
+        (c[1] as string[])[2] === "pool-9",
+    );
+
+    // Check none of them inject the pending-file read prompt (the legacy pattern)
+    for (const call of send_keys_calls) {
+      const payload = String((call[1] as string[])[3] ?? "");
+      expect(payload).not.toContain("lf-pending");
+      expect(payload).not.toContain("Read ");
+    }
+  });
+
+  it("start_tmux failure before write is handled (write happens first)", async () => {
     const bot = make_bot({
       id: 2,
       state: "parked",
@@ -306,146 +359,25 @@ describe("resume nudge (issue #156)", () => {
       },
     ]);
 
-    // Make start_tmux throw
-    vi.spyOn(pool as unknown as Record<string, unknown>, "start_tmux" as never).mockRejectedValue(
-      new Error("tmux failed"),
-    );
+    start_tmux_spy.mockRejectedValue(new Error("tmux failed"));
 
     await pool.resume_parked_bots();
-    await vi.advanceTimersByTimeAsync(25_000);
 
-    // writeFile should NOT have been called with the pending nudge path
-    const write_calls = (writeFile as Mock).mock.calls;
-    const nudge_call = write_calls.find((c: unknown[]) =>
-      (c[0] as string).includes("lf-pending-pool-2"),
-    );
-    expect(nudge_call).toBeUndefined();
-
-    // send-keys should NOT have been called for this bot
-    const send_calls = (execFileSync as Mock).mock.calls.filter(
+    // The pending file is written before start_tmux is attempted — that's
+    // acceptable for the hook model because the stale file just sits in
+    // /tmp until the next spawn overwrites it (or drain_pending_files
+    // removes the legacy .txt variant, not applicable here). What we
+    // MUST NOT do is fall back to tmux send-keys for delivery.
+    const send_keys_calls = (execFileSync as Mock).mock.calls.filter(
       (c: unknown[]) =>
         c[0] === "tmux" &&
+        Array.isArray(c[1]) &&
         (c[1] as string[])[0] === "send-keys" &&
         (c[1] as string[])[2] === "pool-2",
     );
-    expect(send_calls).toHaveLength(0);
-  });
-
-  it("does not nudge if bot is not ready within timeout", async () => {
-    const bot = make_bot({
-      id: 4,
-      state: "parked",
-      channel_id: "ch-4",
-      entity_id: "e1",
-      archetype: "planner",
-      session_id: "sess-slow",
-    });
-    pool.inject_bots([bot]);
-    pool.inject_resume_candidates([
-      {
-        id: 4,
-        state: "assigned",
-        channel_id: "ch-4",
-        entity_id: "e1",
-        archetype: "planner",
-        channel_type: null,
-        session_id: "sess-slow",
-        last_active: new Date().toISOString(),
-      },
-    ]);
-
-    // tmux capture-pane never returns the ready indicator.
-    // has-session throws — simulates dead session, causing early bail after first attempt.
-    (execFileSync as Mock).mockImplementation((cmd: string, args: string[]) => {
-      if (cmd === "tmux" && args[0] === "capture-pane") {
-        return "Loading conversation history...";
-      }
-      if (cmd === "tmux" && args[0] === "has-session") {
-        throw new Error("no session");
-      }
-      return "";
-    });
-
-    await pool.resume_parked_bots();
-    // wait_for_bot_ready_with_retries uses 30s timeout per attempt (3 attempts max).
-    // With has-session throwing, it bails after the first 30s attempt.
-    await vi.advanceTimersByTimeAsync(35_000);
-
-    // Pending file IS written (before readiness check) so drain_pending_files
-    // can recover it later if the bot becomes ready on a subsequent health tick
-    const write_calls = (writeFile as Mock).mock.calls;
-    const nudge_call = write_calls.find((c: unknown[]) =>
-      (c[0] as string).includes("lf-pending-pool-4"),
-    );
-    expect(nudge_call).toBeDefined();
-
-    // send-keys should NOT have been called for this bot
-    const send_calls = (execFileSync as Mock).mock.calls.filter(
-      (c: unknown[]) =>
-        c[0] === "tmux" &&
-        (c[1] as string[])[0] === "send-keys" &&
-        (c[1] as string[])[2] === "pool-4",
-    );
-    expect(send_calls).toHaveLength(0);
-  });
-
-  it("skips send-keys when drain already claimed the pending file", async () => {
-    // Scenario: bridge writes the pending file, starts readiness polling.
-    // Meanwhile, drain_pending_files (health-check timer) claims and delivers
-    // the file. When bridge's readiness wait succeeds, the file is gone.
-    // Bridge should bail silently — no double-delivery.
-    const bot = make_bot({
-      id: 5,
-      state: "parked",
-      channel_id: "ch-5",
-      entity_id: "e1",
-      archetype: "planner",
-      session_id: "sess-drained",
-    });
-    pool.inject_bots([bot]);
-    pool.inject_resume_candidates([
-      {
-        id: 5,
-        state: "assigned",
-        channel_id: "ch-5",
-        entity_id: "e1",
-        archetype: "planner",
-        channel_type: null,
-        session_id: "sess-drained",
-        last_active: new Date().toISOString(),
-      },
-    ]);
-
-    // Bot becomes ready — wait_for_bot_ready_with_retries will return true
-    (execFileSync as Mock).mockImplementation((cmd: string, args: string[]) => {
-      if (cmd === "tmux" && args[0] === "capture-pane") {
-        return "Listening for channel messages\n❯ ";
-      }
-      return "";
-    });
-
-    // Simulate drain having already deleted the pending file:
-    // writeFile succeeds (bridge writes it), but access() fails (file gone by
-    // the time bridge checks after readiness wait completes).
-    (access as Mock).mockRejectedValue(new Error("ENOENT"));
-
-    await pool.resume_parked_bots();
-    await vi.advanceTimersByTimeAsync(25_000);
-
-    // Pending file was written (before readiness check)
-    const write_calls = (writeFile as Mock).mock.calls;
-    const nudge_call = write_calls.find((c: unknown[]) =>
-      (c[0] as string).includes("lf-pending-pool-5"),
-    );
-    expect(nudge_call).toBeDefined();
-
-    // send-keys should NOT have been called — drain already delivered
-    const send_calls = (execFileSync as Mock).mock.calls.filter(
-      (c: unknown[]) =>
-        c[0] === "tmux" &&
-        (c[1] as string[])[0] === "send-keys" &&
-        (c[1] as string[])[2] === "pool-5",
-    );
-    expect(send_calls).toHaveLength(0);
+    for (const call of send_keys_calls) {
+      const payload = String((call[1] as string[])[3] ?? "");
+      expect(payload).not.toContain("lf-pending");
+    }
   });
 });

--- a/packages/daemon/src/__tests__/session-start-hook.test.ts
+++ b/packages/daemon/src/__tests__/session-start-hook.test.ts
@@ -1,0 +1,230 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeEach, describe, expect, it } from "vitest";
+
+// ── Locate the hook script ──
+// __dirname points at .../packages/daemon/src/__tests__. The hook lives at
+// .../config/claude/hooks/session-start-inject.sh — walk up to the repo root.
+const this_dir = dirname(fileURLToPath(import.meta.url));
+
+function find_hook_script(): string {
+  let dir = this_dir;
+  for (let i = 0; i < 10; i++) {
+    const candidate = join(dir, "config", "claude", "hooks", "session-start-inject.sh");
+    try {
+      if (existsSync(candidate)) return candidate;
+    } catch {
+      /* keep walking */
+    }
+    dir = resolve(dir, "..");
+  }
+  throw new Error("Could not locate session-start-inject.sh — is the repo checkout complete?");
+}
+
+const HOOK_SCRIPT = find_hook_script();
+
+// ── Detect availability ──
+// The hook uses jq + bash. Skip if either is unavailable (CI sandboxes,
+// minimal containers). Locally these should always be present.
+let hook_available = false;
+try {
+  execFileSync("jq", ["--version"], { stdio: "ignore" });
+  execFileSync("bash", ["--version"], { stdio: "ignore" });
+  hook_available = existsSync(HOOK_SCRIPT);
+} catch {
+  hook_available = false;
+}
+
+// ── Helpers ──
+
+/** Invoke the hook script with the given env. Returns stdout + exit code. */
+function run_hook(env: Record<string, string>): { stdout: string; stderr: string; code: number } {
+  const result = spawnSync("bash", [HOOK_SCRIPT], {
+    env: { ...process.env, ...env },
+    encoding: "utf-8",
+    timeout: 5000,
+  });
+  return {
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    code: result.status ?? -1,
+  };
+}
+
+// ── Tests ──
+
+describe.skipIf(!hook_available)("session-start-inject.sh hook", () => {
+  let scratch_dir: string;
+
+  beforeEach(() => {
+    scratch_dir = mkdtempSync(join(tmpdir(), "lf-hook-test-"));
+  });
+
+  it("emits SessionStart hook output when pending file is valid JSON", () => {
+    const pending_path = join(scratch_dir, "lf-pending-pool-0.json");
+    const payload = {
+      user: "alice",
+      channel_id: "1234567890",
+      message_id: "9876543210",
+      content: "hello bot",
+      ts: "2026-04-16T12:00:00.000Z",
+    };
+    writeFileSync(pending_path, JSON.stringify(payload));
+
+    const { stdout, code } = run_hook({ LF_PENDING_FILE: pending_path });
+
+    expect(code).toBe(0);
+    expect(stdout.trim()).not.toBe("");
+
+    const emitted = JSON.parse(stdout.trim());
+    expect(emitted).toHaveProperty("hookSpecificOutput");
+    expect(emitted.hookSpecificOutput.hookEventName).toBe("SessionStart");
+    expect(typeof emitted.hookSpecificOutput.additionalContext).toBe("string");
+
+    const ctx = emitted.hookSpecificOutput.additionalContext as string;
+    expect(ctx).toContain("alice");
+    expect(ctx).toContain("hello bot");
+    expect(ctx).toContain("1234567890"); // channel_id
+    expect(ctx).toContain("2026-04-16T12:00:00.000Z"); // ts
+  });
+
+  it("handles multiline content correctly (JSON escaping)", () => {
+    const pending_path = join(scratch_dir, "lf-pending-pool-1.json");
+    const payload = {
+      user: "bob",
+      channel_id: "ch-1",
+      message_id: "msg-1",
+      content: "line one\nline two\nline three",
+      ts: "2026-04-16T12:00:00.000Z",
+    };
+    writeFileSync(pending_path, JSON.stringify(payload));
+
+    const { stdout, code } = run_hook({ LF_PENDING_FILE: pending_path });
+
+    expect(code).toBe(0);
+    const emitted = JSON.parse(stdout.trim());
+    const ctx = emitted.hookSpecificOutput.additionalContext as string;
+    expect(ctx).toContain("line one");
+    expect(ctx).toContain("line two");
+    expect(ctx).toContain("line three");
+  });
+
+  it("handles special chars in content without breaking JSON output", () => {
+    const pending_path = join(scratch_dir, "lf-pending-pool-2.json");
+    const payload = {
+      user: "eve",
+      channel_id: "ch-2",
+      message_id: "msg-2",
+      content: `quotes "like this" and backslash \\ and backtick \`code\``,
+      ts: "2026-04-16T12:00:00.000Z",
+    };
+    writeFileSync(pending_path, JSON.stringify(payload));
+
+    const { stdout, code } = run_hook({ LF_PENDING_FILE: pending_path });
+
+    expect(code).toBe(0);
+    // If JSON escaping is broken, JSON.parse will throw
+    const emitted = JSON.parse(stdout.trim());
+    const ctx = emitted.hookSpecificOutput.additionalContext as string;
+    expect(ctx).toContain(`quotes "like this"`);
+    expect(ctx).toContain("backtick `code`");
+  });
+
+  it("unlinks the pending file after successful read", () => {
+    const pending_path = join(scratch_dir, "lf-pending-pool-3.json");
+    writeFileSync(
+      pending_path,
+      JSON.stringify({
+        user: "a",
+        channel_id: "c",
+        message_id: "m",
+        content: "x",
+        ts: "2026-04-16T00:00:00Z",
+      }),
+    );
+    expect(existsSync(pending_path)).toBe(true);
+
+    const { code } = run_hook({ LF_PENDING_FILE: pending_path });
+    expect(code).toBe(0);
+
+    // File must be gone — otherwise a later --resume would re-inject stale content.
+    expect(existsSync(pending_path)).toBe(false);
+  });
+
+  it("no-ops silently (exit 0, empty stdout) when LF_PENDING_FILE is unset", () => {
+    const { stdout, code } = run_hook({});
+    expect(code).toBe(0);
+    expect(stdout.trim()).toBe("");
+  });
+
+  it("no-ops silently when LF_PENDING_FILE points at a missing file", () => {
+    const missing = join(scratch_dir, "does-not-exist.json");
+    const { stdout, code } = run_hook({ LF_PENDING_FILE: missing });
+    expect(code).toBe(0);
+    expect(stdout.trim()).toBe("");
+  });
+
+  it("no-ops and cleans up when the file is empty", () => {
+    const pending_path = join(scratch_dir, "lf-pending-pool-4.json");
+    writeFileSync(pending_path, "");
+
+    const { stdout, code } = run_hook({ LF_PENDING_FILE: pending_path });
+    expect(code).toBe(0);
+    expect(stdout.trim()).toBe("");
+    expect(existsSync(pending_path)).toBe(false);
+  });
+
+  it("no-ops (but cleans up) when content field is empty", () => {
+    const pending_path = join(scratch_dir, "lf-pending-pool-5.json");
+    writeFileSync(
+      pending_path,
+      JSON.stringify({
+        user: "a",
+        channel_id: "c",
+        message_id: "m",
+        content: "",
+        ts: "t",
+      }),
+    );
+
+    const { stdout, code } = run_hook({ LF_PENDING_FILE: pending_path });
+    expect(code).toBe(0);
+    expect(stdout.trim()).toBe("");
+    expect(existsSync(pending_path)).toBe(false);
+  });
+
+  it("no-ops gracefully (exit 0) when file contains invalid JSON", () => {
+    const pending_path = join(scratch_dir, "lf-pending-pool-6.json");
+    writeFileSync(pending_path, "not-json-at-all");
+
+    const { code } = run_hook({ LF_PENDING_FILE: pending_path });
+
+    // Must NOT return non-zero — we never want to block Claude session start.
+    expect(code).toBe(0);
+    // Clean up the malformed file so we don't get stuck in a loop.
+    expect(existsSync(pending_path)).toBe(false);
+  });
+
+  it("falls back to 'a user' when the user field is missing", () => {
+    const pending_path = join(scratch_dir, "lf-pending-pool-7.json");
+    writeFileSync(
+      pending_path,
+      JSON.stringify({
+        channel_id: "ch-7",
+        message_id: "m-7",
+        content: "anonymous message",
+        ts: "2026-04-16T00:00:00Z",
+      }),
+    );
+
+    const { stdout, code } = run_hook({ LF_PENDING_FILE: pending_path });
+    expect(code).toBe(0);
+    const emitted = JSON.parse(stdout.trim());
+    const ctx = emitted.hookSpecificOutput.additionalContext as string;
+    expect(ctx).toContain("a user");
+    expect(ctx).toContain("anonymous message");
+  });
+});

--- a/packages/daemon/src/__tests__/session-start-inject.test.ts
+++ b/packages/daemon/src/__tests__/session-start-inject.test.ts
@@ -1,0 +1,242 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
+import type { LobsterFarmConfig } from "@lobster-farm/shared";
+import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type PoolBot, pending_json_path } from "../pool.js";
+import { BotPoolTestBase } from "./helpers/test-bot-pool-base.js";
+
+// ── Mocks ──
+
+// Mock fs to capture writeFile — that's the key assertion for the hook
+// contract (daemon writes pending JSON file before spawn).
+vi.mock("node:fs/promises", async () => {
+  const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+  return {
+    ...actual,
+    access: vi.fn().mockResolvedValue(undefined),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    readFile: vi.fn().mockResolvedValue("{}"),
+    readdir: vi.fn().mockResolvedValue([]),
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    unlink: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+// Mock child_process — assert send-keys is NOT called for message bridging.
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    execFileSync: vi.fn().mockReturnValue(""),
+    spawn: vi.fn(),
+  };
+});
+
+import { execFileSync } from "node:child_process";
+import { writeFile } from "node:fs/promises";
+
+// ── Test helpers ──
+
+let temp_dir: string;
+
+function make_config(): LobsterFarmConfig {
+  return LobsterFarmConfigSchema.parse({
+    user: { name: "Test" },
+    paths: { lobsterfarm_dir: temp_dir },
+  });
+}
+
+function make_bot(id: number, overrides: Partial<PoolBot> = {}): PoolBot {
+  return {
+    id,
+    state: "free",
+    channel_id: null,
+    entity_id: null,
+    archetype: null,
+    channel_type: null,
+    session_id: null,
+    session_confirmed: false,
+    tmux_session: `pool-${String(id)}`,
+    last_active: null,
+    assigned_at: null,
+    state_dir: `/tmp/test-pool-${String(id)}`,
+    model: null,
+    effort: null,
+    last_avatar_archetype: null,
+    last_avatar_set_at: null,
+    ...overrides,
+  };
+}
+
+class TestBotPool extends BotPoolTestBase {
+  inject_bots(bots: PoolBot[]): void {
+    (this as unknown as { bots: PoolBot[] }).bots = bots;
+  }
+}
+
+// ── Tests ──
+
+describe("assign() with pending_message (SessionStart hook wiring — issue #290)", () => {
+  let config: LobsterFarmConfig;
+  let pool: TestBotPool;
+  let start_tmux_spy: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    temp_dir = join(tmpdir(), `pending-inject-test-${Date.now()}`);
+    config = make_config();
+    pool = new TestBotPool(config);
+
+    // Stub assign() side effects
+    vi.spyOn(pool as unknown as Record<string, unknown>, "kill_tmux" as never).mockImplementation(
+      () => {},
+    );
+    vi.spyOn(
+      pool as unknown as Record<string, unknown>,
+      "write_access_json" as never,
+    ).mockResolvedValue(undefined);
+    vi.spyOn(
+      pool as unknown as Record<string, unknown>,
+      "set_bot_nickname" as never,
+    ).mockResolvedValue(undefined);
+    vi.spyOn(
+      pool as unknown as Record<string, unknown>,
+      "set_bot_avatar" as never,
+    ).mockResolvedValue(undefined);
+    start_tmux_spy = vi
+      .spyOn(pool as unknown as Record<string, unknown>, "start_tmux" as never)
+      .mockResolvedValue(undefined) as unknown as Mock;
+    vi.spyOn(pool as unknown as Record<string, unknown>, "persist" as never).mockResolvedValue(
+      undefined,
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("writes a JSON pending file and sets LF_PENDING_FILE on spawn", async () => {
+    pool.inject_bots([make_bot(0)]);
+
+    const result = await pool.assign(
+      "channel-abc",
+      "entity-1",
+      "planner",
+      undefined,
+      undefined,
+      undefined,
+      {
+        user: "carol",
+        channel_id: "channel-abc",
+        message_id: "msg-1",
+        content: "please build the feature",
+        ts: "2026-04-16T10:00:00.000Z",
+      },
+    );
+
+    expect(result).not.toBeNull();
+
+    // JSON payload written to the canonical pending_json_path
+    const json_write = (writeFile as Mock).mock.calls.find((c: unknown[]) =>
+      (c[0] as string).endsWith("lf-pending-pool-0.json"),
+    );
+    expect(json_write).toBeDefined();
+    const written = JSON.parse((json_write![1] as string).trim());
+    expect(written).toMatchObject({
+      user: "carol",
+      channel_id: "channel-abc",
+      message_id: "msg-1",
+      content: "please build the feature",
+      ts: "2026-04-16T10:00:00.000Z",
+    });
+
+    // start_tmux received LF_PENDING_FILE in extra_env (7th arg)
+    expect(start_tmux_spy).toHaveBeenCalled();
+    const extra_env = start_tmux_spy.mock.calls[0]![6] as Record<string, string>;
+    expect(extra_env.LF_PENDING_FILE).toBe(pending_json_path("pool-0"));
+  });
+
+  it("does NOT write pending file when no pending_message is given", async () => {
+    pool.inject_bots([make_bot(1)]);
+
+    await pool.assign("channel-def", "entity-1", "planner");
+
+    const json_writes = (writeFile as Mock).mock.calls.filter((c: unknown[]) =>
+      (c[0] as string).endsWith("lf-pending-pool-1.json"),
+    );
+    expect(json_writes).toHaveLength(0);
+
+    // extra_env to start_tmux should not include LF_PENDING_FILE
+    const extra_env = start_tmux_spy.mock.calls[0]?.[6] as Record<string, string> | undefined;
+    expect(extra_env?.LF_PENDING_FILE).toBeUndefined();
+  });
+
+  it("does NOT invoke tmux send-keys to bridge the first message", async () => {
+    pool.inject_bots([make_bot(2)]);
+
+    await pool.assign("channel-ghi", "entity-1", "planner", undefined, undefined, undefined, {
+      user: "dave",
+      channel_id: "channel-ghi",
+      message_id: "msg-2",
+      content: "hello",
+      ts: new Date().toISOString(),
+    });
+
+    // Allow any async background work to settle
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    // There should be no send-keys call targeting pool-2 with a pending-file prompt.
+    // Other send-keys calls (e.g. trust-dialog auto-accept inside start_tmux, which
+    // we've stubbed out entirely) are fine — we assert on message-injection pattern.
+    const send_keys_calls = (execFileSync as Mock).mock.calls.filter(
+      (c: unknown[]) =>
+        c[0] === "tmux" &&
+        Array.isArray(c[1]) &&
+        (c[1] as string[])[0] === "send-keys" &&
+        (c[1] as string[])[2] === "pool-2",
+    );
+    for (const call of send_keys_calls) {
+      const payload = String((call[1] as string[])[3] ?? "");
+      expect(payload).not.toContain("lf-pending");
+      expect(payload).not.toContain("Read /tmp");
+    }
+  });
+
+  it("pending file write failure does not block assignment", async () => {
+    pool.inject_bots([make_bot(3)]);
+
+    // Make only the JSON pending-file write fail — other writes (access.json, etc.)
+    // must still succeed for assign() to progress.
+    (writeFile as Mock).mockImplementation(async (path: string) => {
+      if (path.includes("lf-pending-pool-3")) {
+        throw new Error("disk full");
+      }
+    });
+
+    const result = await pool.assign(
+      "channel-jkl",
+      "entity-1",
+      "planner",
+      undefined,
+      undefined,
+      undefined,
+      {
+        user: "erin",
+        channel_id: "channel-jkl",
+        message_id: "msg-3",
+        content: "hi",
+        ts: new Date().toISOString(),
+      },
+    );
+
+    // Assignment still succeeds — hook injection is best-effort.
+    expect(result).not.toBeNull();
+    // start_tmux was still called — just without LF_PENDING_FILE.
+    expect(start_tmux_spy).toHaveBeenCalled();
+    const extra_env = start_tmux_spy.mock.calls[0]![6] as Record<string, string>;
+    expect(extra_env.LF_PENDING_FILE).toBeUndefined();
+  });
+});

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -33,11 +33,7 @@ import {
   type Webhook,
 } from "discord.js";
 import { PAT_TMUX_SESSION } from "./commander-process.js";
-import {
-  is_tmux_session_idle,
-  pending_file_path,
-  wait_for_bot_ready_with_retries,
-} from "./pool.js";
+import { is_tmux_session_idle } from "./pool.js";
 import type { BotPool, PoolBot } from "./pool.js";
 import type { TaskQueue } from "./queue.js";
 import type { EntityRegistry } from "./registry.js";
@@ -1894,21 +1890,25 @@ export class DiscordBot extends EventEmitter {
           /* ignore */
         }
 
+        // Pass the user's message as a pending_message so the SessionStart
+        // hook can inject it as additionalContext when the Claude CLI
+        // starts (issue #290). No tmux send-keys bridging required.
         const result = await this._pool.assign(
           message.channelId,
           entry.entity_id,
           archetype,
           undefined, // resume_session_id — pool handles auto-resume from parked bots + session_history
           entry.channel_type,
+          undefined, // working_dir — use entity default
+          {
+            user: message.author.displayName,
+            channel_id: message.channelId,
+            message_id: message.id,
+            content: message.content,
+            ts: new Date(message.createdTimestamp).toISOString(),
+          },
         );
         if (result) {
-          // Bridge the first message: write to file, wait for bot, send via tmux
-          await this.bridge_first_message(
-            result.tmux_session,
-            message.content,
-            message.author.displayName,
-            message.channelId,
-          );
           try {
             await message.reactions.cache.get("⏳")?.users.remove(this.client.user!.id);
             await message.react("👀");
@@ -2302,100 +2302,6 @@ export class DiscordBot extends EventEmitter {
     }
   }
 
-  /**
-   * Bridge a message to a freshly spawned pool bot via tmux send-keys.
-   *
-   * Uses wait_for_bot_ready_with_retries for robust readiness detection
-   * (3 attempts, 30s each = ~90s total). If all retries fail, the pending
-   * file is left in place for the health-check drain to recover, and a
-   * fallback message is posted to the Discord channel so the user knows.
-   */
-  private async bridge_first_message(
-    tmux_session: string,
-    content: string,
-    author_name: string,
-    channel_id?: string,
-  ): Promise<void> {
-    const { execFileSync } = await import("node:child_process");
-    const {
-      access: accessAsync,
-      writeFile: writeFileAsync,
-      unlink,
-    } = await import("node:fs/promises");
-    const pending_path = pending_file_path(tmux_session);
-
-    try {
-      // Write the message to a file (avoids tmux escaping issues)
-      await writeFileAsync(pending_path, `${author_name}: ${content}`, "utf-8");
-
-      // Wait for the bot to be ready with retries (~90s total coverage)
-      const ready = await wait_for_bot_ready_with_retries(tmux_session);
-
-      if (!ready) {
-        console.log(
-          `[discord] Bot ${tmux_session} not ready after all retries — message not bridged`,
-        );
-
-        // Pending file stays in place — health check drain_pending_files()
-        // will deliver it if the bot becomes ready later.
-
-        // Post a fallback message so the user knows something went wrong
-        if (channel_id) {
-          try {
-            await this.send(
-              channel_id,
-              "Your message will be delivered once the bot finishes starting up. If you don't get a response within a few minutes, please resend.",
-            );
-          } catch {
-            /* best effort */
-          }
-        }
-        return;
-      }
-
-      // Guard against drain having already delivered while we were polling.
-      // drain_pending_files runs on the 30s health-check timer and may have
-      // claimed and sent the file during the ~90s readiness wait.
-      try {
-        await accessAsync(pending_path);
-      } catch {
-        console.log(
-          `[discord] Pending file already claimed by drain for ${tmux_session} — skipping bridge send`,
-        );
-        return;
-      }
-
-      // Small extra delay for the plugin to fully connect
-      await new Promise((resolve) => setTimeout(resolve, 2000));
-
-      // Send the prompt to the bot's tmux session
-      const prompt = `A user just messaged you in Discord. Read ${pending_path} for their message and respond to them.`;
-      execFileSync("tmux", ["send-keys", "-t", tmux_session, prompt, "Enter"], {
-        stdio: "ignore",
-        timeout: 5000,
-      });
-
-      console.log(`[discord] Bridged first message to ${tmux_session}`);
-
-      // Clean up shortly after — Claude has the prompt and will read it within seconds.
-      // Mark as draining to prevent drain_pending_files from re-delivering during
-      // the cleanup window.
-      if (this._pool) {
-        const cleanup = this._pool.mark_draining(tmux_session, pending_path);
-        setTimeout(cleanup, 5_000);
-      } else {
-        setTimeout(() => {
-          void unlink(pending_path).catch(() => {});
-        }, 5_000);
-      }
-    } catch (err) {
-      console.error(`[discord] Bridge failed: ${String(err)}`);
-      sentry.captureException(err, {
-        tags: { module: "discord", action: "bridge" },
-      });
-    }
-  }
-
   private async handle_swap_command(args: string[], target: CommandTarget): Promise<void> {
     if (!this._pool) {
       await target.reply("Bot pool not available.");
@@ -2531,29 +2437,31 @@ export class DiscordBot extends EventEmitter {
     await this.persist_entity_config(entity_config);
     this.build_channel_map();
 
-    // Assign a pool bot (planner by default)
+    // Assign a pool bot (planner by default). If the /room command carried
+    // initial context, inject it via the SessionStart hook (issue #290).
+    const pending_message = context
+      ? {
+          user: target.author_name,
+          channel_id,
+          message_id: "",
+          content: context,
+          ts: new Date().toISOString(),
+        }
+      : undefined;
     const assignment = await this._pool.assign(
       channel_id,
       routed.entity_id,
       "planner",
       undefined,
       "work_room",
+      undefined,
+      pending_message,
     );
 
     // Post confirmation in both source channel and new room
     await target.reply(`Room **#${name}** created. Session started.`);
     if (assignment) {
       await this.send(channel_id, "Room created. Session started.");
-
-      // Bridge initial context if provided
-      if (context) {
-        await this.bridge_first_message(
-          assignment.tmux_session,
-          context,
-          target.author_name,
-          channel_id,
-        );
-      }
     }
   }
 

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -115,11 +115,47 @@ export function is_tmux_session_idle(tmux_session: string): boolean {
   }
 }
 
-// ── Pending file path ──
+// ── Pending file paths ──
 
-/** Canonical path for the pending-message file used by bridge and drain. */
+/** Canonical path for the legacy pending-message .txt file used by the
+ * tmux send-keys drain path. Retained for backward compatibility with
+ * drain_pending_files() (belt-and-suspenders — see issue #279). */
 export function pending_file_path(tmux_session: string): string {
   return `/tmp/lf-pending-${tmux_session}.txt`;
+}
+
+/** Canonical path for the SessionStart-hook pending-message JSON file.
+ * Written by the daemon before spawning `claude`; consumed by the
+ * session-start-inject.sh hook during Claude CLI init. See issue #290. */
+export function pending_json_path(tmux_session: string): string {
+  return `/tmp/lf-pending-${tmux_session}.json`;
+}
+
+/** Payload written to pending_json_path(). Keep field names stable —
+ * session-start-inject.sh parses this directly via jq. */
+export interface PendingMessage {
+  /** Display name of the Discord user who sent the message. */
+  user: string;
+  /** Discord channel ID where the message was sent. */
+  channel_id: string;
+  /** Discord message ID (Snowflake), for future reply-to support. */
+  message_id: string;
+  /** Raw message content. */
+  content: string;
+  /** ISO-8601 timestamp of when the daemon received the message. */
+  ts: string;
+}
+
+/** Write a PendingMessage to the session's JSON pending-file path.
+ * Returns the absolute file path so callers can set LF_PENDING_FILE on the
+ * spawn env. Best-effort — throws only on unexpected filesystem errors. */
+export async function write_pending_message(
+  tmux_session: string,
+  msg: PendingMessage,
+): Promise<string> {
+  const path = pending_json_path(tmux_session);
+  await writeFile(path, `${JSON.stringify(msg)}\n`, "utf-8");
+  return path;
 }
 
 // ── Bot readiness polling ──
@@ -786,6 +822,28 @@ export class BotPool extends EventEmitter {
           }
         }
 
+        // Write a resume-nudge pending message and point LF_PENDING_FILE at
+        // it. The SessionStart hook (session-start-inject.sh) delivers it
+        // during Claude init as additionalContext — replacing the legacy
+        // bridge_resume_nudge() tmux send-keys path that raced against
+        // MCP plugin readiness. See issue #290.
+        try {
+          const nudge_path = await write_pending_message(bot.tmux_session, {
+            user: "lobsterfarm-daemon",
+            channel_id: candidate.channel_id,
+            message_id: "",
+            content:
+              "The daemon restarted and your session was resumed. Check where you left off and continue any in-progress work.",
+            ts: new Date().toISOString(),
+          });
+          extra_env.LF_PENDING_FILE = nudge_path;
+        } catch (err) {
+          console.warn(
+            `[pool] Failed to write resume nudge for pool-${String(bot.id)}: ${String(err)}`,
+          );
+          // Non-fatal: the session still resumes, just without the nudge.
+        }
+
         // Spawn a fresh Claude process with --resume — establishes a new MCP
         // connection to this daemon while preserving conversation context
         const working_dir = entity_dir(this.config.paths, candidate.entity_id);
@@ -820,14 +878,6 @@ export class BotPool extends EventEmitter {
           channel_id: bot.channel_id,
           entity_id: bot.entity_id,
         });
-
-        // Bridge a continuation nudge so the resumed session doesn't sit idle.
-        // Fire-and-forget — don't let a nudge failure block the resume loop.
-        this.bridge_resume_nudge(bot).catch((nudge_err) => {
-          console.warn(
-            `[pool] Failed to nudge pool-${String(bot.id)} after resume: ${String(nudge_err)}`,
-          );
-        });
       } catch (err) {
         console.error(`[pool] Failed to resume pool-${String(bot.id)}: ${String(err)}`);
         sentry.captureException(err, {
@@ -851,7 +901,14 @@ export class BotPool extends EventEmitter {
     }
   }
 
-  /** Assign a pool bot to a channel with a specific archetype. */
+  /** Assign a pool bot to a channel with a specific archetype.
+   *
+   * If `pending_message` is provided, the daemon writes it to a JSON file and
+   * sets `LF_PENDING_FILE` on the spawned Claude CLI's env. The
+   * SessionStart hook (session-start-inject.sh) reads it during Claude init
+   * and injects the message as additionalContext — replacing the legacy
+   * tmux send-keys bridging that raced against MCP plugin readiness
+   * (issue #290). */
   async assign(
     channel_id: string,
     entity_id: string,
@@ -859,6 +916,7 @@ export class BotPool extends EventEmitter {
     resume_session_id?: string,
     channel_type?: ChannelType,
     working_dir?: string,
+    pending_message?: PendingMessage,
   ): Promise<PoolAssignment | null> {
     if (this._draining) {
       console.log("[pool] Rejecting assignment — draining");
@@ -1034,6 +1092,23 @@ export class BotPool extends EventEmitter {
         } catch (err) {
           console.warn(`[pool] Failed to resolve GH_TOKEN for ${entity_id}: ${String(err)}`);
           // Non-fatal: session starts without GH_TOKEN
+        }
+      }
+
+      // If a pending message was provided, write it to the JSON file and
+      // point the spawn's LF_PENDING_FILE env var at it. The SessionStart
+      // hook (session-start-inject.sh) will pick it up during Claude CLI
+      // init and inject it as additionalContext — no tmux bridging needed.
+      // See issue #290.
+      if (pending_message) {
+        try {
+          const path = await write_pending_message(bot.tmux_session, pending_message);
+          extra_env.LF_PENDING_FILE = path;
+        } catch (err) {
+          console.warn(
+            `[pool] Failed to write pending message for pool-${String(bot.id)}: ${String(err)}`,
+          );
+          // Non-fatal: session still starts, just without the initial context.
         }
       }
 
@@ -1469,9 +1544,11 @@ export class BotPool extends EventEmitter {
       // Deliver any queued messages to bots that are now at the prompt
       this.drain_pending_injections();
 
-      // Safety net: recover undelivered pending files left by failed bridge attempts.
-      // If bridge_first_message or bridge_resume_nudge timed out but the bot later
-      // became ready, deliver the pending file content via tmux send-keys.
+      // Safety net: recover undelivered legacy .txt pending files left by
+      // any older spawn path. The canonical SessionStart-hook injection
+      // (issue #290) uses .json files consumed by the hook script and
+      // doesn't need drain recovery — but we keep this logic for the
+      // legacy .txt format as belt-and-suspenders per the issue spec.
       await this.drain_pending_files();
 
       for (const bot of this.bots) {
@@ -2417,13 +2494,13 @@ export class BotPool extends EventEmitter {
   }
 
   /**
-   * Safety net for failed bridge attempts.
+   * Safety net for legacy .txt pending files (pre-#290 tmux bridge path).
    *
    * Scans assigned bots for orphaned /tmp/lf-pending-{session}.txt files.
    * If the bot is alive and at the prompt, delivers the message via tmux
-   * send-keys and removes the file. This catches the case where
-   * bridge_first_message or bridge_resume_nudge timed out but the bot
-   * became ready later.
+   * send-keys and removes the file. Kept as belt-and-suspenders even
+   * though the canonical injection path is now the SessionStart hook —
+   * see issue #290.
    */
   private async drain_pending_files(): Promise<void> {
     for (const bot of this.bots) {
@@ -2458,72 +2535,6 @@ export class BotPool extends EventEmitter {
         console.warn(`[pool] Failed to drain pending file for ${bot.tmux_session}: ${String(err)}`);
       }
     }
-  }
-
-  /**
-   * Bridge a continuation nudge to a resumed bot's Claude Code process.
-   * Writes a pending message file that the MCP Discord plugin picks up,
-   * using the same mechanism as bridge_first_message in discord.ts.
-   *
-   * Uses wait_for_bot_ready_with_retries for robust readiness detection
-   * with up to 3 attempts (~90s total coverage).
-   */
-  private async bridge_resume_nudge(bot: PoolBot): Promise<void> {
-    const pending_path = pending_file_path(bot.tmux_session);
-    const nudge =
-      "The daemon restarted and your session was resumed. " +
-      "Check where you left off and continue any in-progress work.";
-
-    // Write file first so drain_pending_files can recover it if readiness times out
-    await writeFile(pending_path, nudge, "utf-8");
-
-    const ready = await wait_for_bot_ready_with_retries(bot.tmux_session);
-
-    if (!ready) {
-      console.log(
-        `[pool] Bot ${bot.tmux_session} not ready after all retries — resume nudge not sent`,
-      );
-      // pending_path stays in place for drain_pending_files to recover
-      return;
-    }
-
-    // Guard against drain having already delivered while we were polling.
-    // drain_pending_files runs on the 30s health-check timer and may have
-    // claimed and sent the file during the ~90s readiness wait.
-    try {
-      await access(pending_path);
-    } catch {
-      console.log(
-        `[pool] Pending file already claimed by drain for ${bot.tmux_session} — skipping nudge send`,
-      );
-      return;
-    }
-
-    // Small extra delay for the MCP plugin to fully connect
-    await new Promise((resolve) => setTimeout(resolve, 2000));
-
-    // Deliver the nudge via tmux send-keys — the file alone is not enough.
-    // The send-keys call injects a prompt into Claude's stdin telling it
-    // to read the pending file (same pattern as bridge_first_message).
-    execFileSync(
-      "tmux",
-      [
-        "send-keys",
-        "-t",
-        bot.tmux_session,
-        `Your session was resumed after a daemon restart. Read ${pending_path} and continue any in-progress work.`,
-        "Enter",
-      ],
-      { stdio: "ignore", timeout: 5000 },
-    );
-
-    console.log(`[pool] Bridged resume nudge to ${bot.tmux_session}`);
-
-    // Clean up shortly after — Claude has the prompt and will read it within seconds.
-    // Keep this well under the 30s health-check interval to prevent drain_pending_files
-    // from re-delivering the same message after Claude finishes processing.
-    const cleanup = this.mark_draining(bot.tmux_session, pending_path);
-    setTimeout(cleanup, 5_000);
   }
 
   /**

--- a/packages/shared/src/paths.ts
+++ b/packages/shared/src/paths.ts
@@ -103,6 +103,10 @@ export function claude_settings_path(config?: Partial<PathConfig>): string {
   return join(claude_dir(config), "settings.json");
 }
 
+export function claude_hooks_dir(config?: Partial<PathConfig>): string {
+  return join(claude_dir(config), "hooks");
+}
+
 export function claude_md_path(config?: Partial<PathConfig>): string {
   return join(claude_dir(config), "CLAUDE.md");
 }


### PR DESCRIPTION
## Summary

Replaces fragile tmux `send-keys` bridging (`bridge_first_message`, `bridge_resume_nudge`) with a Claude Code native `SessionStart` hook. The hook fires deterministically during CLI init — before any tool use — so the first Discord message (or resume-nudge) is injected as `additionalContext` without racing the MCP Discord subscription.

- Hook script at `config/claude/hooks/session-start-inject.sh` reads `LF_PENDING_FILE`, emits `{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: ...}}`, unlinks the file, exits 0 gracefully on every error path (never blocks Claude startup).
- Daemon writes a JSON pending file (`/tmp/lf-pending-{session}.json`) and sets `LF_PENDING_FILE` in the tmux spawn env for both new assignments (`assign()`) and parked-bot resumes (`resume_parked_bots`).
- `lf init` deploys the hook script to `~/.claude/hooks/` (chmod +x) and registers the `SessionStart` matcher in `settings.json`.
- `drain_pending_files()` is kept as belt-and-suspenders cleanup for any legacy `.txt` files from #279.
- Typing-loop grace from #281 is untouched (separate concern).

## Scope

- `config/claude/hooks/session-start-inject.sh` — new hook script (bash + jq).
- `packages/shared/src/paths.ts` — `claude_hooks_dir()` helper.
- `packages/cli/src/commands/init/generate.ts` — copy hooks on init, chmod `.sh` files, register `SessionStart` in settings.
- `packages/daemon/src/pool.ts` — `pending_json_path()`, `PendingMessage`, `write_pending_message()`; `assign()` gains a 7th `pending_message?` param; `resume_parked_bots` writes pending JSON + sets env var before spawn; removed `bridge_resume_nudge()`.
- `packages/daemon/src/discord.ts` — removed `bridge_first_message()`; auto-assign and `/room` paths pass `pending_message` to `assign()`.

## Test plan

- [x] Hook script behavior (9 tests): valid JSON, multiline content, quotes/backslash/backticks, file unlink, no-op on missing env/missing file/empty file/empty content, graceful on invalid JSON, `"a user"` fallback when `user` missing.
- [x] Daemon assign path (4 tests): writes JSON pending file, sets `LF_PENDING_FILE` in `start_tmux` extra_env, does NOT invoke `tmux send-keys` with pending-file prompt, pending-file write failure does not block assignment.
- [x] Resume path (6 tests): writes JSON nudge file, sets `LF_PENDING_FILE`, payload contains continue-work instruction, path matches bot id, no `send-keys` bridging, write happens before `start_tmux` (so a failed spawn leaves a stale file that the next spawn overwrites — never a duplicate delivery).
- [x] All existing daemon tests still pass (1010 daemon + 60 shared + 34 CLI).
- [x] Typecheck clean, biome lint clean.

Closes #290

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>