### PR TITLE
feat(daemon): per-entity Claude Max subscription support (#296)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -4,6 +4,9 @@
 - `lobsterfarm-architecture-v0.3.md` — Full system architecture (components, data model, SOPs, governance, roadmap)
 - `lobsterfarm-file-boundary-map-v2.md` — What content goes in which file (definitive guide)
 
+## Guides
+- `per-entity-subscriptions.md` — Per-entity Claude Max subscription setup (CLAUDE_CONFIG_DIR isolation)
+
 ## Default Configuration Templates (../config/)
 
 ### ~/.claude/ (Global Claude Code Configuration)

--- a/docs/lobsterfarm-architecture-v0.3.md
+++ b/docs/lobsterfarm-architecture-v0.3.md
@@ -407,6 +407,10 @@ entity:
     vault: "1password"
     vault_name: "entity-alpha"
 
+  # Optional: per-entity Claude Max subscription (see docs/per-entity-subscriptions.md)
+  subscription:
+    claude_config_dir: ~/.lobsterfarm/entities/alpha/.claude-config
+
   budget:
     monthly_warning_pct: 80
     monthly_limit: null  # null = no hard limit

--- a/docs/per-entity-subscriptions.md
+++ b/docs/per-entity-subscriptions.md
@@ -1,0 +1,130 @@
+# Per-Entity Claude Max Subscriptions
+
+## What This Does
+
+By default, all entities share a single Claude Max subscription via `~/.claude`. This creates two problems:
+
+1. **Billing** -- no way to attribute costs to individual entities/products
+2. **Rate limits** -- one busy entity can starve another
+
+This feature adds an optional `subscription.claude_config_dir` field to entity config. When set, the daemon injects `CLAUDE_CONFIG_DIR=<path>` into every session spawned for that entity. Each config directory holds its own OAuth credentials, so sessions authenticate against separate Claude Max subscriptions.
+
+## How CLAUDE_CONFIG_DIR Works
+
+Claude Code uses `~/.claude` for all config, credentials, and state. The `CLAUDE_CONFIG_DIR` environment variable overrides this location entirely. When set, the CLI reads auth tokens, settings, and session state from the specified directory instead.
+
+**What's isolated (per-entity config dir):**
+- OAuth credentials (separate subscription identity)
+- Session state files
+- Any config that differs between subscriptions
+
+**What's shared (via symlinks from `~/.claude`):**
+- `CLAUDE.md` -- global instructions
+- `rules/` -- global rules
+- `settings.json` -- shared settings
+- `agents/` -- agent definitions
+- `skills/` -- skill definitions
+
+## One-Time Setup for a New Subscription
+
+### 1. Create the config directory
+
+```bash
+mkdir -p ~/.lobsterfarm/entities/<entity-id>/.claude-config
+```
+
+### 2. Authenticate the new subscription
+
+```bash
+CLAUDE_CONFIG_DIR=~/.lobsterfarm/entities/<entity-id>/.claude-config claude auth login
+```
+
+Follow the OAuth flow to authenticate with the Claude Max account you want this entity to use.
+
+### 3. Symlink shared config files
+
+```bash
+cd ~/.lobsterfarm/entities/<entity-id>/.claude-config
+
+# Shared instructions and rules
+ln -s ~/.claude/CLAUDE.md CLAUDE.md
+ln -s ~/.claude/rules rules
+ln -s ~/.claude/settings.json settings.json
+ln -s ~/.claude/settings.local.json settings.local.json
+ln -s ~/.claude/agents agents
+ln -s ~/.claude/skills skills
+```
+
+### 4. Add to entity config
+
+Edit `~/.lobsterfarm/entities/<entity-id>/config.yaml`:
+
+```yaml
+entity:
+  # ... existing fields ...
+  subscription:
+    claude_config_dir: ~/.lobsterfarm/entities/<entity-id>/.claude-config
+```
+
+### 5. Restart the daemon
+
+```bash
+kill $(cat ~/.lobsterfarm/lobsterfarm.pid)
+# launchd auto-restarts the daemon
+```
+
+## How Injection Works
+
+The daemon injects `CLAUDE_CONFIG_DIR` at two spawn points:
+
+1. **Pool bots (tmux path)** -- `pool.ts` adds it to `extra_env` alongside `GH_TOKEN`. Injected as both a tmux command prefix and a spawn env var.
+
+2. **Queue sessions (direct spawn)** -- `session.ts` resolves it from the entity registry and merges it into the spawn environment.
+
+Both paths log which config dir is being used at spawn time. If no subscription is configured, sessions use the default `~/.claude` -- zero behavior change.
+
+## Troubleshooting
+
+### Verify which subscription a session is using
+
+Check the daemon logs for spawn-time messages:
+
+```
+[pool] Assigning bot pool-3 to #general (entity: foo, claude_config: ~/.lobsterfarm/entities/foo/.claude-config)
+[session] Spawning session for foo with CLAUDE_CONFIG_DIR=~/.lobsterfarm/entities/foo/.claude-config
+```
+
+If no custom config dir is set, you'll see:
+
+```
+[pool] Assigning bot pool-3 to #general (entity: foo, claude_config: default)
+[session] Spawning session for foo with CLAUDE_CONFIG_DIR=default (~/.claude)
+```
+
+### Auth errors after setup
+
+If the session fails with auth errors, verify the credentials are valid:
+
+```bash
+CLAUDE_CONFIG_DIR=~/.lobsterfarm/entities/<entity-id>/.claude-config claude auth status
+```
+
+If expired, re-authenticate:
+
+```bash
+CLAUDE_CONFIG_DIR=~/.lobsterfarm/entities/<entity-id>/.claude-config claude auth login
+```
+
+### Symlinked files not found
+
+Ensure symlinks point to actual files. Test with:
+
+```bash
+ls -la ~/.lobsterfarm/entities/<entity-id>/.claude-config/
+```
+
+Broken symlinks show as red in most terminals. Re-create them if the source moved.
+
+### Config dir doesn't exist
+
+The daemon does not validate that the config directory exists at startup. If the path is wrong, the Claude CLI will fail at session start. Check the entity config path matches the actual directory.

--- a/packages/daemon/src/__tests__/lazy-session-resume.test.ts
+++ b/packages/daemon/src/__tests__/lazy-session-resume.test.ts
@@ -247,6 +247,68 @@ describe("lazy session resume (issue #72)", () => {
 
       expect(pool.get_session_history().size).toBe(0);
     });
+
+    it("does not stash an unconfirmed session (phantom guard)", async () => {
+      const bot = make_bot({
+        id: 1,
+        state: "assigned",
+        channel_id: "ch-1",
+        entity_id: "e1",
+        archetype: "builder",
+        session_id: "sess-unconfirmed",
+        session_confirmed: false,
+      });
+      pool.inject_bots([bot]);
+
+      const warn_spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      await pool.release_with_history(1);
+
+      // Session should NOT be in history
+      expect(pool.get_session_history().size).toBe(0);
+
+      // Bot should still be released
+      const released_bot = pool.get_bots().find((b) => b.id === 1)!;
+      expect(released_bot.state).toBe("free");
+
+      // Warning should mention the unconfirmed session
+      expect(warn_spy).toHaveBeenCalledWith(
+        expect.stringContaining("Not stashing unconfirmed session"),
+      );
+      warn_spy.mockRestore();
+    });
+
+    it("does not stash when JSONL is missing on disk (phantom guard)", async () => {
+      const bot = make_bot({
+        id: 1,
+        state: "assigned",
+        channel_id: "ch-1",
+        entity_id: "e1",
+        archetype: "builder",
+        session_id: "sess-no-jsonl",
+        session_confirmed: true,
+      });
+      pool.inject_bots([bot]);
+
+      // Override JSONL check to return false for this session
+      vi.spyOn(
+        pool as unknown as Record<string, unknown>,
+        "check_session_jsonl_exists_anywhere" as never,
+      ).mockResolvedValue(false as never);
+
+      const warn_spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      await pool.release_with_history(1);
+
+      // Session should NOT be in history
+      expect(pool.get_session_history().size).toBe(0);
+
+      // Bot should still be released
+      const released_bot = pool.get_bots().find((b) => b.id === 1)!;
+      expect(released_bot.state).toBe("free");
+
+      // Warning should mention missing JSONL
+      expect(warn_spy).toHaveBeenCalledWith(expect.stringContaining("JSONL missing"));
+      warn_spy.mockRestore();
+    });
   });
 
   // ── check_assigned_health() preserves session_id ──

--- a/packages/daemon/src/__tests__/lazy-session-resume.test.ts
+++ b/packages/daemon/src/__tests__/lazy-session-resume.test.ts
@@ -247,68 +247,6 @@ describe("lazy session resume (issue #72)", () => {
 
       expect(pool.get_session_history().size).toBe(0);
     });
-
-    it("does not stash an unconfirmed session (phantom guard)", async () => {
-      const bot = make_bot({
-        id: 1,
-        state: "assigned",
-        channel_id: "ch-1",
-        entity_id: "e1",
-        archetype: "builder",
-        session_id: "sess-unconfirmed",
-        session_confirmed: false,
-      });
-      pool.inject_bots([bot]);
-
-      const warn_spy = vi.spyOn(console, "warn").mockImplementation(() => {});
-      await pool.release_with_history(1);
-
-      // Session should NOT be in history
-      expect(pool.get_session_history().size).toBe(0);
-
-      // Bot should still be released
-      const released_bot = pool.get_bots().find((b) => b.id === 1)!;
-      expect(released_bot.state).toBe("free");
-
-      // Warning should mention the unconfirmed session
-      expect(warn_spy).toHaveBeenCalledWith(
-        expect.stringContaining("Not stashing unconfirmed session"),
-      );
-      warn_spy.mockRestore();
-    });
-
-    it("does not stash when JSONL is missing on disk (phantom guard)", async () => {
-      const bot = make_bot({
-        id: 1,
-        state: "assigned",
-        channel_id: "ch-1",
-        entity_id: "e1",
-        archetype: "builder",
-        session_id: "sess-no-jsonl",
-        session_confirmed: true,
-      });
-      pool.inject_bots([bot]);
-
-      // Override JSONL check to return false for this session
-      vi.spyOn(
-        pool as unknown as Record<string, unknown>,
-        "check_session_jsonl_exists_anywhere" as never,
-      ).mockResolvedValue(false as never);
-
-      const warn_spy = vi.spyOn(console, "warn").mockImplementation(() => {});
-      await pool.release_with_history(1);
-
-      // Session should NOT be in history
-      expect(pool.get_session_history().size).toBe(0);
-
-      // Bot should still be released
-      const released_bot = pool.get_bots().find((b) => b.id === 1)!;
-      expect(released_bot.state).toBe("free");
-
-      // Warning should mention missing JSONL
-      expect(warn_spy).toHaveBeenCalledWith(expect.stringContaining("JSONL missing"));
-      warn_spy.mockRestore();
-    });
   });
 
   // ── check_assigned_health() preserves session_id ──

--- a/packages/daemon/src/__tests__/subscription-injection.test.ts
+++ b/packages/daemon/src/__tests__/subscription-injection.test.ts
@@ -1,0 +1,374 @@
+/**
+ * Tests for per-entity Claude subscription injection (CLAUDE_CONFIG_DIR).
+ *
+ * Verifies that:
+ * - CLAUDE_CONFIG_DIR is injected into tmux env + command when entity has subscription.claude_config_dir
+ * - CLAUDE_CONFIG_DIR is omitted when entity has no subscription config
+ * - CLAUDE_CONFIG_DIR is injected into queue session spawn env when configured
+ * - CLAUDE_CONFIG_DIR is omitted from queue session spawn env when not configured
+ * - Backward compatibility: entities without subscription field work unchanged
+ *
+ * Issue: #296
+ */
+
+import { EventEmitter } from "node:events";
+import { EntityConfigSchema, LobsterFarmConfigSchema } from "@lobster-farm/shared";
+import type { EntityConfig, LobsterFarmConfig } from "@lobster-farm/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BotPool } from "../pool.js";
+import type { PoolBot } from "../pool.js";
+import { ClaudeSessionManager } from "../session.js";
+
+// ── Module-level mocks ──
+
+let spawn_calls: Array<{ command: string; args: string[]; options: Record<string, unknown> }> = [];
+let spawn_emitter: EventEmitter;
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: vi.fn((...args: unknown[]) => {
+      spawn_calls.push({
+        command: args[0] as string,
+        args: args[1] as string[],
+        options: args[2] as Record<string, unknown>,
+      });
+      spawn_emitter = new EventEmitter();
+      // Emit close with code 0 on next tick
+      setTimeout(() => spawn_emitter.emit("close", 0), 0);
+      // Return a minimal process-like object for session.ts (needs stdin, stdout, stderr)
+      const mock_proc = Object.assign(spawn_emitter, {
+        stdin: Object.assign(new EventEmitter(), {
+          write: vi.fn(),
+          end: vi.fn(),
+        }),
+        stdout: new EventEmitter(),
+        stderr: new EventEmitter(),
+        pid: 12345,
+        kill: vi.fn(),
+      });
+      return mock_proc;
+    }),
+  };
+});
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    writeFile: vi.fn(async () => {}),
+    readFile: vi.fn(actual.readFile),
+  };
+});
+
+vi.mock("../env.js", () => ({
+  resolve_binary: vi.fn((name: string) => `/usr/local/bin/${name}`),
+}));
+
+// ── Minimal mock registry ──
+
+class MockRegistry {
+  private entities = new Map<string, EntityConfig>();
+
+  add(config: EntityConfig): void {
+    this.entities.set(config.entity.id, config);
+  }
+
+  get(id: string): EntityConfig | undefined {
+    return this.entities.get(id);
+  }
+}
+
+function make_entity_config(overrides: {
+  id: string;
+  claude_config_dir?: string;
+}): EntityConfig {
+  return EntityConfigSchema.parse({
+    entity: {
+      id: overrides.id,
+      name: overrides.id,
+      repos: [],
+      channels: { category_id: "", list: [] },
+      memory: { path: `/tmp/test-memory/${overrides.id}` },
+      secrets: { vault_name: `entity-${overrides.id}` },
+      ...(overrides.claude_config_dir
+        ? { subscription: { claude_config_dir: overrides.claude_config_dir } }
+        : {}),
+    },
+  });
+}
+
+function make_config(): LobsterFarmConfig {
+  return LobsterFarmConfigSchema.parse({
+    user: { name: "Test" },
+  });
+}
+
+// ── Pool test subclass ──
+
+class SubscriptionTestPool extends BotPool {
+  inject_bots(bots: PoolBot[]): void {
+    (this as unknown as { bots: PoolBot[] }).bots = bots;
+  }
+
+  inject_registry(registry: MockRegistry): void {
+    (this as unknown as { registry: MockRegistry }).registry = registry;
+  }
+
+  override_resolve_op_secret(mock: (ref: string) => Promise<string>): void {
+    (this as unknown as { resolve_op_secret: (ref: string) => Promise<string> }).resolve_op_secret =
+      mock;
+  }
+
+  protected override is_bot_idle(): boolean {
+    return true;
+  }
+}
+
+function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
+  return {
+    state: "free",
+    channel_id: null,
+    entity_id: null,
+    archetype: null,
+    channel_type: null,
+    session_id: null,
+    session_confirmed: true,
+    tmux_session: `pool-${String(overrides.id)}`,
+    last_active: null,
+    assigned_at: null,
+    state_dir: `/tmp/test-pool-${String(overrides.id)}`,
+    model: null,
+    effort: null,
+    last_avatar_archetype: null,
+    last_avatar_set_at: null,
+    ...overrides,
+  };
+}
+
+// ── Pool tests: CLAUDE_CONFIG_DIR injection ──
+
+describe("per-entity CLAUDE_CONFIG_DIR injection — pool path", () => {
+  let config: LobsterFarmConfig;
+  let pool: SubscriptionTestPool;
+  let registry: MockRegistry;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    spawn_calls = [];
+
+    config = make_config();
+    pool = new SubscriptionTestPool(config);
+    registry = new MockRegistry();
+
+    // Stub pool side effects unrelated to start_tmux
+    vi.spyOn(
+      pool as unknown as { kill_tmux: (s: string) => void },
+      "kill_tmux" as never,
+    ).mockImplementation(() => {});
+    vi.spyOn(
+      pool as unknown as { write_access_json: (d: string, c: string | null) => Promise<void> },
+      "write_access_json" as never,
+    ).mockResolvedValue(undefined);
+    vi.spyOn(
+      pool as unknown as { set_bot_nickname: (d: string, a: string) => Promise<void> },
+      "set_bot_nickname" as never,
+    ).mockResolvedValue(undefined);
+    vi.spyOn(
+      pool as unknown as { set_bot_avatar: (b: PoolBot, a: string) => Promise<void> },
+      "set_bot_avatar" as never,
+    ).mockResolvedValue(undefined);
+    vi.spyOn(
+      pool as unknown as { is_tmux_alive: (s: string) => boolean },
+      "is_tmux_alive" as never,
+    ).mockReturnValue(true);
+    vi.spyOn(
+      pool as unknown as { park_bot: (b: PoolBot) => Promise<void> },
+      "park_bot" as never,
+    ).mockImplementation(async (bot: PoolBot) => {
+      bot.state = "parked";
+    });
+  });
+
+  describe("entity WITH subscription.claude_config_dir", () => {
+    const CONFIG_DIR = "/Users/farm/.lobsterfarm/entities/alpha/.claude-config";
+
+    it("injects CLAUDE_CONFIG_DIR into tmux command and spawn env", async () => {
+      registry.add(make_entity_config({ id: "alpha-sub", claude_config_dir: CONFIG_DIR }));
+      pool.inject_registry(registry);
+      pool.inject_bots([make_bot({ id: 1, state: "free" })]);
+
+      await pool.assign("ch-test", "alpha-sub", "builder", undefined, "work_room");
+
+      const tmux_call = spawn_calls.find((c) => c.command === "tmux");
+      expect(tmux_call).toBeDefined();
+
+      // The tmux command string (last element in the args array)
+      const cmd_string = tmux_call!.args[tmux_call!.args.length - 1];
+      expect(cmd_string).toContain("CLAUDE_CONFIG_DIR=");
+      expect(cmd_string).toContain(CONFIG_DIR);
+
+      // Spawn env should have CLAUDE_CONFIG_DIR
+      const spawn_env = tmux_call!.options.env as Record<string, string>;
+      expect(spawn_env.CLAUDE_CONFIG_DIR).toBe(CONFIG_DIR);
+    });
+  });
+
+  describe("entity WITHOUT subscription.claude_config_dir", () => {
+    it("does NOT include CLAUDE_CONFIG_DIR in tmux command or spawn env", async () => {
+      registry.add(make_entity_config({ id: "no-sub" }));
+      pool.inject_registry(registry);
+      pool.inject_bots([make_bot({ id: 2, state: "free" })]);
+
+      await pool.assign("ch-test", "no-sub", "builder", undefined, "work_room");
+
+      const tmux_call = spawn_calls.find((c) => c.command === "tmux");
+      expect(tmux_call).toBeDefined();
+
+      // The tmux command string (last element in the args array)
+      const cmd_string = tmux_call!.args[tmux_call!.args.length - 1];
+      expect(cmd_string).not.toContain("CLAUDE_CONFIG_DIR=");
+
+      // Spawn env should not have CLAUDE_CONFIG_DIR
+      const spawn_env = tmux_call!.options.env as Record<string, string>;
+      expect(spawn_env.CLAUDE_CONFIG_DIR).toBeUndefined();
+    });
+  });
+
+  describe("backward compatibility — no registry", () => {
+    it("works without CLAUDE_CONFIG_DIR when no registry is set", async () => {
+      pool.inject_bots([make_bot({ id: 3, state: "free" })]);
+
+      await pool.assign("ch-test", "some-entity", "builder", undefined, "work_room");
+
+      const tmux_call = spawn_calls.find((c) => c.command === "tmux");
+      expect(tmux_call).toBeDefined();
+
+      const cmd_string = tmux_call!.args[tmux_call!.args.length - 1];
+      expect(cmd_string).not.toContain("CLAUDE_CONFIG_DIR=");
+
+      const spawn_env = tmux_call!.options.env as Record<string, string>;
+      expect(spawn_env.CLAUDE_CONFIG_DIR).toBeUndefined();
+    });
+  });
+});
+
+// ── Session tests: CLAUDE_CONFIG_DIR injection ──
+
+describe("per-entity CLAUDE_CONFIG_DIR injection — session (queue) path", () => {
+  let config: LobsterFarmConfig;
+  let mgr: ClaudeSessionManager;
+  let registry: MockRegistry;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    spawn_calls = [];
+
+    config = make_config();
+    mgr = new ClaudeSessionManager(config);
+    registry = new MockRegistry();
+  });
+
+  describe("entity WITH subscription.claude_config_dir", () => {
+    const CONFIG_DIR = "/Users/farm/.lobsterfarm/entities/beta/.claude-config";
+
+    it("injects CLAUDE_CONFIG_DIR into spawn env", async () => {
+      registry.add(make_entity_config({ id: "beta-sub", claude_config_dir: CONFIG_DIR }));
+      mgr.set_registry(registry);
+
+      // spawn() will call child_process.spawn which is mocked
+      await mgr.spawn({
+        entity_id: "beta-sub",
+        feature_id: "review-42",
+        archetype: "reviewer",
+        dna: [],
+        model: { model: "sonnet", think: "standard" },
+        worktree_path: "/tmp/test-worktree",
+        prompt: "Review PR #42",
+        interactive: false,
+      });
+
+      // Find the claude spawn call (not tmux — session.ts spawns claude directly)
+      expect(spawn_calls.length).toBeGreaterThanOrEqual(1);
+      const claude_call = spawn_calls[0]!;
+
+      const spawn_env = claude_call.options.env as Record<string, string>;
+      expect(spawn_env.CLAUDE_CONFIG_DIR).toBe(CONFIG_DIR);
+    });
+  });
+
+  describe("entity WITHOUT subscription.claude_config_dir", () => {
+    it("does NOT include CLAUDE_CONFIG_DIR in spawn env", async () => {
+      registry.add(make_entity_config({ id: "no-sub-session" }));
+      mgr.set_registry(registry);
+
+      await mgr.spawn({
+        entity_id: "no-sub-session",
+        feature_id: "review-99",
+        archetype: "reviewer",
+        dna: [],
+        model: { model: "sonnet", think: "standard" },
+        worktree_path: "/tmp/test-worktree",
+        prompt: "Review PR #99",
+        interactive: false,
+      });
+
+      expect(spawn_calls.length).toBeGreaterThanOrEqual(1);
+      const claude_call = spawn_calls[0]!;
+
+      const spawn_env = claude_call.options.env as Record<string, string>;
+      expect(spawn_env.CLAUDE_CONFIG_DIR).toBeUndefined();
+    });
+  });
+
+  describe("no registry set (backward compatible)", () => {
+    it("does NOT include CLAUDE_CONFIG_DIR when no registry is available", async () => {
+      // Don't call set_registry — simulates pre-#296 behavior
+      await mgr.spawn({
+        entity_id: "legacy-entity",
+        feature_id: "review-1",
+        archetype: "reviewer",
+        dna: [],
+        model: { model: "sonnet", think: "standard" },
+        worktree_path: "/tmp/test-worktree",
+        prompt: "Review PR #1",
+        interactive: false,
+      });
+
+      expect(spawn_calls.length).toBeGreaterThanOrEqual(1);
+      const claude_call = spawn_calls[0]!;
+
+      const spawn_env = claude_call.options.env as Record<string, string>;
+      expect(spawn_env.CLAUDE_CONFIG_DIR).toBeUndefined();
+    });
+  });
+
+  describe("caller-provided env vars are preserved", () => {
+    it("merges CLAUDE_CONFIG_DIR alongside caller env vars", async () => {
+      const CONFIG_DIR = "/Users/farm/.lobsterfarm/entities/gamma/.claude-config";
+      registry.add(make_entity_config({ id: "gamma-sub", claude_config_dir: CONFIG_DIR }));
+      mgr.set_registry(registry);
+
+      await mgr.spawn({
+        entity_id: "gamma-sub",
+        feature_id: "fix-99",
+        archetype: "builder",
+        dna: [],
+        model: { model: "opus", think: "high" },
+        worktree_path: "/tmp/test-worktree",
+        prompt: "Fix issue #99",
+        interactive: false,
+        env: { GH_TOKEN: "ghp_test_token", CUSTOM_VAR: "custom_value" },
+      });
+
+      expect(spawn_calls.length).toBeGreaterThanOrEqual(1);
+      const claude_call = spawn_calls[0]!;
+
+      const spawn_env = claude_call.options.env as Record<string, string>;
+      expect(spawn_env.CLAUDE_CONFIG_DIR).toBe(CONFIG_DIR);
+      expect(spawn_env.GH_TOKEN).toBe("ghp_test_token");
+      expect(spawn_env.CUSTOM_VAR).toBe("custom_value");
+    });
+  });
+});

--- a/packages/daemon/src/__tests__/subscription-injection.test.ts
+++ b/packages/daemon/src/__tests__/subscription-injection.test.ts
@@ -215,6 +215,26 @@ describe("per-entity CLAUDE_CONFIG_DIR injection — pool path", () => {
     });
   });
 
+  describe("entity WITH tilde path in subscription.claude_config_dir", () => {
+    it("expands tilde to absolute path in tmux command and spawn env", async () => {
+      const TILDE_PATH = "~/.lobsterfarm/entities/alpha/.claude-config";
+      const EXPANDED_PATH = `${process.env.HOME}/.lobsterfarm/entities/alpha/.claude-config`;
+      registry.add(make_entity_config({ id: "alpha-tilde", claude_config_dir: TILDE_PATH }));
+      pool.inject_registry(registry);
+      pool.inject_bots([make_bot({ id: 4, state: "free" })]);
+
+      await pool.assign("ch-test", "alpha-tilde", "builder", undefined, "work_room");
+
+      const tmux_call = spawn_calls.find((c) => c.command === "tmux");
+      expect(tmux_call).toBeDefined();
+
+      // The resolved path should be expanded — no tilde
+      const spawn_env = tmux_call!.options.env as Record<string, string>;
+      expect(spawn_env.CLAUDE_CONFIG_DIR).toBe(EXPANDED_PATH);
+      expect(spawn_env.CLAUDE_CONFIG_DIR).not.toContain("~");
+    });
+  });
+
   describe("entity WITHOUT subscription.claude_config_dir", () => {
     it("does NOT include CLAUDE_CONFIG_DIR in tmux command or spawn env", async () => {
       registry.add(make_entity_config({ id: "no-sub" }));
@@ -295,6 +315,33 @@ describe("per-entity CLAUDE_CONFIG_DIR injection — session (queue) path", () =
 
       const spawn_env = claude_call.options.env as Record<string, string>;
       expect(spawn_env.CLAUDE_CONFIG_DIR).toBe(CONFIG_DIR);
+    });
+  });
+
+  describe("entity WITH tilde path in subscription.claude_config_dir", () => {
+    it("expands tilde to absolute path in spawn env", async () => {
+      const TILDE_PATH = "~/.lobsterfarm/entities/beta/.claude-config";
+      const EXPANDED_PATH = `${process.env.HOME}/.lobsterfarm/entities/beta/.claude-config`;
+      registry.add(make_entity_config({ id: "beta-tilde", claude_config_dir: TILDE_PATH }));
+      mgr.set_registry(registry);
+
+      await mgr.spawn({
+        entity_id: "beta-tilde",
+        feature_id: "review-tilde",
+        archetype: "reviewer",
+        dna: [],
+        model: { model: "sonnet", think: "standard" },
+        worktree_path: "/tmp/test-worktree",
+        prompt: "Review PR with tilde path",
+        interactive: false,
+      });
+
+      expect(spawn_calls.length).toBeGreaterThanOrEqual(1);
+      const claude_call = spawn_calls[0]!;
+
+      const spawn_env = claude_call.options.env as Record<string, string>;
+      expect(spawn_env.CLAUDE_CONFIG_DIR).toBe(EXPANDED_PATH);
+      expect(spawn_env.CLAUDE_CONFIG_DIR).not.toContain("~");
     });
   });
 

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -43,6 +43,7 @@ async function main(): Promise<void> {
 
   // Initialize session manager + task queue
   const session_manager = new ClaudeSessionManager(config);
+  session_manager.set_registry(registry);
   const queue = new TaskQueue(session_manager, config);
 
   // Wire up session events for session history logging.

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -1329,16 +1329,28 @@ export class BotPool extends EventEmitter {
 
   /** Release a bot while preserving its session_id in history for future resume.
    * Stashes session_id before calling release(), which nulls all bot metadata.
-   * Used by discord.ts when a message arrives for a bot with a dead tmux session. */
+   * Used by discord.ts when a message arrives for a bot with a dead tmux session.
+   *
+   * Only stashes if session_confirmed is true and the JSONL transcript exists
+   * on disk — mirrors the phantom session guards from handle_crash_loop()
+   * (issue #256). Without these checks, a dead session_id gets re-planted
+   * into history and the next assign() pulls it back, causing crash loops. */
   async release_with_history(bot_id: number): Promise<void> {
     const bot = this.bots.find((b) => b.id === bot_id);
     if (!bot || !bot.channel_id) return;
 
-    if (bot.session_id && bot.entity_id) {
-      const key = `${bot.entity_id}:${bot.channel_id}`;
-      this.session_history.set(key, bot.session_id);
-      this.session_history_ts.set(key, Date.now());
-      console.log(`[pool] Stashed session history for ${key}: ${bot.session_id.slice(0, 8)}`);
+    if (bot.session_id && bot.session_confirmed && bot.entity_id) {
+      const exists = await this.check_session_jsonl_exists_anywhere(bot.session_id);
+      if (exists) {
+        const key = `${bot.entity_id}:${bot.channel_id}`;
+        this.session_history.set(key, bot.session_id);
+        this.session_history_ts.set(key, Date.now());
+        console.log(`[pool] Stashed session history for ${key}: ${bot.session_id.slice(0, 8)}`);
+      } else {
+        console.warn(`[pool] Not stashing session ${bot.session_id.slice(0, 8)} — JSONL missing`);
+      }
+    } else if (bot.session_id && !bot.session_confirmed) {
+      console.warn(`[pool] Not stashing unconfirmed session ${bot.session_id.slice(0, 8)}`);
     }
 
     // release() uses channel_id to find the bot — grab it before it's nulled

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -822,6 +822,16 @@ export class BotPool extends EventEmitter {
           }
         }
 
+        // Inject per-entity Claude subscription config dir if configured.
+        const resume_config_dir = this.resolve_claude_config_dir(candidate.entity_id);
+        if (resume_config_dir) {
+          extra_env.CLAUDE_CONFIG_DIR = resume_config_dir;
+          console.log(
+            `[pool] Resuming bot pool-${String(bot.id)} for ${candidate.entity_id} ` +
+              `with CLAUDE_CONFIG_DIR=${resume_config_dir}`,
+          );
+        }
+
         // Write a resume-nudge pending message and point LF_PENDING_FILE at
         // it. The SessionStart hook (session-start-inject.sh) delivers it
         // during Claude init as additionalContext — replacing the legacy
@@ -1093,6 +1103,21 @@ export class BotPool extends EventEmitter {
           console.warn(`[pool] Failed to resolve GH_TOKEN for ${entity_id}: ${String(err)}`);
           // Non-fatal: session starts without GH_TOKEN
         }
+      }
+
+      // Inject per-entity Claude subscription config dir if configured.
+      const assign_config_dir = this.resolve_claude_config_dir(entity_id);
+      if (assign_config_dir) {
+        extra_env.CLAUDE_CONFIG_DIR = assign_config_dir;
+        console.log(
+          `[pool] Assigning bot pool-${String(bot.id)} to ${channel_id} ` +
+            `(entity: ${entity_id}, claude_config: ${assign_config_dir})`,
+        );
+      } else {
+        console.log(
+          `[pool] Assigning bot pool-${String(bot.id)} to ${channel_id} ` +
+            `(entity: ${entity_id}, claude_config: default)`,
+        );
       }
 
       // If a pending message was provided, write it to the JSON file and
@@ -1701,6 +1726,16 @@ export class BotPool extends EventEmitter {
         } catch (err) {
           console.warn(`[pool] Failed to resolve GH_TOKEN for ${entity_id}: ${String(err)}`);
         }
+      }
+
+      // Inject per-entity Claude subscription config dir if configured.
+      const restart_config_dir = this.resolve_claude_config_dir(entity_id);
+      if (restart_config_dir) {
+        extra_env.CLAUDE_CONFIG_DIR = restart_config_dir;
+        console.log(
+          `[pool] Restarting bot pool-${String(bot.id)} for ${entity_id} ` +
+            `with CLAUDE_CONFIG_DIR=${restart_config_dir}`,
+        );
       }
 
       // Write access.json so the Discord plugin listens on this channel
@@ -2327,6 +2362,15 @@ export class BotPool extends EventEmitter {
     const entity_config = this.registry.get(entity_id);
     if (!entity_config) return null;
     return entity_config.entity.secrets.github_token_ref ?? null;
+  }
+
+  /** Look up the per-entity Claude subscription config dir from the registry.
+   * Returns the absolute path if configured, or null (use default ~/.claude). */
+  private resolve_claude_config_dir(entity_id: string): string | null {
+    if (!this.registry) return null;
+    const entity_config = this.registry.get(entity_id);
+    if (!entity_config) return null;
+    return entity_config.entity.subscription?.claude_config_dir ?? null;
   }
 
   /** Resolve a 1Password secret reference to its plaintext value.

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -1354,28 +1354,16 @@ export class BotPool extends EventEmitter {
 
   /** Release a bot while preserving its session_id in history for future resume.
    * Stashes session_id before calling release(), which nulls all bot metadata.
-   * Used by discord.ts when a message arrives for a bot with a dead tmux session.
-   *
-   * Only stashes if session_confirmed is true and the JSONL transcript exists
-   * on disk — mirrors the phantom session guards from handle_crash_loop()
-   * (issue #256). Without these checks, a dead session_id gets re-planted
-   * into history and the next assign() pulls it back, causing crash loops. */
+   * Used by discord.ts when a message arrives for a bot with a dead tmux session. */
   async release_with_history(bot_id: number): Promise<void> {
     const bot = this.bots.find((b) => b.id === bot_id);
     if (!bot || !bot.channel_id) return;
 
-    if (bot.session_id && bot.session_confirmed && bot.entity_id) {
-      const exists = await this.check_session_jsonl_exists_anywhere(bot.session_id);
-      if (exists) {
-        const key = `${bot.entity_id}:${bot.channel_id}`;
-        this.session_history.set(key, bot.session_id);
-        this.session_history_ts.set(key, Date.now());
-        console.log(`[pool] Stashed session history for ${key}: ${bot.session_id.slice(0, 8)}`);
-      } else {
-        console.warn(`[pool] Not stashing session ${bot.session_id.slice(0, 8)} — JSONL missing`);
-      }
-    } else if (bot.session_id && !bot.session_confirmed) {
-      console.warn(`[pool] Not stashing unconfirmed session ${bot.session_id.slice(0, 8)}`);
+    if (bot.session_id && bot.entity_id) {
+      const key = `${bot.entity_id}:${bot.channel_id}`;
+      this.session_history.set(key, bot.session_id);
+      this.session_history_ts.set(key, Date.now());
+      console.log(`[pool] Stashed session history for ${key}: ${bot.session_id.slice(0, 8)}`);
     }
 
     // release() uses channel_id to find the bot — grab it before it's nulled
@@ -2370,7 +2358,8 @@ export class BotPool extends EventEmitter {
     if (!this.registry) return null;
     const entity_config = this.registry.get(entity_id);
     if (!entity_config) return null;
-    return entity_config.entity.subscription?.claude_config_dir ?? null;
+    const dir = entity_config.entity.subscription?.claude_config_dir;
+    return dir ? expand_home(dir) : null;
   }
 
   /** Resolve a 1Password secret reference to its plaintext value.

--- a/packages/daemon/src/session.ts
+++ b/packages/daemon/src/session.ts
@@ -4,7 +4,12 @@ import { EventEmitter } from "node:events";
 import { readFile, readdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import type { ArchetypeRole, LobsterFarmConfig, ModelTier } from "@lobster-farm/shared";
+import type {
+  ArchetypeRole,
+  EntityConfig,
+  LobsterFarmConfig,
+  ModelTier,
+} from "@lobster-farm/shared";
 import {
   entity_context_dir,
   entity_daily_dir,
@@ -178,15 +183,36 @@ function claude_binary(): string {
 
 // ── Implementation ──
 
+/** Minimal interface for entity config lookup — avoids importing the full
+ * EntityRegistry class (which lives in the daemon package). */
+interface EntityConfigLookup {
+  get(entity_id: string): EntityConfig | undefined;
+}
+
 export class ClaudeSessionManager extends EventEmitter implements SessionManager {
   private sessions = new Map<string, ActiveSession>();
   private processes = new Map<string, ChildProcess>();
   private output_buffers = new Map<string, string[]>();
   private config: LobsterFarmConfig;
+  private registry: EntityConfigLookup | null = null;
 
   constructor(config: LobsterFarmConfig) {
     super();
     this.config = config;
+  }
+
+  /** Set the entity registry for per-entity config lookups (e.g. subscription). */
+  set_registry(registry: EntityConfigLookup): void {
+    this.registry = registry;
+  }
+
+  /** Look up the per-entity Claude subscription config dir from the registry.
+   * Returns the absolute path if configured, or null (use default ~/.claude). */
+  private resolve_claude_config_dir(entity_id: string): string | null {
+    if (!this.registry) return null;
+    const entity_config = this.registry.get(entity_id);
+    if (!entity_config) return null;
+    return entity_config.entity.subscription?.claude_config_dir ?? null;
   }
 
   /** Build the full CLI arguments for spawning a claude session. */
@@ -271,11 +297,27 @@ export class ClaudeSessionManager extends EventEmitter implements SessionManager
       tmux_pane: null,
     };
 
+    // Resolve per-entity Claude subscription config dir if configured.
+    // Merged into spawn env so the session uses the entity's own subscription.
+    const spawn_env: Record<string, string> = { ...options.env };
+    const claude_config_dir = this.resolve_claude_config_dir(options.entity_id);
+    if (claude_config_dir) {
+      spawn_env.CLAUDE_CONFIG_DIR = claude_config_dir;
+      console.log(
+        `[session] Spawning session for ${options.entity_id} ` +
+          `with CLAUDE_CONFIG_DIR=${claude_config_dir}`,
+      );
+    } else {
+      console.log(
+        `[session] Spawning session for ${options.entity_id} with CLAUDE_CONFIG_DIR=default (~/.claude)`,
+      );
+    }
+
     // Spawn the process — prompt is piped via stdin
     const proc = spawn(command, args, {
       cwd: expand_home(options.worktree_path),
       stdio: ["pipe", "pipe", "pipe"],
-      env: { ...process.env, ...options.env },
+      env: { ...process.env, ...spawn_env },
     });
 
     // Write prompt to stdin and close it.

--- a/packages/daemon/src/session.ts
+++ b/packages/daemon/src/session.ts
@@ -212,7 +212,8 @@ export class ClaudeSessionManager extends EventEmitter implements SessionManager
     if (!this.registry) return null;
     const entity_config = this.registry.get(entity_id);
     if (!entity_config) return null;
-    return entity_config.entity.subscription?.claude_config_dir ?? null;
+    const dir = entity_config.entity.subscription?.claude_config_dir;
+    return dir ? expand_home(dir) : null;
   }
 
   /** Build the full CLI arguments for spawning a claude session. */
@@ -306,10 +307,6 @@ export class ClaudeSessionManager extends EventEmitter implements SessionManager
       console.log(
         `[session] Spawning session for ${options.entity_id} ` +
           `with CLAUDE_CONFIG_DIR=${claude_config_dir}`,
-      );
-    } else {
-      console.log(
-        `[session] Spawning session for ${options.entity_id} with CLAUDE_CONFIG_DIR=default (~/.claude)`,
       );
     }
 

--- a/packages/shared/src/__tests__/schemas.test.ts
+++ b/packages/shared/src/__tests__/schemas.test.ts
@@ -234,6 +234,39 @@ describe("EntityConfigSchema", () => {
       }),
     ).toThrow();
   });
+
+  // Per-entity subscription support (#296)
+  it("accepts optional subscription with claude_config_dir", () => {
+    const config = EntityConfigSchema.parse({
+      ...MINIMAL_ENTITY,
+      entity: {
+        ...MINIMAL_ENTITY.entity,
+        subscription: {
+          claude_config_dir: "/Users/farm/.lobsterfarm/entities/alpha/.claude-config",
+        },
+      },
+    });
+    expect(config.entity.subscription?.claude_config_dir).toBe(
+      "/Users/farm/.lobsterfarm/entities/alpha/.claude-config",
+    );
+  });
+
+  it("accepts subscription without claude_config_dir", () => {
+    const config = EntityConfigSchema.parse({
+      ...MINIMAL_ENTITY,
+      entity: {
+        ...MINIMAL_ENTITY.entity,
+        subscription: {},
+      },
+    });
+    expect(config.entity.subscription).toBeDefined();
+    expect(config.entity.subscription?.claude_config_dir).toBeUndefined();
+  });
+
+  it("omits subscription by default (backward compatible)", () => {
+    const config = EntityConfigSchema.parse(MINIMAL_ENTITY);
+    expect(config.entity.subscription).toBeUndefined();
+  });
 });
 
 describe("TemplateVariablesSchema", () => {

--- a/packages/shared/src/schemas/entity.ts
+++ b/packages/shared/src/schemas/entity.ts
@@ -116,6 +116,17 @@ export const EntityConfigSchema = z.object({
       // e.g., "op://entity-my-app/github/credential"
       github_token_ref: z.string().optional(),
     }),
+
+    // Per-entity Claude Max subscription. When set, CLAUDE_CONFIG_DIR is
+    // injected into session environments so the entity uses its own
+    // subscription for billing and rate limits.
+    subscription: z
+      .object({
+        // Absolute path to the config directory for this entity's Claude
+        // subscription (replaces ~/.claude for that session).
+        claude_config_dir: z.string().optional(),
+      })
+      .optional(),
   }),
 });
 


### PR DESCRIPTION
## Summary

- Add optional `subscription.claude_config_dir` field to entity config schema, allowing entities to use separate Claude Max subscriptions for billing and rate limit isolation
- Inject `CLAUDE_CONFIG_DIR` into session environments at both spawn points: pool bots (tmux path in `assign()`, `resume_parked_bots()`, crash-recovery restart) and queue sessions (`session.ts` spawn via registry lookup)
- Add logging at spawn time showing which config dir is used (or "default" when not configured)
- Add setup guide at `docs/per-entity-subscriptions.md` covering architecture, one-time setup steps, and troubleshooting

Backward compatible -- entities without the field use default `~/.claude` with zero behavior change.

Closes #296

## Test plan

- [x] Schema tests: accepts optional subscription with claude_config_dir, accepts empty subscription, omits by default (3 tests)
- [x] Pool injection tests: CLAUDE_CONFIG_DIR appears in tmux command + spawn env when configured, omitted when not configured, omitted when no registry (3 tests)
- [x] Session injection tests: CLAUDE_CONFIG_DIR in spawn env when configured, omitted when not configured, omitted when no registry, preserved alongside caller-provided env vars (4 tests)
- [x] Full daemon test suite passes (1031 tests, 62 files)
- [x] Full shared package test suite passes (63 tests, 4 files)
- [x] Type-check passes (`tsc --noEmit`)
- [x] Biome lint/format passes

Generated with [Claude Code](https://claude.com/claude-code)