### PR TITLE
feat: per-entity Claude Max subscription support

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -4,6 +4,9 @@
 - `lobsterfarm-architecture-v0.3.md` — Full system architecture (components, data model, SOPs, governance, roadmap)
 - `lobsterfarm-file-boundary-map-v2.md` — What content goes in which file (definitive guide)
 
+## Guides
+- `per-entity-subscriptions.md` — Per-entity Claude Max subscription support (setup, architecture, troubleshooting)
+
 ## Default Configuration Templates (../config/)
 
 ### ~/.claude/ (Global Claude Code Configuration)

--- a/docs/per-entity-subscriptions.md
+++ b/docs/per-entity-subscriptions.md
@@ -1,0 +1,143 @@
+# Per-Entity Claude Max Subscriptions
+
+## What This Does
+
+By default, all entities share a single Claude Max subscription -- whichever OAuth credentials exist in `~/.claude`. This creates two problems:
+
+1. **Billing** -- no way to attribute costs to individual entities/products
+2. **Rate limits** -- one busy entity can starve another
+
+This feature adds an optional `subscription.claude_config_dir` field to entity config. When set, the daemon injects `CLAUDE_CONFIG_DIR=<path>` into session environments at spawn time. Each config directory is fully isolated -- separate OAuth login, separate session state, separate rate limits.
+
+## How CLAUDE_CONFIG_DIR Works
+
+Claude Code supports `CLAUDE_CONFIG_DIR`, an environment variable that overrides where the CLI looks for all config, credentials, and state. When set, the CLI uses `$CLAUDE_CONFIG_DIR` instead of `~/.claude` for:
+
+- OAuth credentials (the auth token for Claude Max)
+- Session state (conversation history, JSONL files)
+- Settings and configuration
+
+Each directory is fully isolated. Two sessions with different `CLAUDE_CONFIG_DIR` values use completely separate accounts.
+
+## Entity Config
+
+Add a `subscription` block to the entity's `config.yaml`:
+
+```yaml
+entity:
+  id: my-entity
+  name: My Entity
+  # ... other fields ...
+
+  subscription:
+    claude_config_dir: ~/.lobsterfarm/entities/my-entity/.claude-config
+```
+
+When this field is set, all sessions spawned for this entity (both queue-spawned and pool bot sessions) will have `CLAUDE_CONFIG_DIR` set to the specified path. When omitted, sessions use the default `~/.claude` -- no behavior change.
+
+## One-Time Setup for a New Subscription
+
+### 1. Create the config directory
+
+```bash
+mkdir -p ~/.lobsterfarm/entities/my-entity/.claude-config
+```
+
+### 2. Authenticate with Claude Max
+
+```bash
+CLAUDE_CONFIG_DIR=~/.lobsterfarm/entities/my-entity/.claude-config claude auth login
+```
+
+This opens a browser for OAuth and stores the credentials in the config directory.
+
+### 3. Symlink shared config files
+
+Global instructions (CLAUDE.md, rules, settings, agents) should be shared across all subscriptions. Symlink them from the default `~/.claude`:
+
+```bash
+cd ~/.lobsterfarm/entities/my-entity/.claude-config
+
+# Shared global instructions
+ln -s ~/.claude/CLAUDE.md CLAUDE.md
+ln -s ~/.claude/rules rules
+ln -s ~/.claude/settings.json settings.json
+ln -s ~/.claude/agents agents
+ln -s ~/.claude/skills skills
+```
+
+This way, auth is isolated (each entity uses its own Claude Max account) but global instructions and agent definitions are shared.
+
+### 4. Add to entity config
+
+Edit `~/.lobsterfarm/entities/my-entity/config.yaml`:
+
+```yaml
+entity:
+  # ... existing fields ...
+  subscription:
+    claude_config_dir: ~/.lobsterfarm/entities/my-entity/.claude-config
+```
+
+### 5. Restart the daemon
+
+```bash
+lf stop && lf start
+```
+
+The daemon reads entity configs at startup. After restart, all new sessions for this entity will use the configured subscription.
+
+## What's Shared vs. Isolated
+
+| Component | Shared or Isolated | How |
+|-----------|-------------------|-----|
+| OAuth credentials | **Isolated** | Each config dir has its own auth token |
+| Session state | **Isolated** | JSONL files live in each config dir |
+| CLAUDE.md | **Shared** | Symlinked from ~/.claude |
+| rules/ | **Shared** | Symlinked from ~/.claude |
+| settings.json | **Shared** | Symlinked from ~/.claude |
+| agents/ | **Shared** | Symlinked from ~/.claude |
+| skills/ | **Shared** | Symlinked from ~/.claude |
+
+## Architecture
+
+The injection happens at two points in the daemon:
+
+1. **Queue sessions** (`session.ts`) -- When `ClaudeSessionManager.spawn()` is called, it looks up the entity's config via the registry. If `subscription.claude_config_dir` is set, `CLAUDE_CONFIG_DIR` is added to the env dict passed to `child_process.spawn()`.
+
+2. **Pool bot sessions** (`pool.ts`) -- When a pool bot is assigned, resumed, or crash-recovered, the daemon resolves `subscription.claude_config_dir` and adds it to `extra_env`. This gets injected both as a tmux command-string prefix (for the tmux session environment) and in the `spawn()` env object.
+
+Both paths log which config directory is being used at spawn time.
+
+## Troubleshooting
+
+### Verify which subscription a session is using
+
+Check the daemon logs at spawn time. You'll see one of:
+
+```
+[session] Using CLAUDE_CONFIG_DIR=/path/to/.claude-config for my-entity
+[session] Using default ~/.claude config for my-entity
+```
+
+Or for pool bots:
+
+```
+[pool] Assigning pool-3 with CLAUDE_CONFIG_DIR=/path/to/.claude-config (entity: my-entity)
+```
+
+### Auth expired or invalid
+
+If a session fails because the auth token in the config directory is expired:
+
+```bash
+CLAUDE_CONFIG_DIR=~/.lobsterfarm/entities/my-entity/.claude-config claude auth login
+```
+
+### Config directory doesn't exist
+
+The daemon does not validate that the config directory exists at startup. If the directory is missing, Claude CLI will fail at session startup. Create the directory and authenticate before adding it to entity config.
+
+### Symlinks broken after moving directories
+
+If you move the entity or the default `~/.claude` directory, symlinks will break. Re-create them pointing to the new locations.

--- a/packages/daemon/src/__tests__/gh-token-injection.test.ts
+++ b/packages/daemon/src/__tests__/gh-token-injection.test.ts
@@ -69,6 +69,7 @@ class MockRegistry {
 function make_entity_config(overrides: {
   id: string;
   github_token_ref?: string;
+  claude_config_dir?: string;
 }): EntityConfig {
   return EntityConfigSchema.parse({
     entity: {
@@ -81,6 +82,9 @@ function make_entity_config(overrides: {
         vault_name: `entity-${overrides.id}`,
         ...(overrides.github_token_ref ? { github_token_ref: overrides.github_token_ref } : {}),
       },
+      ...(overrides.claude_config_dir
+        ? { subscription: { claude_config_dir: overrides.claude_config_dir } }
+        : {}),
     },
   });
 }
@@ -346,6 +350,94 @@ describe("per-entity GitHub token injection", () => {
 
       expect(cmd_string).not.toContain("GH_TOKEN=");
       expect(cmd_string).toContain("claude");
+    });
+  });
+
+  describe("per-entity CLAUDE_CONFIG_DIR injection", () => {
+    it("injects CLAUDE_CONFIG_DIR into tmux command and spawn env", async () => {
+      const config_dir = "/home/farm/.lobsterfarm/entities/client-x/.claude-config";
+      registry.add(make_entity_config({ id: "custom-claude", claude_config_dir: config_dir }));
+      pool.inject_registry(registry);
+      pool.inject_bots([make_bot({ id: 7, state: "free" })]);
+
+      await pool.assign("ch-test", "custom-claude", "builder", undefined, "work_room");
+
+      const tmux_call = spawn_calls.find((c) => c.command === "tmux");
+      expect(tmux_call).toBeDefined();
+      const cmd_string = tmux_call!.args[tmux_call!.args.length - 1];
+
+      // CLAUDE_CONFIG_DIR should appear as env var prefix in the tmux command
+      expect(cmd_string).toContain("CLAUDE_CONFIG_DIR=");
+      expect(cmd_string).toContain(config_dir);
+
+      // Spawn env should also have CLAUDE_CONFIG_DIR
+      const spawn_env = tmux_call!.options.env as Record<string, string>;
+      expect(spawn_env.CLAUDE_CONFIG_DIR).toBe(config_dir);
+    });
+
+    it("does NOT inject CLAUDE_CONFIG_DIR when entity has no subscription", async () => {
+      registry.add(make_entity_config({ id: "no-sub-entity" }));
+      pool.inject_registry(registry);
+      pool.inject_bots([make_bot({ id: 8, state: "free" })]);
+
+      await pool.assign("ch-test", "no-sub-entity", "builder", undefined, "work_room");
+
+      const tmux_call = spawn_calls.find((c) => c.command === "tmux");
+      expect(tmux_call).toBeDefined();
+      const cmd_string = tmux_call!.args[tmux_call!.args.length - 1];
+
+      expect(cmd_string).not.toContain("CLAUDE_CONFIG_DIR=");
+
+      const spawn_env = tmux_call!.options.env as Record<string, string>;
+      expect(spawn_env.CLAUDE_CONFIG_DIR).toBeUndefined();
+    });
+
+    it("injects both GH_TOKEN and CLAUDE_CONFIG_DIR when both are configured", async () => {
+      const config_dir = "/tmp/dual-config";
+      const ref = "op://entity-dual/github/credential";
+      registry.add(
+        make_entity_config({
+          id: "dual-entity",
+          github_token_ref: ref,
+          claude_config_dir: config_dir,
+        }),
+      );
+      pool.inject_registry(registry);
+      pool.inject_bots([make_bot({ id: 2, state: "free" })]);
+
+      pool.override_resolve_op_secret(async () => "ghp_dual_token");
+
+      await pool.assign("ch-test", "dual-entity", "builder", undefined, "work_room");
+
+      const tmux_call = spawn_calls.find((c) => c.command === "tmux");
+      expect(tmux_call).toBeDefined();
+      const cmd_string = tmux_call!.args[tmux_call!.args.length - 1];
+
+      // Both env vars should appear in the tmux command string
+      expect(cmd_string).toContain("GH_TOKEN=");
+      expect(cmd_string).toContain("CLAUDE_CONFIG_DIR=");
+      expect(cmd_string).toContain(config_dir);
+
+      // Both should also be in the spawn env
+      const spawn_env = tmux_call!.options.env as Record<string, string>;
+      expect(spawn_env.GH_TOKEN).toBe("ghp_dual_token");
+      expect(spawn_env.CLAUDE_CONFIG_DIR).toBe(config_dir);
+    });
+
+    it("no CLAUDE_CONFIG_DIR when registry is not set", async () => {
+      // Pool without registry — backward compatible
+      pool.inject_bots([make_bot({ id: 0, state: "free" })]);
+
+      await pool.assign("ch-test", "orphan-entity", "builder", undefined, "work_room");
+
+      const tmux_call = spawn_calls.find((c) => c.command === "tmux");
+      expect(tmux_call).toBeDefined();
+      const cmd_string = tmux_call!.args[tmux_call!.args.length - 1];
+
+      expect(cmd_string).not.toContain("CLAUDE_CONFIG_DIR=");
+
+      const spawn_env = tmux_call!.options.env as Record<string, string>;
+      expect(spawn_env.CLAUDE_CONFIG_DIR).toBeUndefined();
     });
   });
 });

--- a/packages/daemon/src/__tests__/session.test.ts
+++ b/packages/daemon/src/__tests__/session.test.ts
@@ -1,8 +1,8 @@
 import { chmod, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { LobsterFarmConfig } from "@lobster-farm/shared";
-import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
+import type { EntityConfig, LobsterFarmConfig } from "@lobster-farm/shared";
+import { EntityConfigSchema, LobsterFarmConfigSchema } from "@lobster-farm/shared";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { build_model_flags } from "../models.js";
 import { ClaudeSessionManager } from "../session.js";
@@ -297,6 +297,197 @@ describe("ClaudeSessionManager", () => {
       await mgr.kill(session.session_id);
       await wait_for(() => mgr.get_active().length === 0);
       expect(mgr.get_active()).toHaveLength(0);
+
+      delete process.env.CLAUDE_BIN;
+    });
+  });
+
+  describe("CLAUDE_CONFIG_DIR injection", () => {
+    /** Minimal mock registry that returns entity configs by ID. */
+    class MockRegistry {
+      private entities = new Map<string, EntityConfig>();
+
+      add(config: EntityConfig): void {
+        this.entities.set(config.entity.id, config);
+      }
+
+      get(id: string): EntityConfig | undefined {
+        return this.entities.get(id);
+      }
+    }
+
+    function make_entity(id: string, claude_config_dir?: string): EntityConfig {
+      return EntityConfigSchema.parse({
+        entity: {
+          id,
+          name: id,
+          repos: [],
+          channels: { category_id: "", list: [] },
+          memory: { path: `/tmp/test-memory/${id}` },
+          secrets: { vault_name: `entity-${id}` },
+          ...(claude_config_dir ? { subscription: { claude_config_dir } } : {}),
+        },
+      });
+    }
+
+    it("injects CLAUDE_CONFIG_DIR when entity has subscription.claude_config_dir", async () => {
+      const mock_claude = join(tmp, "mock-claude-env");
+      // Script that prints its CLAUDE_CONFIG_DIR to stdout
+      await writeFile(
+        mock_claude,
+        '#!/bin/bash\necho "{\\"type\\":\\"result\\",\\"content\\":\\"$CLAUDE_CONFIG_DIR\\"}"\nexit 0\n',
+        "utf-8",
+      );
+      await chmod(mock_claude, 0o755);
+
+      const config = make_config();
+      const mgr = new ClaudeSessionManager(config);
+
+      const registry = new MockRegistry();
+      registry.add(make_entity("test-entity", "/tmp/test-claude-config"));
+      mgr.set_registry(registry as unknown as import("../registry.js").EntityRegistry);
+
+      process.env.CLAUDE_BIN = mock_claude;
+
+      const completed = new Promise<string[]>((resolve) => {
+        mgr.on("session:completed", (result) => resolve(result.output_lines));
+      });
+
+      await mgr.spawn({
+        entity_id: "test-entity",
+        feature_id: "test-42",
+        archetype: "builder",
+        dna: [],
+        model: { model: "opus", think: "high" },
+        worktree_path: tmp,
+        prompt: "test",
+        interactive: false,
+      });
+
+      const output = await completed;
+      // The mock script echoes $CLAUDE_CONFIG_DIR — verify it was set
+      expect(output.some((l) => l.includes("/tmp/test-claude-config"))).toBe(true);
+
+      delete process.env.CLAUDE_BIN;
+    });
+
+    it("does NOT inject CLAUDE_CONFIG_DIR when entity has no subscription", async () => {
+      const mock_claude = join(tmp, "mock-claude-noenv");
+      // Script that prints CLAUDE_CONFIG_DIR (should be empty)
+      await writeFile(
+        mock_claude,
+        '#!/bin/bash\necho "{\\"type\\":\\"result\\",\\"content\\":\\"CONFIG_DIR=$CLAUDE_CONFIG_DIR\\"}"\nexit 0\n',
+        "utf-8",
+      );
+      await chmod(mock_claude, 0o755);
+
+      const config = make_config();
+      const mgr = new ClaudeSessionManager(config);
+
+      const registry = new MockRegistry();
+      registry.add(make_entity("plain-entity"));
+      mgr.set_registry(registry as unknown as import("../registry.js").EntityRegistry);
+
+      process.env.CLAUDE_BIN = mock_claude;
+
+      const completed = new Promise<string[]>((resolve) => {
+        mgr.on("session:completed", (result) => resolve(result.output_lines));
+      });
+
+      await mgr.spawn({
+        entity_id: "plain-entity",
+        feature_id: "test-43",
+        archetype: "builder",
+        dna: [],
+        model: { model: "opus", think: "high" },
+        worktree_path: tmp,
+        prompt: "test",
+        interactive: false,
+      });
+
+      const output = await completed;
+      // CONFIG_DIR= should be empty (no value after =)
+      expect(output.some((l) => l.includes("CONFIG_DIR="))).toBe(true);
+      expect(output.some((l) => l.includes("CONFIG_DIR=/"))).toBe(false);
+
+      delete process.env.CLAUDE_BIN;
+    });
+
+    it("works without a registry (backward compatible)", async () => {
+      const mock_claude = join(tmp, "mock-claude-noreg");
+      await writeFile(
+        mock_claude,
+        '#!/bin/bash\necho "{\\"type\\":\\"result\\",\\"content\\":\\"ok\\"}"\nexit 0\n',
+        "utf-8",
+      );
+      await chmod(mock_claude, 0o755);
+
+      const config = make_config();
+      const mgr = new ClaudeSessionManager(config);
+      // No registry set — should not throw
+
+      process.env.CLAUDE_BIN = mock_claude;
+
+      const completed = new Promise<void>((resolve) => {
+        mgr.on("session:completed", () => resolve());
+      });
+
+      await mgr.spawn({
+        entity_id: "no-registry-entity",
+        feature_id: "test-44",
+        archetype: "builder",
+        dna: [],
+        model: { model: "opus", think: "high" },
+        worktree_path: tmp,
+        prompt: "test",
+        interactive: false,
+      });
+
+      await completed;
+      // Session completed successfully without a registry
+      expect(mgr.get_active()).toHaveLength(0);
+
+      delete process.env.CLAUDE_BIN;
+    });
+
+    it("merges CLAUDE_CONFIG_DIR with caller-provided env", async () => {
+      const mock_claude = join(tmp, "mock-claude-merge");
+      await writeFile(
+        mock_claude,
+        '#!/bin/bash\necho "{\\"type\\":\\"result\\",\\"content\\":\\"GH=$GH_TOKEN CCD=$CLAUDE_CONFIG_DIR\\"}"\nexit 0\n',
+        "utf-8",
+      );
+      await chmod(mock_claude, 0o755);
+
+      const config = make_config();
+      const mgr = new ClaudeSessionManager(config);
+
+      const registry = new MockRegistry();
+      registry.add(make_entity("merge-entity", "/tmp/merge-config"));
+      mgr.set_registry(registry as unknown as import("../registry.js").EntityRegistry);
+
+      process.env.CLAUDE_BIN = mock_claude;
+
+      const completed = new Promise<string[]>((resolve) => {
+        mgr.on("session:completed", (result) => resolve(result.output_lines));
+      });
+
+      await mgr.spawn({
+        entity_id: "merge-entity",
+        feature_id: "test-45",
+        archetype: "builder",
+        dna: [],
+        model: { model: "opus", think: "high" },
+        worktree_path: tmp,
+        prompt: "test",
+        interactive: false,
+        env: { GH_TOKEN: "ghp_test123" },
+      });
+
+      const output = await completed;
+      // Both GH_TOKEN and CLAUDE_CONFIG_DIR should be present
+      expect(output.some((l) => l.includes("GH=ghp_test123"))).toBe(true);
+      expect(output.some((l) => l.includes("CCD=/tmp/merge-config"))).toBe(true);
 
       delete process.env.CLAUDE_BIN;
     });

--- a/packages/daemon/src/__tests__/session.test.ts
+++ b/packages/daemon/src/__tests__/session.test.ts
@@ -1,5 +1,5 @@
 import { chmod, mkdir, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import type { EntityConfig, LobsterFarmConfig } from "@lobster-farm/shared";
 import { EntityConfigSchema, LobsterFarmConfigSchema } from "@lobster-farm/shared";
@@ -367,6 +367,49 @@ describe("ClaudeSessionManager", () => {
       const output = await completed;
       // The mock script echoes $CLAUDE_CONFIG_DIR — verify it was set
       expect(output.some((l) => l.includes("/tmp/test-claude-config"))).toBe(true);
+
+      delete process.env.CLAUDE_BIN;
+    });
+
+    it("expands tilde in claude_config_dir to absolute path", async () => {
+      const mock_claude = join(tmp, "mock-claude-tilde");
+      // Script that prints its CLAUDE_CONFIG_DIR to stdout
+      await writeFile(
+        mock_claude,
+        '#!/bin/bash\necho "{\\"type\\":\\"result\\",\\"content\\":\\"$CLAUDE_CONFIG_DIR\\"}"\nexit 0\n',
+        "utf-8",
+      );
+      await chmod(mock_claude, 0o755);
+
+      const config = make_config();
+      const mgr = new ClaudeSessionManager(config);
+
+      const registry = new MockRegistry();
+      registry.add(make_entity("tilde-entity", "~/.lobsterfarm/entities/tilde/.claude-config"));
+      mgr.set_registry(registry as unknown as import("../registry.js").EntityRegistry);
+
+      process.env.CLAUDE_BIN = mock_claude;
+
+      const completed = new Promise<string[]>((resolve) => {
+        mgr.on("session:completed", (result) => resolve(result.output_lines));
+      });
+
+      await mgr.spawn({
+        entity_id: "tilde-entity",
+        feature_id: "test-tilde",
+        archetype: "builder",
+        dna: [],
+        model: { model: "opus", think: "high" },
+        worktree_path: tmp,
+        prompt: "test",
+        interactive: false,
+      });
+
+      const output = await completed;
+      const expected = join(homedir(), ".lobsterfarm/entities/tilde/.claude-config");
+      // Tilde must be expanded — the injected path should start with / not ~
+      expect(output.some((l) => l.includes(expected))).toBe(true);
+      expect(output.some((l) => l.includes("~/.lobsterfarm"))).toBe(false);
 
       delete process.env.CLAUDE_BIN;
     });

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -43,6 +43,7 @@ async function main(): Promise<void> {
 
   // Initialize session manager + task queue
   const session_manager = new ClaudeSessionManager(config);
+  session_manager.set_registry(registry);
   const queue = new TaskQueue(session_manager, config);
 
   // Wire up session events for session history logging.

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -822,6 +822,16 @@ export class BotPool extends EventEmitter {
           }
         }
 
+        // Resolve per-entity CLAUDE_CONFIG_DIR (if configured) so this session
+        // uses the entity's own Claude Max subscription.
+        const resume_claude_config = this.resolve_claude_config_dir(candidate.entity_id);
+        if (resume_claude_config) {
+          extra_env.CLAUDE_CONFIG_DIR = resume_claude_config;
+          console.log(
+            `[pool] Resuming pool-${String(bot.id)} with CLAUDE_CONFIG_DIR=${resume_claude_config} (entity: ${candidate.entity_id})`,
+          );
+        }
+
         // Write a resume-nudge pending message and point LF_PENDING_FILE at
         // it. The SessionStart hook (session-start-inject.sh) delivers it
         // during Claude init as additionalContext — replacing the legacy
@@ -1093,6 +1103,16 @@ export class BotPool extends EventEmitter {
           console.warn(`[pool] Failed to resolve GH_TOKEN for ${entity_id}: ${String(err)}`);
           // Non-fatal: session starts without GH_TOKEN
         }
+      }
+
+      // Resolve per-entity CLAUDE_CONFIG_DIR (if configured) so this session
+      // uses the entity's own Claude Max subscription.
+      const assign_claude_config = this.resolve_claude_config_dir(entity_id);
+      if (assign_claude_config) {
+        extra_env.CLAUDE_CONFIG_DIR = assign_claude_config;
+        console.log(
+          `[pool] Assigning pool-${String(bot.id)} with CLAUDE_CONFIG_DIR=${assign_claude_config} (entity: ${entity_id})`,
+        );
       }
 
       // If a pending message was provided, write it to the JSON file and
@@ -1689,6 +1709,16 @@ export class BotPool extends EventEmitter {
         } catch (err) {
           console.warn(`[pool] Failed to resolve GH_TOKEN for ${entity_id}: ${String(err)}`);
         }
+      }
+
+      // Resolve per-entity CLAUDE_CONFIG_DIR (if configured) so the restarted
+      // session uses the entity's own Claude Max subscription.
+      const crash_claude_config = this.resolve_claude_config_dir(entity_id);
+      if (crash_claude_config) {
+        extra_env.CLAUDE_CONFIG_DIR = crash_claude_config;
+        console.log(
+          `[pool] Restarting pool-${String(bot.id)} with CLAUDE_CONFIG_DIR=${crash_claude_config} (entity: ${entity_id})`,
+        );
       }
 
       // Write access.json so the Discord plugin listens on this channel
@@ -2315,6 +2345,15 @@ export class BotPool extends EventEmitter {
     const entity_config = this.registry.get(entity_id);
     if (!entity_config) return null;
     return entity_config.entity.secrets.github_token_ref ?? null;
+  }
+
+  /** Look up the subscription.claude_config_dir for an entity from the registry.
+   * Returns the absolute path if configured, or null. */
+  private resolve_claude_config_dir(entity_id: string): string | null {
+    if (!this.registry) return null;
+    const entity_config = this.registry.get(entity_id);
+    if (!entity_config) return null;
+    return entity_config.entity.subscription?.claude_config_dir ?? null;
   }
 
   /** Resolve a 1Password secret reference to its plaintext value.

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -2353,7 +2353,8 @@ export class BotPool extends EventEmitter {
     if (!this.registry) return null;
     const entity_config = this.registry.get(entity_id);
     if (!entity_config) return null;
-    return entity_config.entity.subscription?.claude_config_dir ?? null;
+    const raw = entity_config.entity.subscription?.claude_config_dir;
+    return raw ? expand_home(raw) : null;
   }
 
   /** Resolve a 1Password secret reference to its plaintext value.

--- a/packages/daemon/src/session.ts
+++ b/packages/daemon/src/session.ts
@@ -289,8 +289,6 @@ export class ClaudeSessionManager extends EventEmitter implements SessionManager
       console.log(
         `[session] Using CLAUDE_CONFIG_DIR=${claude_config_dir} for ${options.entity_id}`,
       );
-    } else {
-      console.log(`[session] Using default ~/.claude config for ${options.entity_id}`);
     }
 
     // Spawn the process — prompt is piped via stdin
@@ -459,6 +457,7 @@ export class ClaudeSessionManager extends EventEmitter implements SessionManager
     if (!this.registry) return null;
     const entity_config = this.registry.get(entity_id);
     if (!entity_config) return null;
-    return entity_config.entity.subscription?.claude_config_dir ?? null;
+    const raw = entity_config.entity.subscription?.claude_config_dir;
+    return raw ? expand_home(raw) : null;
   }
 }

--- a/packages/daemon/src/session.ts
+++ b/packages/daemon/src/session.ts
@@ -13,6 +13,7 @@ import {
   expand_home,
 } from "@lobster-farm/shared";
 import { build_model_flags } from "./models.js";
+import type { EntityRegistry } from "./registry.js";
 import * as sentry from "./sentry.js";
 
 // ── Interfaces ──
@@ -183,10 +184,18 @@ export class ClaudeSessionManager extends EventEmitter implements SessionManager
   private processes = new Map<string, ChildProcess>();
   private output_buffers = new Map<string, string[]>();
   private config: LobsterFarmConfig;
+  /** Entity registry reference — set via set_registry(), used to look up
+   * per-entity config (e.g., subscription.claude_config_dir). */
+  private registry: EntityRegistry | null = null;
 
   constructor(config: LobsterFarmConfig) {
     super();
     this.config = config;
+  }
+
+  /** Attach the entity registry so spawn() can resolve per-entity config. */
+  set_registry(registry: EntityRegistry): void {
+    this.registry = registry;
   }
 
   /** Build the full CLI arguments for spawning a claude session. */
@@ -271,11 +280,24 @@ export class ClaudeSessionManager extends EventEmitter implements SessionManager
       tmux_pane: null,
     };
 
+    // Resolve per-entity CLAUDE_CONFIG_DIR (if configured) so this session
+    // uses the entity's own Claude Max subscription for billing and rate limits.
+    const spawn_env: Record<string, string> = { ...options.env };
+    const claude_config_dir = this.resolve_claude_config_dir(options.entity_id);
+    if (claude_config_dir) {
+      spawn_env.CLAUDE_CONFIG_DIR = claude_config_dir;
+      console.log(
+        `[session] Using CLAUDE_CONFIG_DIR=${claude_config_dir} for ${options.entity_id}`,
+      );
+    } else {
+      console.log(`[session] Using default ~/.claude config for ${options.entity_id}`);
+    }
+
     // Spawn the process — prompt is piped via stdin
     const proc = spawn(command, args, {
       cwd: expand_home(options.worktree_path),
       stdio: ["pipe", "pipe", "pipe"],
-      env: { ...process.env, ...options.env },
+      env: { ...process.env, ...spawn_env },
     });
 
     // Write prompt to stdin and close it.
@@ -429,5 +451,14 @@ export class ClaudeSessionManager extends EventEmitter implements SessionManager
   async kill_all(): Promise<void> {
     const sessions = this.get_active();
     await Promise.all(sessions.map((s) => this.kill(s.session_id)));
+  }
+
+  /** Look up the subscription.claude_config_dir for an entity from the registry.
+   * Returns the absolute path if configured, or null. */
+  private resolve_claude_config_dir(entity_id: string): string | null {
+    if (!this.registry) return null;
+    const entity_config = this.registry.get(entity_id);
+    if (!entity_config) return null;
+    return entity_config.entity.subscription?.claude_config_dir ?? null;
   }
 }

--- a/packages/shared/src/README.md
+++ b/packages/shared/src/README.md
@@ -17,6 +17,6 @@ Zod schemas that define the shape of all configuration and runtime data.
 - `index.ts` -- Re-exports all schema modules.
 - `enums.ts` -- Enumeration types: `ArchetypeRole`, `ChannelType`, `EntityStatus`, `AgentMode`, `ModelName`, `ThinkLevel`, `RepoStructure`, `Priority`.
 - `config.ts` -- `LobsterFarmConfigSchema`. Global config shape: version, paths, concurrency limits, default model tiers per task type, Discord settings, user info, machine info, and agent names.
-- `entity.ts` -- `EntityConfigSchema`. Per-entity config shape: identity, status, blueprint, repos, accounts (GitHub/Vercel/Sentry), Discord channels, memory settings, SOP/guideline overrides, and secrets vault.
+- `entity.ts` -- `EntityConfigSchema`. Per-entity config shape: identity, status, blueprint, repos, accounts (GitHub/Vercel/Sentry), Discord channels, memory settings, SOP/guideline overrides, secrets vault, and optional subscription config (`subscription.claude_config_dir` for per-entity Claude Max subscriptions -- see `docs/per-entity-subscriptions.md`).
 - `queue.ts` -- `QueuedTaskSchema`. Task queue entry: entity, feature, archetype, DNA, model, prompt, priority, status, and completion metadata.
 - `template.ts` -- `TemplateVariablesSchema`. All `{{PLACEHOLDER}}` keys used in config templates: user info, GitHub credentials, machine details, agent names (title case and lowercase), and block content.

--- a/packages/shared/src/__tests__/schemas.test.ts
+++ b/packages/shared/src/__tests__/schemas.test.ts
@@ -234,6 +234,39 @@ describe("EntityConfigSchema", () => {
       }),
     ).toThrow();
   });
+
+  // subscription.claude_config_dir (#296)
+  it("accepts optional subscription.claude_config_dir", () => {
+    const config = EntityConfigSchema.parse({
+      ...MINIMAL_ENTITY,
+      entity: {
+        ...MINIMAL_ENTITY.entity,
+        subscription: {
+          claude_config_dir: "/home/farm/.lobsterfarm/entities/alpha/.claude-config",
+        },
+      },
+    });
+    expect(config.entity.subscription?.claude_config_dir).toBe(
+      "/home/farm/.lobsterfarm/entities/alpha/.claude-config",
+    );
+  });
+
+  it("defaults subscription to undefined when omitted", () => {
+    const config = EntityConfigSchema.parse(MINIMAL_ENTITY);
+    expect(config.entity.subscription).toBeUndefined();
+  });
+
+  it("accepts subscription object without claude_config_dir", () => {
+    const config = EntityConfigSchema.parse({
+      ...MINIMAL_ENTITY,
+      entity: {
+        ...MINIMAL_ENTITY.entity,
+        subscription: {},
+      },
+    });
+    expect(config.entity.subscription).toBeDefined();
+    expect(config.entity.subscription?.claude_config_dir).toBeUndefined();
+  });
 });
 
 describe("TemplateVariablesSchema", () => {

--- a/packages/shared/src/schemas/entity.ts
+++ b/packages/shared/src/schemas/entity.ts
@@ -116,6 +116,15 @@ export const EntityConfigSchema = z.object({
       // e.g., "op://entity-my-app/github/credential"
       github_token_ref: z.string().optional(),
     }),
+
+    // Per-entity Claude Max subscription. When set, CLAUDE_CONFIG_DIR is
+    // injected into session environments so this entity uses a separate
+    // Claude account (billing, rate limits). See docs/per-entity-subscriptions.md.
+    subscription: z
+      .object({
+        claude_config_dir: z.string().optional(),
+      })
+      .optional(),
   }),
 });
 


### PR DESCRIPTION
## Summary

- Add optional `subscription.claude_config_dir` field to `EntityConfigSchema` for per-entity Claude Max billing and rate limit isolation
- Inject `CLAUDE_CONFIG_DIR` into queue sessions (`session.ts`) and pool bot sessions (`pool.ts`) at spawn time, following the established `GH_TOKEN` injection pattern
- Log which config directory each session uses at spawn time in both paths
- Add `docs/per-entity-subscriptions.md` with setup instructions, architecture explanation, and troubleshooting

## Test plan

- [x] 3 new schema tests: accepts `subscription.claude_config_dir`, defaults to undefined when omitted, accepts empty subscription object
- [x] 4 new session tests: injects `CLAUDE_CONFIG_DIR` when configured, omits when not configured, works without registry (backward compat), merges with caller-provided env (e.g. `GH_TOKEN`)
- [x] 4 new pool tests: injects into tmux command and spawn env, omits when no subscription, injects both `GH_TOKEN` and `CLAUDE_CONFIG_DIR` together, backward compatible without registry
- [x] All 1127 existing tests pass (63 shared + 34 CLI + 1030 daemon)
- [x] Build, TypeScript typecheck, and Biome lint all clean

Closes #296