### PR TITLE
feat(daemon): per-entity Discord roles for channel visibility (#295)

### DIFF
--- a/packages/daemon/src/__tests__/discord-roles.test.ts
+++ b/packages/daemon/src/__tests__/discord-roles.test.ts
@@ -1,5 +1,6 @@
 import { EntityConfigSchema, LobsterFarmConfigSchema } from "@lobster-farm/shared";
 import { describe, expect, it } from "vitest";
+import { is_lf_bot } from "../discord.js";
 
 // ── Schema tests ──
 
@@ -74,41 +75,35 @@ describe("LobsterFarmConfig discord.user_id (#295)", () => {
   });
 });
 
-// ── Route registration test ──
-// Pattern shape test only — validates the regex matches expected paths.
-// Actual route wiring (presence in server.ts routes[]) is verified via
-// integration testing, not unit tests.
+// ── is_lf_bot — ensures only LobsterFarm bots receive the Administrator role ──
 
-describe("POST /lockdown endpoint", () => {
-  it("lockdown route pattern matches /lockdown path", () => {
-    // The route is registered as: { method: "POST", pattern: /^\/lockdown$/ }
-    // Verify the pattern works correctly.
-    const pattern = /^\/lockdown$/;
-    expect(pattern.test("/lockdown")).toBe(true);
-    expect(pattern.test("/lockdown/")).toBe(false);
-    expect(pattern.test("/lockdowns")).toBe(false);
-    expect(pattern.test("/scaffold/lockdown")).toBe(false);
+describe("is_lf_bot (#295)", () => {
+  it("matches LobsterFarm pool bots (lf-0 through lf-14)", () => {
+    expect(is_lf_bot("lf-0")).toBe(true);
+    expect(is_lf_bot("lf-9")).toBe(true);
+    expect(is_lf_bot("lf-14")).toBe(true);
   });
-});
 
-// ── scaffold_entity return shape ──
+  it("matches lobsterfarm-prefixed bots", () => {
+    expect(is_lf_bot("lobsterfarm")).toBe(true);
+    expect(is_lf_bot("lobsterfarm-daemon")).toBe(true);
+    expect(is_lf_bot("LobsterFarm-Failsafe")).toBe(true);
+  });
 
-describe("scaffold_entity return value includes role_id (#295)", () => {
-  it("return type includes role_id field", () => {
-    // Verify the expected shape — this is a type/contract test.
-    // The actual Discord API calls are mocked in integration tests.
-    const result: {
-      category_id: string;
-      role_id: string;
-      channels: Array<{ type: string; id: string; purpose: string }>;
-    } = {
-      category_id: "cat-123",
-      role_id: "role-456",
-      channels: [{ type: "general", id: "ch-789", purpose: "Entity-level discussion" }],
-    };
+  it("matches lobster-farm-prefixed bots", () => {
+    expect(is_lf_bot("lobster-farm")).toBe(true);
+    expect(is_lf_bot("Lobster-Farm-Pat")).toBe(true);
+  });
 
-    expect(result.role_id).toBe("role-456");
-    expect(result.category_id).toBe("cat-123");
-    expect(result.channels).toHaveLength(1);
+  it("is case-insensitive", () => {
+    expect(is_lf_bot("LF-0")).toBe(true);
+    expect(is_lf_bot("LOBSTERFARM")).toBe(true);
+  });
+
+  it("rejects non-LobsterFarm bots", () => {
+    expect(is_lf_bot("MEE6")).toBe(false);
+    expect(is_lf_bot("Dyno")).toBe(false);
+    expect(is_lf_bot("GitHub")).toBe(false);
+    expect(is_lf_bot("some-random-bot")).toBe(false);
   });
 });

--- a/packages/daemon/src/__tests__/discord-roles.test.ts
+++ b/packages/daemon/src/__tests__/discord-roles.test.ts
@@ -75,8 +75,9 @@ describe("LobsterFarmConfig discord.user_id (#295)", () => {
 });
 
 // ── Route registration test ──
-// Verifies that POST /lockdown is a registered route in the server module.
-// We import the routes indirectly by checking the module structure.
+// Pattern shape test only — validates the regex matches expected paths.
+// Actual route wiring (presence in server.ts routes[]) is verified via
+// integration testing, not unit tests.
 
 describe("POST /lockdown endpoint", () => {
   it("lockdown route pattern matches /lockdown path", () => {

--- a/packages/daemon/src/__tests__/discord-roles.test.ts
+++ b/packages/daemon/src/__tests__/discord-roles.test.ts
@@ -1,0 +1,113 @@
+import { EntityConfigSchema, LobsterFarmConfigSchema } from "@lobster-farm/shared";
+import { describe, expect, it } from "vitest";
+
+// ── Schema tests ──
+
+describe("ChannelsSchema role_id field (#295)", () => {
+  const MINIMAL_ENTITY = {
+    entity: {
+      id: "test-entity",
+      name: "Test Entity",
+      memory: { path: "~/.lobsterfarm/entities/test-entity" },
+      secrets: { vault_name: "entity-test-entity" },
+    },
+  };
+
+  it("accepts role_id in channels", () => {
+    const config = EntityConfigSchema.parse({
+      ...MINIMAL_ENTITY,
+      entity: {
+        ...MINIMAL_ENTITY.entity,
+        channels: {
+          category_id: "cat-123456789012345678",
+          role_id: "role-123456789012345678",
+          list: [{ type: "general", id: "ch-123456789012345678" }],
+        },
+      },
+    });
+    expect(config.entity.channels.role_id).toBe("role-123456789012345678");
+    expect(config.entity.channels.category_id).toBe("cat-123456789012345678");
+  });
+
+  it("defaults role_id to undefined when omitted", () => {
+    const config = EntityConfigSchema.parse({
+      ...MINIMAL_ENTITY,
+      entity: {
+        ...MINIMAL_ENTITY.entity,
+        channels: {
+          category_id: "cat-123",
+          list: [],
+        },
+      },
+    });
+    expect(config.entity.channels.role_id).toBeUndefined();
+  });
+
+  it("existing channels config without role_id still parses (backward compat)", () => {
+    const config = EntityConfigSchema.parse(MINIMAL_ENTITY);
+    expect(config.entity.channels.category_id).toBe("");
+    expect(config.entity.channels.role_id).toBeUndefined();
+    expect(config.entity.channels.list).toEqual([]);
+  });
+});
+
+// ── Config schema: discord.user_id is required for lockdown ──
+
+describe("LobsterFarmConfig discord.user_id (#295)", () => {
+  it("parses config with discord.user_id set", () => {
+    const config = LobsterFarmConfigSchema.parse({
+      user: { name: "Test" },
+      discord: {
+        server_id: "1485323605331017859",
+        user_id: "732686813856006245",
+      },
+    });
+    expect(config.discord?.user_id).toBe("732686813856006245");
+  });
+
+  it("allows discord.user_id to be omitted", () => {
+    const config = LobsterFarmConfigSchema.parse({
+      user: { name: "Test" },
+      discord: { server_id: "1485323605331017859" },
+    });
+    expect(config.discord?.user_id).toBeUndefined();
+  });
+});
+
+// ── Route registration test ──
+// Verifies that POST /lockdown is a registered route in the server module.
+// We import the routes indirectly by checking the module structure.
+
+describe("POST /lockdown endpoint", () => {
+  it("lockdown route pattern matches /lockdown path", () => {
+    // The route is registered as: { method: "POST", pattern: /^\/lockdown$/ }
+    // Verify the pattern works correctly.
+    const pattern = /^\/lockdown$/;
+    expect(pattern.test("/lockdown")).toBe(true);
+    expect(pattern.test("/lockdown/")).toBe(false);
+    expect(pattern.test("/lockdowns")).toBe(false);
+    expect(pattern.test("/scaffold/lockdown")).toBe(false);
+  });
+});
+
+// ── scaffold_entity return shape ──
+
+describe("scaffold_entity return value includes role_id (#295)", () => {
+  it("return type includes role_id field", () => {
+    // Verify the expected shape — this is a type/contract test.
+    // The actual Discord API calls are mocked in integration tests.
+    const result: {
+      category_id: string;
+      role_id: string;
+      channels: Array<{ type: string; id: string; purpose: string }>;
+    } = {
+      category_id: "cat-123",
+      role_id: "role-456",
+      channels: [{ type: "general", id: "ch-789", purpose: "Entity-level discussion" }],
+    };
+
+    expect(result.role_id).toBe("role-456");
+    expect(result.category_id).toBe("cat-123");
+    expect(result.channels).toHaveLength(1);
+  });
+});

--- a/packages/daemon/src/__tests__/discord-roles.test.ts
+++ b/packages/daemon/src/__tests__/discord-roles.test.ts
@@ -1,6 +1,8 @@
+import type { Server } from "node:http";
 import { EntityConfigSchema, LobsterFarmConfigSchema } from "@lobster-farm/shared";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { is_lf_bot } from "../discord.js";
+import { start_server } from "../server.js";
 
 // ── Schema tests ──
 
@@ -105,5 +107,90 @@ describe("is_lf_bot (#295)", () => {
     expect(is_lf_bot("Dyno")).toBe(false);
     expect(is_lf_bot("GitHub")).toBe(false);
     expect(is_lf_bot("some-random-bot")).toBe(false);
+  });
+});
+
+// ── /lockdown route guard tests (#295) ──
+
+describe("/lockdown route guards (#295)", () => {
+  let server: Server;
+  let port: number;
+
+  /** Minimal mocks — just enough to start the server and test route guards. */
+  function make_server_deps(discord: unknown = null) {
+    const registry = {
+      get_all: () => [],
+      get_active: () => [],
+      count: () => 0,
+      get: () => null,
+    } as never;
+    const config = LobsterFarmConfigSchema.parse({ user: { name: "Test" } });
+    const session_manager = { get_active: () => [] } as never;
+    const queue = {
+      get_stats: () => ({ pending: 0, active: 0, total: 0 }),
+      get_pending: () => [],
+      get_active: () => [],
+    } as never;
+    return { registry, config, session_manager, queue, discord };
+  }
+
+  async function start_test_server(discord: unknown = null): Promise<void> {
+    const deps = make_server_deps(discord);
+    // Use port 0 so the OS assigns a free port
+    server = start_server(
+      deps.registry,
+      deps.config,
+      deps.session_manager,
+      deps.queue,
+      null,
+      deps.discord as never,
+      null,
+      null,
+      null,
+      null,
+      0,
+    );
+    // Wait for listen
+    await new Promise<void>((resolve) => {
+      server.on("listening", resolve);
+    });
+    const addr = server.address();
+    port = typeof addr === "object" && addr ? addr.port : 0;
+  }
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    }
+  });
+
+  it("returns 503 when discord is not connected", async () => {
+    await start_test_server(null);
+
+    const res = await fetch(`http://localhost:${String(port)}/lockdown`, { method: "POST" });
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/Discord bot not connected/);
+  });
+
+  it("returns 409 when lockdown is already in progress", async () => {
+    // Mock discord with a lockdown that never resolves (simulates long-running migration)
+    const discord = {
+      lockdown: () => new Promise<void>(() => {}), // never resolves
+    };
+
+    await start_test_server(discord);
+
+    // First request: should return 202 (accepted, fire-and-forget)
+    const first = await fetch(`http://localhost:${String(port)}/lockdown`, { method: "POST" });
+    expect(first.status).toBe(202);
+
+    // Second request while first is still in progress: should return 409
+    const second = await fetch(`http://localhost:${String(port)}/lockdown`, { method: "POST" });
+    expect(second.status).toBe(409);
+    const body = (await second.json()) as { error: string };
+    expect(body.error).toMatch(/already in progress/);
   });
 });

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -494,6 +494,9 @@ export class DiscordBot extends EventEmitter {
     this.client = new Client({
       intents: [
         GatewayIntentBits.Guilds,
+        // Privileged intent — requires "Server Members Intent" enabled in
+        // Discord Developer Portal (Bot → Privileged Gateway Intents).
+        // Needed for guild.members.fetch() in lockdown().
         GatewayIntentBits.GuildMembers,
         GatewayIntentBits.GuildMessages,
         GatewayIntentBits.MessageContent,
@@ -1861,6 +1864,7 @@ export class DiscordBot extends EventEmitter {
   async lockdown(): Promise<{
     bot_role_id: string;
     entities_processed: number;
+    entities_failed: number;
     global_locked: boolean;
     failsafe_locked: boolean;
     bots_assigned: number;
@@ -1900,6 +1904,7 @@ export class DiscordBot extends EventEmitter {
 
     // 3. Process each entity — create role, set category overrides, store role_id
     let entities_processed = 0;
+    let entities_failed = 0;
     for (const entity_config of this.registry.get_all()) {
       const entity_id = entity_config.entity.id;
       const category_id = entity_config.entity.channels.category_id;
@@ -1942,6 +1947,7 @@ export class DiscordBot extends EventEmitter {
         entities_processed++;
         console.log(`[lockdown] Processed entity "${entity_id}"`);
       } catch (err) {
+        entities_failed++;
         console.error(`[lockdown] Failed to process entity "${entity_id}": ${String(err)}`);
         sentry.captureException(err, {
           tags: { module: "discord", action: "lockdown", entity: entity_id },
@@ -2039,7 +2045,8 @@ export class DiscordBot extends EventEmitter {
     this.build_channel_map();
 
     console.log(
-      `[lockdown] Complete: ${String(entities_processed)} entities, ` +
+      `[lockdown] Complete: ${String(entities_processed)} entities processed, ` +
+        `${String(entities_failed)} failed, ` +
         `${String(bots_assigned)} bots, global=${String(global_locked)}, ` +
         `failsafe=${String(failsafe_locked)}`,
     );
@@ -2047,6 +2054,7 @@ export class DiscordBot extends EventEmitter {
     return {
       bot_role_id: bot_role.id,
       entities_processed,
+      entities_failed,
       global_locked,
       failsafe_locked,
       bots_assigned,

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -28,6 +28,9 @@ import {
   GatewayIntentBits,
   type Guild,
   type Message,
+  OverwriteType,
+  PermissionFlagsBits,
+  type Role,
   SlashCommandBuilder,
   type TextChannel,
   type Webhook,
@@ -491,6 +494,7 @@ export class DiscordBot extends EventEmitter {
     this.client = new Client({
       intents: [
         GatewayIntentBits.Guilds,
+        GatewayIntentBits.GuildMembers,
         GatewayIntentBits.GuildMessages,
         GatewayIntentBits.MessageContent,
       ],
@@ -1694,8 +1698,78 @@ export class DiscordBot extends EventEmitter {
   }
 
   /**
+   * Find or create the "LobsterFarm Bot" role.
+   * Used by scaffold_entity and lockdown to ensure bots have a shared role.
+   */
+  async find_or_create_bot_role(guild: Guild): Promise<Role> {
+    const existing = guild.roles.cache.find((r) => r.name === "LobsterFarm Bot");
+    if (existing) return existing;
+
+    const role = await guild.roles.create({
+      name: "LobsterFarm Bot",
+      permissions: [PermissionFlagsBits.Administrator],
+      reason: "LobsterFarm bot role — grants bots access to all channels",
+    });
+    console.log(`[discord] Created "LobsterFarm Bot" role (${role.id})`);
+    return role;
+  }
+
+  /**
+   * Find or create the entity-specific Discord role.
+   * The role itself has no special permissions — it's used as a tag
+   * for category permission overrides.
+   */
+  async find_or_create_entity_role(guild: Guild, entity_id: string): Promise<Role> {
+    const existing = guild.roles.cache.find((r) => r.name === entity_id);
+    if (existing) return existing;
+
+    const role = await guild.roles.create({
+      name: entity_id,
+      reason: `LobsterFarm entity role for ${entity_id}`,
+    });
+    console.log(`[discord] Created entity role "${entity_id}" (${role.id})`);
+    return role;
+  }
+
+  /**
+   * Set permission overrides on a category so only the entity role and
+   * bot role can view channels within it. @everyone is denied ViewChannel.
+   */
+  async set_entity_category_permissions(
+    category: CategoryChannel,
+    entity_role: Role,
+    bot_role: Role,
+  ): Promise<void> {
+    const guild = category.guild;
+
+    await category.permissionOverwrites.set([
+      {
+        id: guild.roles.everyone.id,
+        type: OverwriteType.Role,
+        deny: [PermissionFlagsBits.ViewChannel],
+      },
+      {
+        id: entity_role.id,
+        type: OverwriteType.Role,
+        allow: [PermissionFlagsBits.ViewChannel],
+      },
+      {
+        id: bot_role.id,
+        type: OverwriteType.Role,
+        allow: [PermissionFlagsBits.ViewChannel],
+      },
+    ]);
+
+    console.log(
+      `[discord] Set permission overrides on category "${category.name}" ` +
+        `(entity: ${entity_role.name}, bot: ${bot_role.name})`,
+    );
+  }
+
+  /**
    * Scaffold Discord channels for a new entity.
-   * Creates a category and standard channels (general, alerts).
+   * Creates a category, standard channels (general, alerts), an entity role,
+   * and sets permission overrides so only the entity role + bot role can view.
    * Work rooms are created on demand via /room.
    * Returns the channel mappings to store in entity config.
    */
@@ -1704,13 +1778,15 @@ export class DiscordBot extends EventEmitter {
     entity_name: string,
   ): Promise<{
     category_id: string;
+    role_id: string;
     channels: Array<{ type: string; id: string; purpose: string }>;
   }> {
     const guild = await this.get_guild();
-    if (!guild) return { category_id: "", channels: [] };
+    if (!guild) return { category_id: "", role_id: "", channels: [] };
 
     const channels: Array<{ type: string; id: string; purpose: string }> = [];
     let category_id = "";
+    let role_id = "";
 
     try {
       // Create entity category
@@ -1728,6 +1804,12 @@ export class DiscordBot extends EventEmitter {
         console.log(`[discord] Created category "${category_name}"`);
       }
       category_id = category.id;
+
+      // Create entity role and bot role, set category permissions
+      const bot_role = await this.find_or_create_bot_role(guild);
+      const entity_role = await this.find_or_create_entity_role(guild, entity_id);
+      role_id = entity_role.id;
+      await this.set_entity_category_permissions(category, entity_role, bot_role);
 
       // Standard entity channels — work rooms are created on demand via /room
       const entity_channels = [
@@ -1762,7 +1844,213 @@ export class DiscordBot extends EventEmitter {
       });
     }
 
-    return { category_id, channels };
+    return { category_id, role_id, channels };
+  }
+
+  /**
+   * One-time lockdown migration.
+   *
+   * Idempotent — safe to run multiple times. For each entity:
+   * 1. Creates/finds the "LobsterFarm Bot" role, assigns to all bot members
+   * 2. Creates/finds entity roles, sets category permission overrides
+   * 3. Stores role_id in entity config
+   * 4. Locks down the GLOBAL category (Jax + bots only)
+   * 5. Locks down the failsafe channel if it exists
+   * 6. Reloads entity configs
+   */
+  async lockdown(): Promise<{
+    bot_role_id: string;
+    entities_processed: number;
+    global_locked: boolean;
+    failsafe_locked: boolean;
+    bots_assigned: number;
+  }> {
+    const guild = await this.get_guild();
+    if (!guild) {
+      throw new Error("Cannot fetch guild — Discord not connected or server_id missing");
+    }
+
+    const user_id = this.config.discord?.user_id;
+    if (!user_id) {
+      throw new Error("discord.user_id not set in config — required for global channel lockdown");
+    }
+
+    // 1. Create/find the bot role
+    const bot_role = await this.find_or_create_bot_role(guild);
+
+    // 2. Assign bot role to all bot members in the server
+    const members = await guild.members.fetch();
+    let bots_assigned = 0;
+    for (const [, member] of members) {
+      if (member.user.bot && !member.roles.cache.has(bot_role.id)) {
+        try {
+          await member.roles.add(bot_role, "LobsterFarm lockdown — assigning bot role");
+          bots_assigned++;
+          console.log(`[lockdown] Assigned bot role to ${member.user.tag}`);
+        } catch (err) {
+          // The daemon bot's own application role may be higher, causing this
+          // to fail for the bot itself. Log and continue.
+          console.warn(
+            `[lockdown] Failed to assign bot role to ${member.user.tag}: ${String(err)}`,
+          );
+        }
+      }
+    }
+    console.log(`[lockdown] Bot role assigned to ${String(bots_assigned)} new bots`);
+
+    // 3. Process each entity — create role, set category overrides, store role_id
+    let entities_processed = 0;
+    for (const entity_config of this.registry.get_all()) {
+      const entity_id = entity_config.entity.id;
+      const category_id = entity_config.entity.channels.category_id;
+      if (!category_id || !is_discord_snowflake(category_id)) {
+        console.log(`[lockdown] Skipping entity "${entity_id}" — no valid category_id`);
+        continue;
+      }
+
+      try {
+        // Find or create entity role
+        const entity_role = await this.find_or_create_entity_role(guild, entity_id);
+
+        // Fetch category channel and set overrides
+        const category = (await guild.channels.fetch(category_id)) as CategoryChannel | null;
+        if (!category || category.type !== DiscordChannelType.GuildCategory) {
+          console.warn(`[lockdown] Category ${category_id} not found for entity "${entity_id}"`);
+          continue;
+        }
+
+        await this.set_entity_category_permissions(category, entity_role, bot_role);
+
+        // Sync child channel permissions to match category
+        for (const [, child] of category.children.cache) {
+          try {
+            await child.lockPermissions();
+          } catch (err) {
+            console.warn(
+              `[lockdown] Failed to sync permissions for #${child.name}: ${String(err)}`,
+            );
+          }
+        }
+
+        // Store role_id in entity config if not already set
+        if (entity_config.entity.channels.role_id !== entity_role.id) {
+          entity_config.entity.channels.role_id = entity_role.id;
+          await this.persist_entity_config(entity_config);
+          console.log(`[lockdown] Stored role_id for entity "${entity_id}"`);
+        }
+
+        entities_processed++;
+        console.log(`[lockdown] Processed entity "${entity_id}"`);
+      } catch (err) {
+        console.error(`[lockdown] Failed to process entity "${entity_id}": ${String(err)}`);
+        sentry.captureException(err, {
+          tags: { module: "discord", action: "lockdown", entity: entity_id },
+        });
+      }
+    }
+
+    // 4. Lock down GLOBAL category — Jax + bots only
+    let global_locked = false;
+    try {
+      const global_category = guild.channels.cache.find(
+        (c) => c.name === "GLOBAL" && c.type === DiscordChannelType.GuildCategory,
+      ) as CategoryChannel | undefined;
+
+      if (global_category) {
+        await global_category.permissionOverwrites.set([
+          {
+            id: guild.roles.everyone.id,
+            type: OverwriteType.Role,
+            deny: [PermissionFlagsBits.ViewChannel],
+          },
+          {
+            id: user_id,
+            type: OverwriteType.Member,
+            allow: [PermissionFlagsBits.ViewChannel],
+          },
+          {
+            id: bot_role.id,
+            type: OverwriteType.Role,
+            allow: [PermissionFlagsBits.ViewChannel],
+          },
+        ]);
+
+        // Sync child channels
+        for (const [, child] of global_category.children.cache) {
+          try {
+            await child.lockPermissions();
+          } catch (err) {
+            console.warn(`[lockdown] Failed to sync GLOBAL child #${child.name}: ${String(err)}`);
+          }
+        }
+
+        global_locked = true;
+        console.log("[lockdown] GLOBAL category locked down");
+      } else {
+        console.log("[lockdown] GLOBAL category not found — skipping");
+      }
+    } catch (err) {
+      console.error(`[lockdown] Failed to lock GLOBAL category: ${String(err)}`);
+      sentry.captureException(err, {
+        tags: { module: "discord", action: "lockdown_global" },
+      });
+    }
+
+    // 5. Lock down failsafe channel (may exist outside a category)
+    let failsafe_locked = false;
+    try {
+      const failsafe = guild.channels.cache.find(
+        (c) => c.name === "failsafe" && c.type === DiscordChannelType.GuildText,
+      ) as TextChannel | undefined;
+
+      if (failsafe) {
+        await failsafe.permissionOverwrites.set([
+          {
+            id: guild.roles.everyone.id,
+            type: OverwriteType.Role,
+            deny: [PermissionFlagsBits.ViewChannel],
+          },
+          {
+            id: user_id,
+            type: OverwriteType.Member,
+            allow: [PermissionFlagsBits.ViewChannel],
+          },
+          {
+            id: bot_role.id,
+            type: OverwriteType.Role,
+            allow: [PermissionFlagsBits.ViewChannel],
+          },
+        ]);
+
+        failsafe_locked = true;
+        console.log("[lockdown] Failsafe channel locked down");
+      } else {
+        console.log("[lockdown] Failsafe channel not found — skipping");
+      }
+    } catch (err) {
+      console.error(`[lockdown] Failed to lock failsafe channel: ${String(err)}`);
+      sentry.captureException(err, {
+        tags: { module: "discord", action: "lockdown_failsafe" },
+      });
+    }
+
+    // 6. Reload entity configs and rebuild channel map
+    await this.registry.load_all();
+    this.build_channel_map();
+
+    console.log(
+      `[lockdown] Complete: ${String(entities_processed)} entities, ` +
+        `${String(bots_assigned)} bots, global=${String(global_locked)}, ` +
+        `failsafe=${String(failsafe_locked)}`,
+    );
+
+    return {
+      bot_role_id: bot_role.id,
+      entities_processed,
+      global_locked,
+      failsafe_locked,
+      bots_assigned,
+    };
   }
 
   /** Rebuild the channel → entity/type index from entity configs. */
@@ -2243,8 +2531,8 @@ export class DiscordBot extends EventEmitter {
 
       await target.reply(`Setting up entity **${entity_id}** ("${entity_name}")...`);
 
-      // 1. Create Discord channels
-      const { category_id, channels } = await this.scaffold_entity(entity_id, entity_name);
+      // 1. Create Discord channels and entity role
+      const { category_id, role_id, channels } = await this.scaffold_entity(entity_id, entity_name);
 
       // 2. Create directory structure
       const paths = this.config.paths;
@@ -2277,6 +2565,7 @@ export class DiscordBot extends EventEmitter {
           accounts: {},
           channels: {
             category_id,
+            role_id: role_id || undefined,
             list: channels,
           },
           memory: {

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -50,6 +50,16 @@ export function is_discord_snowflake(id: string): boolean {
   return /^\d{17,20}$/.test(id);
 }
 
+/**
+ * Check whether a Discord bot username belongs to LobsterFarm.
+ * Only LF bots should receive the Administrator-privileged "LobsterFarm Bot" role.
+ */
+const LF_BOT_USERNAME_PREFIXES = ["lf-", "lobsterfarm", "lobster-farm"];
+export function is_lf_bot(username: string): boolean {
+  const lower = username.toLowerCase();
+  return LF_BOT_USERNAME_PREFIXES.some((prefix) => lower.startsWith(prefix));
+}
+
 // ── Formatting helpers ──
 
 /** Format the duration between a start time and now as a human-readable string (e.g., "2h 14m"). */
@@ -1705,6 +1715,8 @@ export class DiscordBot extends EventEmitter {
    * Used by scaffold_entity and lockdown to ensure bots have a shared role.
    */
   async find_or_create_bot_role(guild: Guild): Promise<Role> {
+    // Fetch fresh from API to avoid creating duplicates if role was created externally
+    await guild.roles.fetch();
     const existing = guild.roles.cache.find((r) => r.name === "LobsterFarm Bot");
     if (existing) return existing;
 
@@ -1723,6 +1735,8 @@ export class DiscordBot extends EventEmitter {
    * for category permission overrides.
    */
   async find_or_create_entity_role(guild: Guild, entity_id: string): Promise<Role> {
+    // Fetch fresh from API to avoid creating duplicates if role was created externally
+    await guild.roles.fetch();
     const existing = guild.roles.cache.find((r) => r.name === entity_id);
     if (existing) return existing;
 
@@ -1882,11 +1896,16 @@ export class DiscordBot extends EventEmitter {
     // 1. Create/find the bot role
     const bot_role = await this.find_or_create_bot_role(guild);
 
-    // 2. Assign bot role to all bot members in the server
+    // 2. Assign bot role to LobsterFarm bot members only (not all bots in the server).
+    // The "LobsterFarm Bot" role carries Administrator — only our bots should have it.
     const members = await guild.members.fetch();
     let bots_assigned = 0;
     for (const [, member] of members) {
-      if (member.user.bot && !member.roles.cache.has(bot_role.id)) {
+      if (
+        member.user.bot &&
+        is_lf_bot(member.user.username) &&
+        !member.roles.cache.has(bot_role.id)
+      ) {
         try {
           await member.roles.add(bot_role, "LobsterFarm lockdown — assigning bot role");
           bots_assigned++;

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -1711,12 +1711,12 @@ export class DiscordBot extends EventEmitter {
   }
 
   /**
-   * Find or create the "LobsterFarm Bot" role.
+   * Find or create the "LobsterFarm Bot" role with Administrator permissions.
    * Used by scaffold_entity and lockdown to ensure bots have a shared role.
+   * @param skip_fetch - Skip the API fetch if the caller already refreshed the role cache.
    */
-  async find_or_create_bot_role(guild: Guild): Promise<Role> {
-    // Fetch fresh from API to avoid creating duplicates if role was created externally
-    await guild.roles.fetch();
+  async find_or_create_bot_role(guild: Guild, skip_fetch = false): Promise<Role> {
+    if (!skip_fetch) await guild.roles.fetch();
     const existing = guild.roles.cache.find((r) => r.name === "LobsterFarm Bot");
     if (existing) return existing;
 
@@ -1733,10 +1733,14 @@ export class DiscordBot extends EventEmitter {
    * Find or create the entity-specific Discord role.
    * The role itself has no special permissions — it's used as a tag
    * for category permission overrides.
+   * @param skip_fetch - Skip the API fetch if the caller already refreshed the role cache.
    */
-  async find_or_create_entity_role(guild: Guild, entity_id: string): Promise<Role> {
-    // Fetch fresh from API to avoid creating duplicates if role was created externally
-    await guild.roles.fetch();
+  async find_or_create_entity_role(
+    guild: Guild,
+    entity_id: string,
+    skip_fetch = false,
+  ): Promise<Role> {
+    if (!skip_fetch) await guild.roles.fetch();
     const existing = guild.roles.cache.find((r) => r.name === entity_id);
     if (existing) return existing;
 
@@ -1805,6 +1809,25 @@ export class DiscordBot extends EventEmitter {
     let category_id = "";
     let role_id = "";
 
+    // Create roles before any channels — if role creation fails (e.g., bot lacks
+    // Manage Roles permission), we fail fast before leaving an empty, unprotected category.
+    let bot_role: Role;
+    let entity_role: Role;
+    try {
+      await guild.roles.fetch();
+      bot_role = await this.find_or_create_bot_role(guild, true);
+      entity_role = await this.find_or_create_entity_role(guild, entity_id, true);
+      role_id = entity_role.id;
+    } catch (err) {
+      console.error(
+        `[discord] Role creation failed for ${entity_id} — aborting scaffold: ${String(err)}`,
+      );
+      sentry.captureException(err, {
+        tags: { module: "discord", action: "scaffold_entity_roles", entity: entity_id },
+      });
+      return { category_id, role_id, channels };
+    }
+
     try {
       // Create entity category
       const category_name = entity_name;
@@ -1822,10 +1845,7 @@ export class DiscordBot extends EventEmitter {
       }
       category_id = category.id;
 
-      // Create entity role and bot role, set category permissions
-      const bot_role = await this.find_or_create_bot_role(guild);
-      const entity_role = await this.find_or_create_entity_role(guild, entity_id);
-      role_id = entity_role.id;
+      // Set category permissions with the already-created roles
       await this.set_entity_category_permissions(category, entity_role, bot_role);
 
       // Standard entity channels — work rooms are created on demand via /room
@@ -1891,6 +1911,11 @@ export class DiscordBot extends EventEmitter {
     const user_id = this.config.discord?.user_id;
     if (!user_id) {
       throw new Error("discord.user_id not set in config — required for global channel lockdown");
+    }
+    if (!is_discord_snowflake(user_id)) {
+      throw new Error(
+        `discord.user_id "${user_id}" is not a valid Discord snowflake — expected a 17-20 digit numeric string`,
+      );
     }
 
     // 1. Create/find the bot role
@@ -1975,8 +2000,10 @@ export class DiscordBot extends EventEmitter {
     }
 
     // 4. Lock down GLOBAL category — Jax + bots only
+    // Fetch fresh channel list to match the API-fetched approach used for entity categories
     let global_locked = false;
     try {
+      await guild.channels.fetch();
       const global_category = guild.channels.cache.find(
         (c) => c.name === "GLOBAL" && c.type === DiscordChannelType.GuildCategory,
       ) as CategoryChannel | undefined;

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -1958,13 +1958,15 @@ export class DiscordBot extends EventEmitter {
       }
 
       try {
-        // Find or create entity role
-        const entity_role = await this.find_or_create_entity_role(guild, entity_id);
+        // Find or create entity role — skip_fetch=true because find_or_create_bot_role
+        // already populated the role cache at the start of lockdown
+        const entity_role = await this.find_or_create_entity_role(guild, entity_id, true);
 
         // Fetch category channel and set overrides
         const category = (await guild.channels.fetch(category_id)) as CategoryChannel | null;
         if (!category || category.type !== DiscordChannelType.GuildCategory) {
           console.warn(`[lockdown] Category ${category_id} not found for entity "${entity_id}"`);
+          entities_failed++;
           continue;
         }
 

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -1711,12 +1711,21 @@ export class DiscordBot extends EventEmitter {
   }
 
   /**
+   * Populate the guild's role cache from the API. Call once before using
+   * find_or_create_bot_role / find_or_create_entity_role, which operate
+   * on cache only. Newly created roles are automatically added to cache
+   * by discord.js, so a single fetch at the start of a batch is sufficient.
+   */
+  async ensure_roles_cached(guild: Guild): Promise<void> {
+    await guild.roles.fetch();
+  }
+
+  /**
    * Find or create the "LobsterFarm Bot" role with Administrator permissions.
    * Used by scaffold_entity and lockdown to ensure bots have a shared role.
-   * @param skip_fetch - Skip the API fetch if the caller already refreshed the role cache.
+   * Caller must call ensure_roles_cached(guild) first.
    */
-  async find_or_create_bot_role(guild: Guild, skip_fetch = false): Promise<Role> {
-    if (!skip_fetch) await guild.roles.fetch();
+  async find_or_create_bot_role(guild: Guild): Promise<Role> {
     const existing = guild.roles.cache.find((r) => r.name === "LobsterFarm Bot");
     if (existing) return existing;
 
@@ -1733,14 +1742,9 @@ export class DiscordBot extends EventEmitter {
    * Find or create the entity-specific Discord role.
    * The role itself has no special permissions — it's used as a tag
    * for category permission overrides.
-   * @param skip_fetch - Skip the API fetch if the caller already refreshed the role cache.
+   * Caller must call ensure_roles_cached(guild) first.
    */
-  async find_or_create_entity_role(
-    guild: Guild,
-    entity_id: string,
-    skip_fetch = false,
-  ): Promise<Role> {
-    if (!skip_fetch) await guild.roles.fetch();
+  async find_or_create_entity_role(guild: Guild, entity_id: string): Promise<Role> {
     const existing = guild.roles.cache.find((r) => r.name === entity_id);
     if (existing) return existing;
 
@@ -1814,9 +1818,9 @@ export class DiscordBot extends EventEmitter {
     let bot_role: Role;
     let entity_role: Role;
     try {
-      await guild.roles.fetch();
-      bot_role = await this.find_or_create_bot_role(guild, true);
-      entity_role = await this.find_or_create_entity_role(guild, entity_id, true);
+      await this.ensure_roles_cached(guild);
+      bot_role = await this.find_or_create_bot_role(guild);
+      entity_role = await this.find_or_create_entity_role(guild, entity_id);
       role_id = entity_role.id;
     } catch (err) {
       console.error(
@@ -1827,6 +1831,11 @@ export class DiscordBot extends EventEmitter {
       });
       return { category_id, role_id, channels };
     }
+
+    // Track whether permissions were successfully set. If the category is created
+    // but permissions fail, we must clean up to avoid leaving an unprotected category
+    // visible to @everyone.
+    let permissions_set = false;
 
     try {
       // Create entity category
@@ -1845,8 +1854,10 @@ export class DiscordBot extends EventEmitter {
       }
       category_id = category.id;
 
-      // Set category permissions with the already-created roles
+      // Set category permissions — this is a fatal step. If it fails after the
+      // category exists, the entity would be scaffolded but unprotected.
       await this.set_entity_category_permissions(category, entity_role, bot_role);
+      permissions_set = true;
 
       // Standard entity channels — work rooms are created on demand via /room
       const entity_channels = [
@@ -1879,6 +1890,23 @@ export class DiscordBot extends EventEmitter {
       sentry.captureException(err, {
         tags: { module: "discord", action: "scaffold_entity", entity: entity_id },
       });
+
+      // If the category was created but permissions weren't set, delete it
+      // to avoid leaving an unprotected category visible to @everyone.
+      if (category_id && !permissions_set) {
+        try {
+          const cat = guild.channels.cache.get(category_id);
+          if (cat) {
+            await cat.delete("LobsterFarm scaffold cleanup — permission setup failed");
+            console.log(`[discord] Deleted unprotected category ${category_id} for ${entity_id}`);
+          }
+        } catch (cleanup_err) {
+          console.error(
+            `[discord] Failed to clean up unprotected category ${category_id}: ${String(cleanup_err)}`,
+          );
+        }
+        category_id = "";
+      }
     }
 
     return { category_id, role_id, channels };
@@ -1918,7 +1946,8 @@ export class DiscordBot extends EventEmitter {
       );
     }
 
-    // 1. Create/find the bot role
+    // 1. Create/find the bot role — populate cache once for the entire lockdown
+    await this.ensure_roles_cached(guild);
     const bot_role = await this.find_or_create_bot_role(guild);
 
     // 2. Assign bot role to LobsterFarm bot members only (not all bots in the server).
@@ -1958,9 +1987,9 @@ export class DiscordBot extends EventEmitter {
       }
 
       try {
-        // Find or create entity role — skip_fetch=true because find_or_create_bot_role
-        // already populated the role cache at the start of lockdown
-        const entity_role = await this.find_or_create_entity_role(guild, entity_id, true);
+        // Find or create entity role — cache was populated by ensure_roles_cached()
+        // at the start of lockdown; newly created roles are auto-added to cache.
+        const entity_role = await this.find_or_create_entity_role(guild, entity_id);
 
         // Fetch category channel and set overrides
         const category = (await guild.channels.fetch(category_id)) as CategoryChannel | null;
@@ -1972,7 +2001,8 @@ export class DiscordBot extends EventEmitter {
 
         await this.set_entity_category_permissions(category, entity_role, bot_role);
 
-        // Sync child channel permissions to match category
+        // lockPermissions() syncs the channel to inherit from the category, wiping any
+        // channel-level overrides. Safe for our setup — all LF channels should inherit.
         for (const [, child] of category.children.cache) {
           try {
             await child.lockPermissions();
@@ -2029,7 +2059,8 @@ export class DiscordBot extends EventEmitter {
           },
         ]);
 
-        // Sync child channels
+        // lockPermissions() syncs the channel to inherit from the category, wiping any
+        // channel-level overrides. Safe for our setup — all LF channels should inherit.
         for (const [, child] of global_category.children.cache) {
           try {
             await child.lockPermissions();

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -761,13 +761,25 @@ const handle_lockdown: RouteHandler = async (_req, res, ctx) => {
     return;
   }
 
-  try {
-    const result = await ctx.discord.lockdown();
-    json_response(res, 200, { ok: true, ...result });
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    json_response(res, 500, { error: msg });
-  }
+  // Respond immediately — lockdown makes many sequential Discord API calls
+  // and may be rate-limited. Fire-and-forget; check logs for results.
+  json_response(res, 202, {
+    ok: true,
+    message: "Lockdown started — check daemon logs for results",
+  });
+
+  void ctx.discord.lockdown().then(
+    (result) => {
+      console.log("[lockdown] Completed successfully:", JSON.stringify(result));
+    },
+    (err) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[lockdown] Failed: ${msg}`);
+      sentry.captureException(err, {
+        tags: { module: "server", action: "lockdown" },
+      });
+    },
+  );
 };
 
 // ── Router ──

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -753,6 +753,23 @@ const handle_channel_delete: RouteHandler = async (req, res, ctx) => {
   json_response(res, 200, { ok: true, deleted: params.channel_id });
 };
 
+// ── Lockdown route ──
+
+const handle_lockdown: RouteHandler = async (_req, res, ctx) => {
+  if (!ctx.discord) {
+    json_response(res, 503, { error: "Discord bot not connected" });
+    return;
+  }
+
+  try {
+    const result = await ctx.discord.lockdown();
+    json_response(res, 200, { ok: true, ...result });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    json_response(res, 500, { error: msg });
+  }
+};
+
 // ── Router ──
 
 const routes: Route[] = [
@@ -768,6 +785,7 @@ const routes: Route[] = [
   { method: "POST", pattern: /^\/pr\/watch$/, handler: handle_pr_watch },
   { method: "POST", pattern: /^\/channels\/delete$/, handler: handle_channel_delete },
   { method: "POST", pattern: /^\/scaffold\/entity$/, handler: handle_scaffold_entity },
+  { method: "POST", pattern: /^\/lockdown$/, handler: handle_lockdown },
   { method: "POST", pattern: /^\/reload$/, handler: handle_reload },
   { method: "POST", pattern: /^\/webhooks\/github$/, handler: handle_webhook_github },
   { method: "POST", pattern: /^\/webhooks\/sentry$/, handler: handle_webhook_sentry },

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -757,6 +757,10 @@ const handle_channel_delete: RouteHandler = async (req, res, ctx) => {
 
 let lockdown_in_progress = false;
 
+// Safety timeout for lockdown — if it hangs (e.g., Discord API rate-limit loop),
+// the flag resets so the endpoint isn't permanently stuck until process restart.
+const LOCKDOWN_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
 const handle_lockdown: RouteHandler = async (_req, res, ctx) => {
   if (!ctx.discord) {
     json_response(res, 503, { error: "Discord bot not connected" });
@@ -777,8 +781,11 @@ const handle_lockdown: RouteHandler = async (_req, res, ctx) => {
     message: "Lockdown started — check daemon logs for results",
   });
 
-  void ctx.discord
-    .lockdown()
+  const timeout_promise = new Promise<never>((_, reject) => {
+    setTimeout(() => reject(new Error("Lockdown timed out after 5 minutes")), LOCKDOWN_TIMEOUT_MS);
+  });
+
+  void Promise.race([ctx.discord.lockdown(), timeout_promise])
     .then(
       (result) => {
         console.log("[lockdown] Completed successfully:", JSON.stringify(result));

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -755,11 +755,20 @@ const handle_channel_delete: RouteHandler = async (req, res, ctx) => {
 
 // ── Lockdown route ──
 
+let lockdown_in_progress = false;
+
 const handle_lockdown: RouteHandler = async (_req, res, ctx) => {
   if (!ctx.discord) {
     json_response(res, 503, { error: "Discord bot not connected" });
     return;
   }
+
+  if (lockdown_in_progress) {
+    json_response(res, 409, { error: "Lockdown already in progress" });
+    return;
+  }
+
+  lockdown_in_progress = true;
 
   // Respond immediately — lockdown makes many sequential Discord API calls
   // and may be rate-limited. Fire-and-forget; check logs for results.
@@ -768,18 +777,23 @@ const handle_lockdown: RouteHandler = async (_req, res, ctx) => {
     message: "Lockdown started — check daemon logs for results",
   });
 
-  void ctx.discord.lockdown().then(
-    (result) => {
-      console.log("[lockdown] Completed successfully:", JSON.stringify(result));
-    },
-    (err) => {
-      const msg = err instanceof Error ? err.message : String(err);
-      console.error(`[lockdown] Failed: ${msg}`);
-      sentry.captureException(err, {
-        tags: { module: "server", action: "lockdown" },
-      });
-    },
-  );
+  void ctx.discord
+    .lockdown()
+    .then(
+      (result) => {
+        console.log("[lockdown] Completed successfully:", JSON.stringify(result));
+      },
+      (err) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`[lockdown] Failed: ${msg}`);
+        sentry.captureException(err, {
+          tags: { module: "server", action: "lockdown" },
+        });
+      },
+    )
+    .finally(() => {
+      lockdown_in_progress = false;
+    });
 };
 
 // ── Router ──

--- a/packages/shared/src/__tests__/schemas.test.ts
+++ b/packages/shared/src/__tests__/schemas.test.ts
@@ -183,6 +183,37 @@ describe("EntityConfigSchema", () => {
     expect(config.entity.channels.list[1]!.assigned_feature).toBe("alpha-42");
   });
 
+  it("accepts channels with role_id (#295)", () => {
+    const config = EntityConfigSchema.parse({
+      ...MINIMAL_ENTITY,
+      entity: {
+        ...MINIMAL_ENTITY.entity,
+        channels: {
+          category_id: "cat-123",
+          role_id: "role-456",
+          list: [{ type: "general", id: "discord-123" }],
+        },
+      },
+    });
+    expect(config.entity.channels.category_id).toBe("cat-123");
+    expect(config.entity.channels.role_id).toBe("role-456");
+    expect(config.entity.channels.list).toHaveLength(1);
+  });
+
+  it("defaults role_id to undefined when omitted (#295)", () => {
+    const config = EntityConfigSchema.parse({
+      ...MINIMAL_ENTITY,
+      entity: {
+        ...MINIMAL_ENTITY.entity,
+        channels: {
+          category_id: "cat-123",
+          list: [],
+        },
+      },
+    });
+    expect(config.entity.channels.role_id).toBeUndefined();
+  });
+
   it("accepts per-entity accounts", () => {
     const config = EntityConfigSchema.parse({
       ...MINIMAL_ENTITY,

--- a/packages/shared/src/schemas/entity.ts
+++ b/packages/shared/src/schemas/entity.ts
@@ -13,6 +13,7 @@ export type ChannelMapping = z.infer<typeof ChannelMappingSchema>;
 export const ChannelsSchema = z
   .object({
     category_id: z.string().default(""),
+    role_id: z.string().optional(),
     list: z.array(ChannelMappingSchema).default([]),
   })
   .default({ category_id: "", list: [] });


### PR DESCRIPTION
## Summary

- Adds `role_id` field to `ChannelsSchema` in the shared package for storing per-entity Discord role IDs
- Updates `scaffold_entity()` to create an entity role + bot role and set category permission overrides (deny `@everyone`, allow entity role + bot role) on every new entity scaffold
- Adds `POST /lockdown` daemon endpoint for one-time migration that creates roles, assigns bot role to all bots, locks down GLOBAL + failsafe channels (Jax + bots only), persists role_ids, and reloads configs — fully idempotent
- Adds `GuildMembers` privileged intent for member enumeration during lockdown

## Pre-deploy checklist

- [ ] Enable "Server Members Intent" in Discord Developer Portal (Bot → Privileged Gateway Intents) for the bot application. `GuildMembers` is a privileged intent — without this, the bot will fail to connect with close code `4014 DISALLOWED_INTENTS`.

## Test plan

- [x] Schema tests: `role_id` accepted in channels config, defaults to undefined when omitted, backward compatible
- [x] Route pattern test: `/lockdown` path matches correctly
- [x] Full daemon test suite passes (62 files, 1043 tests)
- [x] Full shared test suite passes (4 files, 65 tests)
- [x] TypeScript typecheck clean on both packages
- [ ] Manual: trigger `POST /lockdown` after merge to apply migration
- [ ] Manual: verify entity categories deny @everyone view
- [ ] Manual: verify coworkers with entity role see only their channels
- [ ] Manual: verify bots can still operate in all channels

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)