### PR TITLE
fix(daemon): include infrastructure bots in lockdown role assignment (#302)

### DIFF
--- a/packages/daemon/src/__tests__/discord-roles.test.ts
+++ b/packages/daemon/src/__tests__/discord-roles.test.ts
@@ -110,6 +110,79 @@ describe("is_lf_bot (#295)", () => {
   });
 });
 
+// ── is_lf_bot — infrastructure bot allowlist (#302) ──
+//
+// Pat, daemon, failsafe, and merm do not share a username prefix with pool bots,
+// so the original prefix-match check locked them out during lockdown. Callers pass
+// a config-driven allowlist of exact usernames to include alongside the prefix set.
+
+describe("is_lf_bot infrastructure allowlist (#302)", () => {
+  const INFRA = ["pat", "daemon", "failsafe", "merm"];
+
+  it("matches configured infrastructure bot names (pat)", () => {
+    expect(is_lf_bot("pat", INFRA)).toBe(true);
+  });
+
+  it("matches configured infrastructure bot names (daemon)", () => {
+    expect(is_lf_bot("daemon", INFRA)).toBe(true);
+  });
+
+  it("matches configured infrastructure bot names (failsafe)", () => {
+    expect(is_lf_bot("failsafe", INFRA)).toBe(true);
+  });
+
+  it("matches configured infrastructure bot names (merm)", () => {
+    expect(is_lf_bot("merm", INFRA)).toBe(true);
+  });
+
+  it("still matches pool bots when an allowlist is provided (regression)", () => {
+    expect(is_lf_bot("lf-3", INFRA)).toBe(true);
+  });
+
+  it("rejects random bots when an allowlist is provided (no false positives)", () => {
+    expect(is_lf_bot("random-bot", INFRA)).toBe(false);
+  });
+
+  it("uses exact match for infrastructure names to avoid prefix collisions", () => {
+    // "pat" is short — "patrick" must not match just because it starts with "pat".
+    expect(is_lf_bot("patrick", INFRA)).toBe(false);
+    expect(is_lf_bot("daemonic", INFRA)).toBe(false);
+  });
+
+  it("matches infrastructure names case-insensitively", () => {
+    expect(is_lf_bot("Pat", INFRA)).toBe(true);
+    expect(is_lf_bot("DAEMON", INFRA)).toBe(true);
+  });
+
+  it("omitting the allowlist preserves legacy prefix-only behaviour", () => {
+    expect(is_lf_bot("pat")).toBe(false);
+    expect(is_lf_bot("lf-0")).toBe(true);
+  });
+});
+
+// ── Config schema: discord.infrastructure_bots default (#302) ──
+
+describe("LobsterFarmConfig discord.infrastructure_bots (#302)", () => {
+  it("defaults to the canonical infrastructure bot list", () => {
+    const config = LobsterFarmConfigSchema.parse({
+      user: { name: "Test" },
+      discord: { server_id: "1485323605331017859" },
+    });
+    expect(config.discord?.infrastructure_bots).toEqual(["pat", "daemon", "failsafe", "merm"]);
+  });
+
+  it("accepts a custom infrastructure_bots list", () => {
+    const config = LobsterFarmConfigSchema.parse({
+      user: { name: "Test" },
+      discord: {
+        server_id: "1485323605331017859",
+        infrastructure_bots: ["pat", "daemon", "failsafe", "merm", "bouncer"],
+      },
+    });
+    expect(config.discord?.infrastructure_bots).toContain("bouncer");
+  });
+});
+
 // ── /lockdown route guard tests (#295) ──
 
 describe("/lockdown route guards (#295)", () => {

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -53,11 +53,19 @@ export function is_discord_snowflake(id: string): boolean {
 /**
  * Check whether a Discord bot username belongs to LobsterFarm.
  * Only LF bots should receive the Administrator-privileged "LobsterFarm Bot" role.
+ *
+ * Pool bots match by prefix (`lf-*`, `lobsterfarm*`, `lobster-farm*`). Infrastructure
+ * bots (Pat, daemon, failsafe, merm) don't share a prefix with pool bots, so callers
+ * pass an `infrastructure_bots` allowlist — matched by exact username (case-insensitive)
+ * to avoid collisions with short names like "pat" accidentally matching "patrick" (#302).
  */
 const LF_BOT_USERNAME_PREFIXES = ["lf-", "lobsterfarm", "lobster-farm"];
-export function is_lf_bot(username: string): boolean {
+export function is_lf_bot(username: string, infrastructure_bots: string[] = []): boolean {
   const lower = username.toLowerCase();
-  return LF_BOT_USERNAME_PREFIXES.some((prefix) => lower.startsWith(prefix));
+  if (LF_BOT_USERNAME_PREFIXES.some((prefix) => lower.startsWith(prefix))) {
+    return true;
+  }
+  return infrastructure_bots.some((name) => name.toLowerCase() === lower);
 }
 
 // ── Formatting helpers ──
@@ -1952,12 +1960,15 @@ export class DiscordBot extends EventEmitter {
 
     // 2. Assign bot role to LobsterFarm bot members only (not all bots in the server).
     // The "LobsterFarm Bot" role carries Administrator — only our bots should have it.
+    // Infrastructure bots (Pat, daemon, failsafe, merm) don't share a prefix with pool
+    // bots, so the config-driven allowlist covers them explicitly (#302).
+    const infrastructure_bots = this.config.discord?.infrastructure_bots ?? [];
     const members = await guild.members.fetch();
     let bots_assigned = 0;
     for (const [, member] of members) {
       if (
         member.user.bot &&
-        is_lf_bot(member.user.username) &&
+        is_lf_bot(member.user.username, infrastructure_bots) &&
         !member.roles.cache.has(bot_role.id)
       ) {
         try {

--- a/packages/shared/src/schemas/config.ts
+++ b/packages/shared/src/schemas/config.ts
@@ -54,6 +54,13 @@ export const LobsterFarmConfigSchema = z.object({
       bot_token_ref: z.string().optional(),
       /** The owner's Discord user ID — used for pool bot access control. */
       user_id: z.string().optional(),
+      /**
+       * Usernames of non-pool infrastructure bots (Pat, daemon, failsafe, merm).
+       * During lockdown these are assigned the "LobsterFarm Bot" role alongside
+       * the pool bots (lf-*), which would otherwise lock them out of locked
+       * channels because they don't share the pool prefix (#302).
+       */
+      infrastructure_bots: z.array(z.string()).default(["pat", "daemon", "failsafe", "merm"]),
     })
     .optional(),
 


### PR DESCRIPTION
## Summary

Lockdown's `is_lf_bot()` matched only pool-bot prefixes (`lf-*`, `lobsterfarm*`, `lobster-farm*`), so Pat, daemon, failsafe, and merm never received the "LobsterFarm Bot" (Administrator) role during lockdown and got locked out of locked-down channels. This was patched manually in prod by adding the role directly via the Discord API; this PR is the durable fix.

## Changes

- **Config schema** — add `discord.infrastructure_bots: string[]` with default `["pat", "daemon", "failsafe", "merm"]` (`packages/shared/src/schemas/config.ts`).
- **`is_lf_bot`** — accepts an optional `infrastructure_bots` allowlist matched by case-insensitive **exact username** to avoid short-name prefix collisions (e.g. `pat` vs `patrick`). Pool-bot prefix matching is unchanged, so existing callers are unaffected.
- **Lockdown** — reads `config.discord?.infrastructure_bots` and passes it to `is_lf_bot` when scanning guild members. Infrastructure bots are now assigned the "LobsterFarm Bot" role alongside pool bots.

## Tests

New regression tests in `packages/daemon/src/__tests__/discord-roles.test.ts`:

- `is_lf_bot("pat" | "daemon" | "failsafe" | "merm", INFRA)` → `true`
- `is_lf_bot("lf-3", INFRA)` → `true` (pool-bot regression)
- `is_lf_bot("random-bot", INFRA)` → `false` (no false positives)
- `is_lf_bot("patrick", INFRA)` → `false` (exact match, not prefix)
- Case-insensitive matching for infra names
- Legacy behavior preserved when allowlist is omitted
- Schema default equals `["pat", "daemon", "failsafe", "merm"]`

Full daemon suite: **1059 passed**. Typecheck clean. Biome clean.

## Deployment note

Per the issue, the manual workaround (Pat already has the role in prod) stays in place — this fix takes effect on the **next** lockdown run, which is not being triggered now.

## Test plan

- [x] `pnpm test src/__tests__/discord-roles.test.ts` — 23 passed
- [x] `pnpm -r test` — 1059 passed
- [x] `pnpm -r typecheck` — clean
- [x] `pnpm biome check` — clean

Closes #302