### PR TITLE
feat(hooks): ship entity isolation hook for bot filesystem scoping (#304)

### DIFF
--- a/config/hooks/README.md
+++ b/config/hooks/README.md
@@ -10,6 +10,8 @@ Claude Code hook scripts that run before tool invocations. Registered in `~/.cla
 
 - `protect-branch.sh` -- Prevents Edit/Write operations on main/master branches. Extracts `tool_input.file_path` from stdin JSON, checks if the file is inside the current git repo, and blocks if the current branch is main or master. Fails open if not in a git repo, jq is missing, or input is malformed.
 
+- `entity-isolation.sh` -- Prevents cross-entity filesystem access for pool bot sessions. Identifies the session's self-entity from `CLAUDE_PROJECT_DIR` (or the hook input `cwd` as a fallback), enumerates sibling entities under `~/.lobsterfarm/entities/`, and blocks Bash commands or Read/Edit/Write/NotebookEdit file paths that reference another entity. Fails open for platform-level sessions (e.g., Pat) that aren't scoped to an entity, when no sibling entities exist, and when jq is missing or input is malformed. Deployed to `~/.claude/hooks/` by `lf init` and registered in `~/.claude/settings.json` with matcher `Bash|Read|Edit|Write|NotebookEdit`.
+
 ### tests/
 
 - `test-scan-bash-secrets.sh` -- Test suite for the Bash secret scanner. Exercises each pattern category with both positive (should block) and negative (should allow) cases.
@@ -17,3 +19,5 @@ Claude Code hook scripts that run before tool invocations. Registered in `~/.cla
 - `test-scan-edit-write-secrets.sh` -- Test suite for the Edit/Write secret scanner. Tests all 3 pattern categories for both Edit and Write tools, plus edge cases (empty stdin, malformed JSON, missing jq, secret in old_string only).
 
 - `test-protect-branch.sh` -- Test suite for the branch protector. Tests blocking on main/master, allowing on feature branches, files outside repo, and fail-open edge cases.
+
+- `test-entity-isolation.sh` -- Test suite for the entity isolation hook. Uses a fake `HOME` with multiple entity directories to cover same-entity allowed, cross-entity blocked (Bash + Read/Edit/Write/NotebookEdit), platform-level sessions allowed, `CLAUDE_PROJECT_DIR` vs `cwd` fallback, and fail-open edge cases (empty/malformed stdin, missing fields, missing jq).

--- a/config/hooks/entity-isolation.sh
+++ b/config/hooks/entity-isolation.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# entity-isolation.sh — PreToolUse hook to prevent cross-entity filesystem access.
+#
+# When a pool bot session is running for entity X, this hook blocks attempts to
+# read/write/exec paths under ~/.lobsterfarm/entities/<other>/. Fails open if
+# the session is not in an entity directory (e.g., Pat at the platform level).
+#
+# Install: register in ~/.claude/settings.json under hooks.PreToolUse
+#   matchers: "Bash", "Read|Edit|Write"
+#
+# Hook input: JSON on stdin with {tool_name, tool_input, cwd, ...}
+
+set -euo pipefail
+
+# --- Dependency check ---
+if ! command -v jq &>/dev/null; then
+  # Fail open — a broken hook must never block all tool calls
+  exit 0
+fi
+
+# --- Read input ---
+INPUT="$(cat)" || exit 0
+[ -z "$INPUT" ] && exit 0
+
+# --- Identify self-entity ---
+# Prefer CLAUDE_PROJECT_DIR (set by Claude Code to the session's initial cwd,
+# unchanged by internal cd). Fall back to the cwd field in the hook input.
+ENTITIES_DIR="$HOME/.lobsterfarm/entities"
+SELF_DIR="${CLAUDE_PROJECT_DIR:-}"
+if [ -z "$SELF_DIR" ]; then
+  SELF_DIR="$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)" || exit 0
+fi
+
+# Not a pool bot session if not under entities/ — skip check
+case "$SELF_DIR" in
+  "$ENTITIES_DIR"/*) ;;
+  *) exit 0 ;;
+esac
+
+# Extract entity id: first path component after entities/
+SELF_ENTITY="${SELF_DIR#"$ENTITIES_DIR"/}"
+SELF_ENTITY="${SELF_ENTITY%%/*}"
+[ -z "$SELF_ENTITY" ] && exit 0
+
+# --- Collect other entity ids ---
+# Build a pipe-separated regex alternation of sibling entity ids.
+OTHER_ENTITIES=""
+for dir in "$ENTITIES_DIR"/*/; do
+  [ -d "$dir" ] || continue
+  name="$(basename "$dir")"
+  [ "$name" = "$SELF_ENTITY" ] && continue
+  if [ -z "$OTHER_ENTITIES" ]; then
+    OTHER_ENTITIES="$name"
+  else
+    OTHER_ENTITIES="$OTHER_ENTITIES|$name"
+  fi
+done
+[ -z "$OTHER_ENTITIES" ] && exit 0
+
+# --- Extract tool input ---
+TOOL="$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)" || exit 0
+
+block() {
+  local other="$1"
+  local hint="$2"
+  cat >&2 <<MSG
+BLOCK: Cross-entity access — "$SELF_ENTITY" session attempted to access "$other" entity.
+→ Pool bots are scoped to a single entity. Reading another entity's files leaks context and breaks isolation.
+→ $hint
+MSG
+  exit 2
+}
+
+case "$TOOL" in
+  Bash)
+    CMD="$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)" || exit 0
+    [ -z "$CMD" ] && exit 0
+    # Match references to other entity directories. Patterns:
+    #   /.lobsterfarm/entities/<other>/
+    #   entities/<other>/
+    #   entities/<other>$
+    #   entities/<other> (end of word)
+    # Using extended regex with the alternation of other entity names.
+    if echo "$CMD" | grep -qE "(\\.lobsterfarm/entities|entities)/($OTHER_ENTITIES)(/|\$|[[:space:]]|\"|'|\\))"; then
+      matched="$(echo "$CMD" | grep -oE "entities/($OTHER_ENTITIES)" | head -1 | sed -E "s|entities/||")"
+      block "$matched" "If you need cross-entity data, request it through the daemon API or escalate to Pat."
+    fi
+    ;;
+  Read|Edit|Write|NotebookEdit)
+    FILE="$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)" || exit 0
+    [ -z "$FILE" ] && exit 0
+    # Normalize: expand ~ to $HOME if present
+    case "$FILE" in
+      "~/"*) FILE="$HOME/${FILE#~/}" ;;
+    esac
+    # Check if path is under another entity's directory
+    if [[ "$FILE" == "$ENTITIES_DIR"/* ]]; then
+      target_entity="${FILE#"$ENTITIES_DIR"/}"
+      target_entity="${target_entity%%/*}"
+      if [ "$target_entity" != "$SELF_ENTITY" ] && [ -n "$target_entity" ]; then
+        block "$target_entity" "Edit your own entity's files only."
+      fi
+    fi
+    ;;
+esac
+
+exit 0

--- a/config/hooks/tests/test-entity-isolation.sh
+++ b/config/hooks/tests/test-entity-isolation.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# test-entity-isolation.sh — Tests for the entity isolation PreToolUse hook.
+#
+# Usage: bash config/hooks/tests/test-entity-isolation.sh
+#
+# Creates a fake ~/.lobsterfarm/entities/ layout under a tmpdir and points
+# HOME at it, then feeds JSON hook events to the hook via stdin.
+# Exit 0 = allowed, exit 2 = blocked.
+
+set -uo pipefail
+
+# Resolve script location so tests work from any cwd
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/../entity-isolation.sh"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+# --- Fake HOME setup ---
+# Use pwd -P to resolve symlinks (macOS /var -> /private/var) so path
+# comparisons inside the hook agree with the paths we pass in.
+FAKE_HOME="$(cd "$(mktemp -d)" && pwd -P)"
+FAKE_ENTITIES="$FAKE_HOME/.lobsterfarm/entities"
+mkdir -p "$FAKE_ENTITIES/alpha/repos/app"
+mkdir -p "$FAKE_ENTITIES/beta/repos/app"
+mkdir -p "$FAKE_ENTITIES/gamma/repos/app"
+
+cleanup() { rm -rf "$FAKE_HOME"; }
+trap cleanup EXIT
+
+# --- Helpers ---
+
+# Build a JSON Bash hook event.
+make_bash_event() {
+  local cmd="$1"
+  local cwd="$2"
+  jq -n --arg cmd "$cmd" --arg cwd "$cwd" '{
+    tool_name: "Bash",
+    tool_input: { command: $cmd, description: "test", timeout: 120000 },
+    session_id: "test-session",
+    cwd: $cwd,
+    hook_event_name: "PreToolUse"
+  }'
+}
+
+# Build a JSON file-tool hook event (Read/Edit/Write/NotebookEdit).
+# $1 = tool name, $2 = file path, $3 = cwd
+make_file_event() {
+  local tool="$1"
+  local file_path="$2"
+  local cwd="$3"
+  jq -n --arg tool "$tool" --arg path "$file_path" --arg cwd "$cwd" '{
+    tool_name: $tool,
+    tool_input: { file_path: $path },
+    session_id: "test-session",
+    cwd: $cwd,
+    hook_event_name: "PreToolUse"
+  }'
+}
+
+# Run the hook with a fake HOME + CLAUDE_PROJECT_DIR.
+# $1 = test name
+# $2 = event JSON (on stdin)
+# $3 = CLAUDE_PROJECT_DIR value (self-entity cwd)
+# $4 = expected exit code
+# $5 = optional stderr substring that must be present
+run_test() {
+  local name="$1"
+  local event="$2"
+  local self_dir="$3"
+  local expected="$4"
+  local expected_stderr="${5:-}"
+  TOTAL=$((TOTAL + 1))
+
+  local stderr_output actual
+  stderr_output="$(
+    HOME="$FAKE_HOME" CLAUDE_PROJECT_DIR="$self_dir" \
+      bash "$HOOK" <<<"$event" 2>&1 >/dev/null
+  )"
+  actual=$?
+
+  if [ "$actual" -ne "$expected" ]; then
+    echo "  FAIL: $name (expected exit $expected, got exit $actual)"
+    [ -n "$stderr_output" ] && echo "        stderr: $(echo "$stderr_output" | head -1)"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  if [ -n "$expected_stderr" ] && ! echo "$stderr_output" | grep -qF "$expected_stderr"; then
+    echo "  FAIL: $name (stderr missing expected substring: '$expected_stderr')"
+    echo "        stderr: $stderr_output"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  echo "  PASS: $name"
+  PASS=$((PASS + 1))
+}
+
+ALPHA_CWD="$FAKE_ENTITIES/alpha/repos/app"
+BETA_CWD="$FAKE_ENTITIES/beta/repos/app"
+
+# --- MUST ALLOW (exit 0) — self-entity access ---
+
+echo ""
+echo "=== MUST ALLOW — same-entity (exit 0) ==="
+echo ""
+
+run_test "Bash: same-entity path reference" \
+  "$(make_bash_event "ls $FAKE_ENTITIES/alpha/repos/app" "$ALPHA_CWD")" \
+  "$ALPHA_CWD" 0
+
+run_test "Bash: unrelated command (no entity reference)" \
+  "$(make_bash_event "git status" "$ALPHA_CWD")" \
+  "$ALPHA_CWD" 0
+
+run_test "Read: same-entity file_path" \
+  "$(make_file_event "Read" "$FAKE_ENTITIES/alpha/repos/app/README.md" "$ALPHA_CWD")" \
+  "$ALPHA_CWD" 0
+
+run_test "Edit: same-entity file_path" \
+  "$(make_file_event "Edit" "$FAKE_ENTITIES/alpha/repos/app/src/index.ts" "$ALPHA_CWD")" \
+  "$ALPHA_CWD" 0
+
+run_test "Write: same-entity file_path" \
+  "$(make_file_event "Write" "$FAKE_ENTITIES/alpha/repos/app/new.ts" "$ALPHA_CWD")" \
+  "$ALPHA_CWD" 0
+
+run_test "NotebookEdit: same-entity file_path" \
+  "$(make_file_event "NotebookEdit" "$FAKE_ENTITIES/alpha/repos/app/nb.ipynb" "$ALPHA_CWD")" \
+  "$ALPHA_CWD" 0
+
+run_test "Read: file outside entities/ tree" \
+  "$(make_file_event "Read" "/tmp/not-an-entity.txt" "$ALPHA_CWD")" \
+  "$ALPHA_CWD" 0
+
+# --- MUST BLOCK (exit 2) — cross-entity access ---
+
+echo ""
+echo "=== MUST BLOCK — cross-entity (exit 2) ==="
+echo ""
+
+run_test "Bash: ls sibling entity dir (absolute)" \
+  "$(make_bash_event "ls $FAKE_ENTITIES/beta/" "$ALPHA_CWD")" \
+  "$ALPHA_CWD" 2 "BLOCK: Cross-entity access"
+
+run_test "Bash: cat file in sibling entity" \
+  "$(make_bash_event "cat $FAKE_ENTITIES/beta/repos/app/secret.txt" "$ALPHA_CWD")" \
+  "$ALPHA_CWD" 2 "BLOCK: Cross-entity access"
+
+run_test "Bash: grep across sibling entity (ends at space)" \
+  "$(make_bash_event "grep -r foo $FAKE_ENTITIES/gamma" "$ALPHA_CWD")" \
+  "$ALPHA_CWD" 2 "BLOCK: Cross-entity access"
+
+run_test "Read: sibling entity file_path" \
+  "$(make_file_event "Read" "$FAKE_ENTITIES/beta/repos/app/README.md" "$ALPHA_CWD")" \
+  "$ALPHA_CWD" 2 "BLOCK: Cross-entity access"
+
+run_test "Edit: sibling entity file_path" \
+  "$(make_file_event "Edit" "$FAKE_ENTITIES/beta/repos/app/src/index.ts" "$ALPHA_CWD")" \
+  "$ALPHA_CWD" 2 "BLOCK: Cross-entity access"
+
+run_test "Write: sibling entity file_path" \
+  "$(make_file_event "Write" "$FAKE_ENTITIES/gamma/repos/app/new.ts" "$ALPHA_CWD")" \
+  "$ALPHA_CWD" 2 "BLOCK: Cross-entity access"
+
+# --- MUST ALLOW (exit 0) — platform-level sessions ---
+
+echo ""
+echo "=== MUST ALLOW — platform-level (exit 0) ==="
+echo ""
+
+# Pat at ~/.lobsterfarm/ (no entity) — should skip and allow everything
+run_test "Platform cwd: touching entity dir is allowed (no self-entity)" \
+  "$(make_bash_event "ls $FAKE_ENTITIES/beta/" "$FAKE_HOME/.lobsterfarm")" \
+  "$FAKE_HOME/.lobsterfarm" 0
+
+run_test "Platform cwd: Read on entity file is allowed" \
+  "$(make_file_event "Read" "$FAKE_ENTITIES/beta/repos/app/README.md" "$FAKE_HOME/.lobsterfarm")" \
+  "$FAKE_HOME/.lobsterfarm" 0
+
+run_test "Platform cwd: unrelated bash command" \
+  "$(make_bash_event "echo hi" "$FAKE_HOME/.lobsterfarm")" \
+  "$FAKE_HOME/.lobsterfarm" 0
+
+# Completely unrelated cwd (e.g., user shell outside lobsterfarm)
+run_test "Non-lobsterfarm cwd: allowed" \
+  "$(make_bash_event "ls $FAKE_ENTITIES/beta/" "/tmp")" \
+  "/tmp" 0
+
+# --- EDGE CASES ---
+
+echo ""
+echo "=== EDGE CASES ==="
+echo ""
+
+# Empty stdin — fail open
+TOTAL=$((TOTAL + 1))
+HOME="$FAKE_HOME" CLAUDE_PROJECT_DIR="$ALPHA_CWD" \
+  bash "$HOOK" </dev/null 2>/dev/null
+if [ $? -eq 0 ]; then
+  echo "  PASS: Empty stdin (fail open)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: Empty stdin (expected exit 0, should fail open)"
+  FAIL=$((FAIL + 1))
+fi
+
+# Malformed JSON — fail open
+TOTAL=$((TOTAL + 1))
+HOME="$FAKE_HOME" CLAUDE_PROJECT_DIR="$ALPHA_CWD" \
+  bash "$HOOK" <<<"not json at all" 2>/dev/null
+if [ $? -eq 0 ]; then
+  echo "  PASS: Malformed JSON (fail open)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: Malformed JSON (expected exit 0, should fail open)"
+  FAIL=$((FAIL + 1))
+fi
+
+# Missing command in Bash event
+run_test "Bash: missing command field (fail open)" \
+  '{"tool_name":"Bash","tool_input":{}}' \
+  "$ALPHA_CWD" 0
+
+# Missing file_path in Read event
+run_test "Read: missing file_path field (fail open)" \
+  '{"tool_name":"Read","tool_input":{}}' \
+  "$ALPHA_CWD" 0
+
+# Only one entity exists — no others to block against
+TOTAL=$((TOTAL + 1))
+SOLO_HOME="$(cd "$(mktemp -d)" && pwd -P)"
+mkdir -p "$SOLO_HOME/.lobsterfarm/entities/alpha/repos/app"
+SOLO_EVENT="$(jq -n --arg cmd "ls /anywhere" --arg cwd "$SOLO_HOME/.lobsterfarm/entities/alpha/repos/app" '{
+  tool_name: "Bash",
+  tool_input: { command: $cmd },
+  cwd: $cwd,
+  hook_event_name: "PreToolUse"
+}')"
+HOME="$SOLO_HOME" CLAUDE_PROJECT_DIR="$SOLO_HOME/.lobsterfarm/entities/alpha/repos/app" \
+  bash "$HOOK" <<<"$SOLO_EVENT" >/dev/null 2>&1
+if [ $? -eq 0 ]; then
+  echo "  PASS: Only self-entity exists (nothing to block)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: Only self-entity exists (expected exit 0)"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$SOLO_HOME"
+
+# Fall back to input.cwd when CLAUDE_PROJECT_DIR is unset
+TOTAL=$((TOTAL + 1))
+EVENT="$(make_bash_event "ls $FAKE_ENTITIES/beta/" "$ALPHA_CWD")"
+HOME="$FAKE_HOME" bash "$HOOK" <<<"$EVENT" >/dev/null 2>&1
+actual=$?
+if [ "$actual" -eq 2 ]; then
+  echo "  PASS: Falls back to input.cwd when CLAUDE_PROJECT_DIR unset"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: CLAUDE_PROJECT_DIR fallback (expected exit 2, got $actual)"
+  FAIL=$((FAIL + 1))
+fi
+
+# Missing jq — fail open
+# Write event to file to avoid SIGPIPE: the hook exits before reading stdin
+# when jq is absent, which kills the pipe writer under pipefail.
+TOTAL=$((TOTAL + 1))
+FAKE_PATH="$(mktemp -d)"
+JQ_TEST_EVENT="$(mktemp)"
+for cmd in bash cat grep echo head sed basename; do
+  real="$(command -v "$cmd" 2>/dev/null)" && [ -n "$real" ] && ln -sf "$real" "$FAKE_PATH/$cmd"
+done
+make_bash_event "ls $FAKE_ENTITIES/beta/" "$ALPHA_CWD" > "$JQ_TEST_EVENT"
+HOME="$FAKE_HOME" CLAUDE_PROJECT_DIR="$ALPHA_CWD" PATH="$FAKE_PATH" \
+  bash "$HOOK" < "$JQ_TEST_EVENT" >/dev/null 2>&1
+if [ $? -eq 0 ]; then
+  echo "  PASS: Missing jq (fail open)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: Missing jq (expected exit 0, should fail open)"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$FAKE_PATH" "$JQ_TEST_EVENT"
+
+# --- Summary ---
+
+echo ""
+echo "=============================="
+echo "Results: $PASS passed, $FAIL failed, $TOTAL total"
+echo "=============================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/packages/cli/src/commands/init/generate.ts
+++ b/packages/cli/src/commands/init/generate.ts
@@ -126,14 +126,16 @@ export async function generate_config_files(
   // Hooks are tiny shell scripts invoked by Claude Code during lifecycle
   // events (SessionStart, PreToolUse, Stop, etc.). See generate_settings()
   // for the settings.json registration that wires them up.
-  const hooks_src = join(config_dir, "claude", "hooks");
+  const dest_hooks_dir = claude_hooks_dir(path_overrides);
+  await mkdir(dest_hooks_dir, { recursive: true });
+
+  // Lifecycle hooks (SessionStart etc.) live in config/claude/hooks/.
+  const lifecycle_hooks_src = join(config_dir, "claude", "hooks");
   try {
-    const hook_entries = await readdir(hooks_src, { withFileTypes: true });
-    const dest_hooks_dir = claude_hooks_dir(path_overrides);
-    await mkdir(dest_hooks_dir, { recursive: true });
+    const hook_entries = await readdir(lifecycle_hooks_src, { withFileTypes: true });
     for (const entry of hook_entries) {
       if (!entry.isFile()) continue;
-      const src_file = join(hooks_src, entry.name);
+      const src_file = join(lifecycle_hooks_src, entry.name);
       const dest_file = join(dest_hooks_dir, entry.name);
       await copyFile(src_file, dest_file);
       // Preserve executability — copyFile doesn't always carry perms across
@@ -147,15 +149,38 @@ export async function generate_config_files(
     // hooks directory might not exist — not fatal
   }
 
+  // PreToolUse guard hooks live in config/hooks/ (alongside their tests).
+  // We deploy entity-isolation.sh here because generate_settings() references
+  // it by absolute path in ~/.claude/settings.json — without the file, the
+  // hook call errors out on every tool invocation. Other scripts in
+  // config/hooks/ are currently wired inline in generate_settings() and don't
+  // need deployment yet; add them to this list as they're migrated to
+  // file-based registration.
+  const guard_hooks_src = join(config_dir, "hooks");
+  const guard_hook_files = ["entity-isolation.sh"];
+  for (const name of guard_hook_files) {
+    try {
+      const src_file = join(guard_hooks_src, name);
+      const dest_file = join(dest_hooks_dir, name);
+      await copyFile(src_file, dest_file);
+      await chmod(dest_file, 0o755);
+      created.push(dest_file);
+    } catch {
+      // Missing guard hook script — not fatal. The inline fallback (if any)
+      // in generate_settings() will still protect the session.
+    }
+  }
+
   return created;
 }
 
 /** Generate the ~/.claude/settings.json with bypass permissions and hooks. */
 export async function generate_settings(path_overrides?: Partial<PathConfig>): Promise<string> {
-  // Absolute path to the deployed SessionStart hook. We use an absolute path
-  // rather than relying on $HOME expansion because Claude Code's hook runner
-  // doesn't guarantee a shell wrapper.
+  // Absolute paths to deployed hook scripts. We use absolute paths rather than
+  // relying on $HOME expansion because Claude Code's hook runner doesn't
+  // guarantee a shell wrapper.
   const session_start_hook = join(claude_hooks_dir(path_overrides), "session-start-inject.sh");
+  const entity_isolation_hook = join(claude_hooks_dir(path_overrides), "entity-isolation.sh");
 
   const settings = {
     permissions: {
@@ -198,6 +223,22 @@ export async function generate_settings(path_overrides?: Partial<PathConfig>): P
               type: "command",
               command:
                 'bash -c \'if echo "$TOOL_INPUT" | grep -qiE "(sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36,}|AKIA[A-Z0-9]{16}|xox[bpras]-[a-zA-Z0-9-]+|-----BEGIN (RSA |EC |DSA )?PRIVATE KEY-----)"; then echo "BLOCK: Detected potential hardcoded secret in tool input." >&2; exit 2; fi\'',
+            },
+          ],
+        },
+        {
+          // Entity isolation — pool bots run with bypassPermissions and would
+          // otherwise be able to read any entity's files on disk. This hook
+          // blocks reads/writes/bash against sibling entities under
+          // ~/.lobsterfarm/entities/<other>/ when a session is scoped to a
+          // specific entity. Deployed by generate_config_files() from
+          // config/hooks/entity-isolation.sh.
+          matcher: "Bash|Read|Edit|Write|NotebookEdit",
+          hooks: [
+            {
+              type: "command",
+              command: `bash ${entity_isolation_hook}`,
+              timeout: 5,
             },
           ],
         },


### PR DESCRIPTION
## Summary

Pool bots run with `bypassPermissions`, which grants blanket filesystem access even when `--add-dir` is scoped to the session's entity. Without a guard, a pool bot scoped to entity X can still `ls ~/.lobsterfarm/entities/Y/` and start impersonating Y (observed in #301).

This PR ships the already-validated `entity-isolation.sh` PreToolUse hook so new installs pick it up automatically.

- **Hook script** — `config/hooks/entity-isolation.sh`. Identifies the session's self-entity from `CLAUDE_PROJECT_DIR` (fallback: hook input `cwd`), enumerates sibling entities, and blocks `Bash`/`Read`/`Edit`/`Write`/`NotebookEdit` calls that reference another entity's directory. Fails open for platform-level sessions (Pat), sessions with no sibling entities, and when `jq` is missing or input is malformed. Content is identical to the validated version currently live at `~/.claude/hooks/entity-isolation.sh`.
- **Install wiring** — `generate_config_files()` now also copies `config/hooks/entity-isolation.sh` into `~/.claude/hooks/` (with `+x`), and `generate_settings()` adds a `PreToolUse` entry with matcher `Bash|Read|Edit|Write|NotebookEdit` pointing at the deployed absolute path, timeout 5.
- **Tests** — `config/hooks/tests/test-entity-isolation.sh` (24 cases) using a fake `HOME` with multiple entity dirs: same-entity allowed, cross-entity blocked (Bash + each file tool) with stderr assertions, platform-level allowed, `CLAUDE_PROJECT_DIR` vs `cwd` fallback, and fail-open edge cases (empty/malformed stdin, missing fields, missing `jq`).

The already-deployed hook at `~/.claude/hooks/entity-isolation.sh` is untouched.

## Test plan

- [x] `bash config/hooks/tests/test-entity-isolation.sh` — 24/24 pass
- [x] Existing bash hook tests still pass (`test-scan-bash-secrets.sh` 35/35, `test-scan-edit-write-secrets.sh` 39/39). `test-protect-branch.sh` has a pre-existing failure on `origin/main` unrelated to this PR.
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 1048/1048 pass
- [x] `pnpm build` succeeds
- [x] E2E simulation of `lf init` against a fake `HOME`: hook file deployed (+x), settings.json registers matcher `Bash|Read|Edit|Write|NotebookEdit` pointing at the deployed absolute path

Closes #304
Closes #301