### PR TITLE
feat(sentry): thread-based incident alerts + user tagging (#310)

### DIFF
--- a/packages/daemon/src/__tests__/sentry-triage.test.ts
+++ b/packages/daemon/src/__tests__/sentry-triage.test.ts
@@ -51,6 +51,7 @@ import {
   type SentryTriageContext,
   type SentryTriageState,
   _reset_for_test,
+  handle_sentry_fix_pr_merged,
   handle_sentry_resolved,
   handle_sentry_triage_event,
   load_triage_state,
@@ -148,7 +149,13 @@ function make_discord(): DiscordBot {
 
 function make_alert_router() {
   return {
-    post_alert: vi.fn().mockResolvedValue({ message_id: null }),
+    // Default: simulate incident_open returning a thread_id; other tiers return null.
+    post_alert: vi.fn().mockImplementation(async (payload: { tier: string }) => {
+      if (payload.tier === "incident_open") {
+        return { message_id: "msg-100", thread_id: "thread-200" };
+      }
+      return { message_id: null };
+    }),
     resolve_incident: vi.fn().mockResolvedValue(undefined),
   };
 }
@@ -1213,5 +1220,496 @@ describe("build_sentry_fix_prompt", () => {
     expect(prompt).toContain("**Culprit:** src/handler.ts in process");
     expect(prompt).toContain("at handler.ts:99");
     expect(prompt).toContain("Do NOT merge the PR");
+  });
+});
+
+// ── Thread-based alert lifecycle tests (#310) ──
+
+const USER_TAG = "<@732686813856006245>";
+
+describe("thread-based alerts — ingress", () => {
+  it("opens incident thread with correct title and body on ingress", async () => {
+    const ctx = make_context();
+    const alert_router = ctx.alert_router as unknown as {
+      post_alert: ReturnType<typeof vi.fn>;
+    };
+
+    await handle_sentry_triage_event("ISSUE-INGRESS-1", "test-backend", "created", ctx);
+
+    // Incident_open should have been posted first, with the Sentry issue title + URL
+    const incident_open_call = alert_router.post_alert.mock.calls.find(
+      (c) => (c[0] as { tier: string }).tier === "incident_open",
+    );
+    expect(incident_open_call).toBeDefined();
+    const payload = incident_open_call![0] as {
+      title: string;
+      body: string;
+      entity_id: string;
+    };
+    expect(payload.entity_id).toBe("test-entity");
+    expect(payload.title).toContain("Sentry");
+    expect(payload.title).toContain("TypeError");
+    expect(payload.body).toContain("https://sentry.io/issues/12345/");
+    expect(payload.body).toContain("received");
+  });
+
+  it("persists thread_id on triage state after ingress", async () => {
+    const config = make_config();
+    const ctx = make_context({ config });
+
+    await handle_sentry_triage_event("ISSUE-PERSIST", "test-backend", "created", ctx);
+
+    const state = await load_triage_state(config);
+    expect(state.triages["ISSUE-PERSIST"]).toBeDefined();
+    expect(state.triages["ISSUE-PERSIST"]!.thread_id).toBe("thread-200");
+    expect(state.triages["ISSUE-PERSIST"]!.alert_message_id).toBe("msg-100");
+  });
+
+  it("does NOT open incident when dedup gate fires", async () => {
+    const ctx = make_context();
+    const alert_router = ctx.alert_router as unknown as {
+      post_alert: ReturnType<typeof vi.fn>;
+    };
+
+    // First call opens incident
+    await handle_sentry_triage_event("ISSUE-DEDUP", "test-backend", "created", ctx);
+    const opens_first = alert_router.post_alert.mock.calls.filter(
+      (c) => (c[0] as { tier: string }).tier === "incident_open",
+    );
+    expect(opens_first.length).toBe(1);
+
+    // Second call should be deduped — no new incident_open
+    await handle_sentry_triage_event("ISSUE-DEDUP", "test-backend", "created", ctx);
+    const opens_second = alert_router.post_alert.mock.calls.filter(
+      (c) => (c[0] as { tier: string }).tier === "incident_open",
+    );
+    expect(opens_second.length).toBe(1);
+  });
+
+  it("does NOT open incident when cooldown gate fires (non-regression)", async () => {
+    const config = make_config();
+    const ctx = make_context({ config });
+    const alert_router = ctx.alert_router as unknown as {
+      post_alert: ReturnType<typeof vi.fn>;
+    };
+
+    // Pre-seed a recent triage
+    const state_dir = join(temp_dir, "state");
+    await mkdir(state_dir, { recursive: true });
+    await save_triage_state(
+      {
+        triages: {
+          "ISSUE-COOL-310": {
+            entity_id: "test-entity",
+            project_slug: "test-backend",
+            error_title: "Old error",
+            triaged_at: new Date().toISOString(),
+            status: "tracked",
+            sentry_url: "https://sentry.io/issues/ISSUE-COOL-310/",
+          },
+        },
+        stats: {
+          total_triaged: 1,
+          issues_created: 0,
+          dismissed: 0,
+          last_triage_at: new Date().toISOString(),
+        },
+      },
+      config,
+    );
+
+    await handle_sentry_triage_event("ISSUE-COOL-310", "test-backend", "created", ctx);
+
+    const opens = alert_router.post_alert.mock.calls.filter(
+      (c) => (c[0] as { tier: string }).tier === "incident_open",
+    );
+    expect(opens.length).toBe(0);
+  });
+});
+
+describe("thread-based alerts — state transitions", () => {
+  /**
+   * Helper: trigger ingress + complete the triage session with a given verdict.
+   * Returns the spy so the caller can assert on thread messages.
+   */
+  async function triage_and_complete(
+    sentry_issue_id: string,
+    verdict_json: string | null,
+    overrides: Partial<SentryTriageContext> = {},
+  ) {
+    const session_manager = make_session_manager();
+    const ctx = make_context({ session_manager, ...overrides });
+    const sm = session_manager as unknown as { spawn: ReturnType<typeof vi.fn> };
+
+    let spawn_count = 0;
+    sm.spawn.mockImplementation(async () => {
+      spawn_count++;
+      return {
+        session_id: `session-${String(spawn_count)}`,
+        entity_id: "test-entity",
+        feature_id: `sentry-triage-${sentry_issue_id}`,
+        archetype: spawn_count === 1 ? "operator" : "builder",
+        started_at: new Date(),
+        pid: 10000 + spawn_count,
+      };
+    });
+
+    await handle_sentry_triage_event(sentry_issue_id, "test-backend", "created", ctx);
+
+    const output_lines = verdict_json
+      ? ["Diagnostic output...", `SENTRY_TRIAGE_VERDICT:${verdict_json}`]
+      : ["Diagnostic prose line 1", "Diagnostic prose line 2", "ran out of tokens, no verdict"];
+
+    (session_manager as unknown as EventEmitter).emit("session:completed", {
+      session_id: "session-1",
+      exit_code: 0,
+      output_lines,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    return { ctx, sm, session_manager };
+  }
+
+  it("verdict (P1 auto-fixable) posts thread update, no user tag", async () => {
+    const { ctx } = await triage_and_complete(
+      "ISSUE-P1",
+      '{"severity":"P1","auto_fixable":true,"github_issue":42,"fix_approach":"Fix null check"}',
+    );
+    const alert_router = ctx.alert_router as unknown as {
+      post_alert: ReturnType<typeof vi.fn>;
+    };
+
+    // Find the incident_update call for the verdict
+    const updates = alert_router.post_alert.mock.calls.filter(
+      (c) => (c[0] as { tier: string }).tier === "incident_update",
+    );
+    expect(updates.length).toBeGreaterThanOrEqual(1);
+
+    const verdict_update = updates.find((c) => {
+      const body = (c[0] as { body: string }).body;
+      return body.includes("P1") && body.includes("Fix null check");
+    });
+    expect(verdict_update).toBeDefined();
+    const payload = verdict_update![0] as {
+      tier: string;
+      incident_id: string;
+      body: string;
+    };
+    expect(payload.incident_id).toBe("thread-200");
+    expect(payload.body).not.toContain(USER_TAG);
+    expect(payload.body).toContain("#42");
+
+    // No action_required top-level alert for the verdict anymore
+    const action_required_verdict = alert_router.post_alert.mock.calls.find((c) => {
+      const p = c[0] as { tier: string; title: string };
+      return p.tier === "action_required" && p.title.includes("triage");
+    });
+    expect(action_required_verdict).toBeUndefined();
+  });
+
+  it("verdict (P0) posts thread update WITH user tag", async () => {
+    const { ctx } = await triage_and_complete(
+      "ISSUE-P0",
+      '{"severity":"P0","auto_fixable":false,"github_issue":5,"fix_approach":null}',
+    );
+    const alert_router = ctx.alert_router as unknown as {
+      post_alert: ReturnType<typeof vi.fn>;
+    };
+
+    const updates = alert_router.post_alert.mock.calls.filter(
+      (c) => (c[0] as { tier: string }).tier === "incident_update",
+    );
+    const verdict_update = updates.find((c) => {
+      const body = (c[0] as { body: string }).body;
+      return body.includes("P0");
+    });
+    expect(verdict_update).toBeDefined();
+    expect((verdict_update![0] as { body: string }).body).toContain(USER_TAG);
+  });
+
+  it("no-verdict posts thread update WITH user tag AND Ray's last 20 output lines", async () => {
+    // Build a session output with >20 lines to verify tail truncation
+    const long_output = Array.from({ length: 30 }, (_, i) => `line ${String(i + 1)}`);
+
+    const session_manager = make_session_manager();
+    const ctx = make_context({ session_manager });
+    const sm = session_manager as unknown as { spawn: ReturnType<typeof vi.fn> };
+
+    sm.spawn.mockResolvedValue({
+      session_id: "session-1",
+      entity_id: "test-entity",
+      feature_id: "sentry-triage-ISSUE-NOVERDICT",
+      archetype: "operator",
+      started_at: new Date(),
+      pid: 12345,
+    });
+
+    await handle_sentry_triage_event("ISSUE-NOVERDICT", "test-backend", "created", ctx);
+
+    (session_manager as unknown as EventEmitter).emit("session:completed", {
+      session_id: "session-1",
+      exit_code: 0,
+      output_lines: long_output,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    const alert_router = ctx.alert_router as unknown as {
+      post_alert: ReturnType<typeof vi.fn>;
+    };
+    const updates = alert_router.post_alert.mock.calls.filter(
+      (c) => (c[0] as { tier: string }).tier === "incident_update",
+    );
+    const no_verdict_update = updates.find((c) => {
+      const body = (c[0] as { body: string }).body;
+      return body.includes("didn't emit") || body.includes("didn't output");
+    });
+    expect(no_verdict_update).toBeDefined();
+    const body = (no_verdict_update![0] as { body: string }).body;
+    expect(body).toContain(USER_TAG);
+    // Last 20 lines means lines 11..30; line 10 must NOT appear, line 11 must
+    expect(body).toContain("line 30");
+    expect(body).toContain("line 11");
+    expect(body).not.toContain("line 10\n");
+    // Should be code-blocked
+    expect(body).toContain("```");
+  });
+
+  it("session failure posts thread update WITH user tag and error message", async () => {
+    const session_manager = make_session_manager();
+    const ctx = make_context({ session_manager });
+    const sm = session_manager as unknown as { spawn: ReturnType<typeof vi.fn> };
+
+    sm.spawn.mockResolvedValue({
+      session_id: "session-1",
+      entity_id: "test-entity",
+      feature_id: "sentry-triage-ISSUE-CRASH",
+      archetype: "operator",
+      started_at: new Date(),
+      pid: 12345,
+    });
+
+    await handle_sentry_triage_event("ISSUE-CRASH", "test-backend", "created", ctx);
+
+    (session_manager as unknown as EventEmitter).emit(
+      "session:failed",
+      "session-1",
+      "tmux session died unexpectedly",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    const alert_router = ctx.alert_router as unknown as {
+      post_alert: ReturnType<typeof vi.fn>;
+    };
+    const updates = alert_router.post_alert.mock.calls.filter(
+      (c) => (c[0] as { tier: string }).tier === "incident_update",
+    );
+    const crash_update = updates.find((c) => {
+      const body = (c[0] as { body: string }).body;
+      return body.includes("crashed") || body.includes("tmux");
+    });
+    expect(crash_update).toBeDefined();
+    const body = (crash_update![0] as { body: string }).body;
+    expect(body).toContain(USER_TAG);
+    expect(body).toContain("tmux session died unexpectedly");
+  });
+
+  it("fix-attempt exhaustion posts thread update WITH user tag", async () => {
+    const config = make_config();
+    const session_manager = make_session_manager();
+    const ctx = make_context({ session_manager, config });
+    const sm = session_manager as unknown as { spawn: ReturnType<typeof vi.fn> };
+
+    // Pre-seed: 2 attempts already used, thread_id already set (as if from prior ingress)
+    await save_triage_state(
+      {
+        triages: {
+          "ISSUE-EXHAUST": {
+            entity_id: "test-entity",
+            project_slug: "test-backend",
+            error_title: "Already tried to fix",
+            triaged_at: new Date().toISOString(),
+            status: "tracked",
+            sentry_url: "https://sentry.io/issues/ISSUE-EXHAUST/",
+            severity: "P1",
+            auto_fixable: true,
+            fix_attempts: 2,
+            fix_status: "failed",
+            thread_id: "thread-200",
+            alert_message_id: "msg-100",
+          },
+        },
+        stats: {
+          total_triaged: 1,
+          issues_created: 1,
+          dismissed: 0,
+          last_triage_at: new Date().toISOString(),
+        },
+      },
+      config,
+    );
+
+    sm.spawn.mockResolvedValue({
+      session_id: "session-1",
+      entity_id: "test-entity",
+      feature_id: "sentry-triage-ISSUE-EXHAUST",
+      archetype: "operator",
+      started_at: new Date(),
+      pid: 12345,
+    });
+
+    // Regression bypasses cooldown
+    await handle_sentry_triage_event("ISSUE-EXHAUST", "test-backend", "regression", ctx);
+
+    // Complete with auto_fixable verdict — but cap will kick in
+    (session_manager as unknown as EventEmitter).emit("session:completed", {
+      session_id: "session-1",
+      exit_code: 0,
+      output_lines: [
+        'SENTRY_TRIAGE_VERDICT:{"severity":"P1","auto_fixable":true,"github_issue":42,"fix_approach":"Try again"}',
+      ],
+    });
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    const alert_router = ctx.alert_router as unknown as {
+      post_alert: ReturnType<typeof vi.fn>;
+    };
+    const updates = alert_router.post_alert.mock.calls.filter(
+      (c) => (c[0] as { tier: string }).tier === "incident_update",
+    );
+    const exhaust_update = updates.find((c) => {
+      const body = (c[0] as { body: string }).body;
+      return body.includes("after") && body.includes("attempts");
+    });
+    expect(exhaust_update).toBeDefined();
+    expect((exhaust_update![0] as { body: string }).body).toContain(USER_TAG);
+  });
+});
+
+describe("thread-based alerts — resolve on fix merge", () => {
+  it("fix PR merge calls resolve_incident with PR number in body", async () => {
+    const config = make_config();
+
+    // Pre-seed state: triage has a thread_id and a linked github issue
+    await save_triage_state(
+      {
+        triages: {
+          "ISSUE-RESOLVE": {
+            entity_id: "test-entity",
+            project_slug: "test-backend",
+            error_title: "Fixable error",
+            triaged_at: new Date().toISOString(),
+            status: "tracked",
+            sentry_url: "https://sentry.io/issues/ISSUE-RESOLVE/",
+            severity: "P1",
+            auto_fixable: true,
+            github_issue: 42,
+            fix_attempts: 1,
+            fix_status: "fixing",
+            thread_id: "thread-200",
+            alert_message_id: "msg-100",
+          },
+        },
+        stats: {
+          total_triaged: 1,
+          issues_created: 1,
+          dismissed: 0,
+          last_triage_at: new Date().toISOString(),
+        },
+      },
+      config,
+    );
+
+    const alert_router = make_alert_router();
+    const ctx = make_context({
+      config,
+      alert_router: alert_router as unknown as SentryTriageContext["alert_router"],
+    });
+
+    // Simulate the fix PR merging — linked to issue #42, PR number 99
+    await handle_sentry_fix_pr_merged(99, [42], ctx);
+
+    expect(alert_router.resolve_incident).toHaveBeenCalledWith(
+      "thread-200",
+      expect.stringContaining("99"),
+    );
+
+    // Triage state fix_status should now be "fixed"
+    const state = await load_triage_state(config);
+    expect(state.triages["ISSUE-RESOLVE"]!.fix_status).toBe("fixed");
+  });
+});
+
+describe("thread-based alerts — back-compat", () => {
+  it("legacy triage state without thread_id falls back to action_required top-level alert", async () => {
+    const config = make_config();
+
+    // Pre-seed state WITHOUT thread_id (simulates a state from before #310)
+    await save_triage_state(
+      {
+        triages: {
+          "ISSUE-LEGACY": {
+            entity_id: "test-entity",
+            project_slug: "test-backend",
+            error_title: "Legacy error",
+            triaged_at: new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString(),
+            status: "tracked",
+            sentry_url: "https://sentry.io/issues/ISSUE-LEGACY/",
+          },
+        },
+        stats: {
+          total_triaged: 1,
+          issues_created: 0,
+          dismissed: 0,
+          last_triage_at: new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString(),
+        },
+      },
+      config,
+    );
+
+    const session_manager = make_session_manager();
+    const alert_router = make_alert_router();
+    // Simulate incident_open failing (so no thread_id is persisted) by returning nulls
+    alert_router.post_alert.mockImplementation(async (payload: { tier: string }) => {
+      if (payload.tier === "incident_open") {
+        return { message_id: null };
+      }
+      return { message_id: null };
+    });
+
+    const ctx = make_context({
+      config,
+      session_manager,
+      alert_router: alert_router as unknown as SentryTriageContext["alert_router"],
+    });
+    const sm = session_manager as unknown as { spawn: ReturnType<typeof vi.fn> };
+
+    sm.spawn.mockResolvedValue({
+      session_id: "session-1",
+      entity_id: "test-entity",
+      feature_id: "sentry-triage-ISSUE-LEGACY",
+      archetype: "operator",
+      started_at: new Date(),
+      pid: 12345,
+    });
+
+    // cooldown expired (25h ago), so we proceed. But incident_open returned null → no thread_id persisted.
+    await handle_sentry_triage_event("ISSUE-LEGACY", "test-backend", "created", ctx);
+
+    (session_manager as unknown as EventEmitter).emit("session:completed", {
+      session_id: "session-1",
+      exit_code: 0,
+      output_lines: [
+        'SENTRY_TRIAGE_VERDICT:{"severity":"P1","auto_fixable":false,"github_issue":42,"fix_approach":"Manual review"}',
+      ],
+    });
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    // With no thread_id, the verdict must fall back to action_required top-level alert
+    const action_required = alert_router.post_alert.mock.calls.find((c) => {
+      const p = c[0] as { tier: string; title: string };
+      return p.tier === "action_required" && p.title.includes("triage");
+    });
+    expect(action_required).toBeDefined();
   });
 });

--- a/packages/daemon/src/__tests__/sentry-triage.test.ts
+++ b/packages/daemon/src/__tests__/sentry-triage.test.ts
@@ -1253,6 +1253,30 @@ describe("thread-based alerts — ingress", () => {
     expect(payload.body).toContain("received");
   });
 
+  it("triaging posts 🔍 thread update after session spawns", async () => {
+    const ctx = make_context();
+    const alert_router = ctx.alert_router as unknown as {
+      post_alert: ReturnType<typeof vi.fn>;
+    };
+
+    await handle_sentry_triage_event("ISSUE-TRIAGING", "test-backend", "created", ctx);
+    // Allow the async post_alert in spawn_triage_session (fire-and-forget) to flush.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const triaging_update = alert_router.post_alert.mock.calls.find((c) => {
+      const p = c[0] as { tier: string; body: string };
+      return p.tier === "incident_update" && p.body.includes("Triage session started");
+    });
+    expect(triaging_update).toBeDefined();
+    const payload = triaging_update![0] as {
+      tier: string;
+      incident_id: string;
+      body: string;
+    };
+    expect(payload.incident_id).toBe("thread-200");
+    expect(payload.body).toContain("\u{1f50d}");
+  });
+
   it("persists thread_id on triage state after ingress", async () => {
     const config = make_config();
     const ctx = make_context({ config });

--- a/packages/daemon/src/sentry-alert-format.ts
+++ b/packages/daemon/src/sentry-alert-format.ts
@@ -241,6 +241,104 @@ export function get_cached_issue_details(
   return promise;
 }
 
+// ── Incident thread formatting (#310) ──
+
+/**
+ * Discord user ID for the entity owner (e.g. Jax). Hardcoded for now.
+ *
+ * When multi-user support lands, read this from entity config instead. For
+ * this issue the only consumer is lobster-farm's own alerts.
+ */
+const USER_MENTION = "<@732686813856006245>";
+
+/**
+ * Mention the user who should act on a Sentry incident. Used in thread
+ * updates that require human attention (P0, parse failures, crashes,
+ * fix-attempt exhaustion).
+ */
+export function mention_user(): string {
+  return USER_MENTION;
+}
+
+/**
+ * Truncate an issue title to the 80-char embed title budget, with ellipsis.
+ */
+export function truncate_title(title: string, max = 80): string {
+  if (title.length <= max) return title;
+  return `${title.slice(0, max - 1)}…`;
+}
+
+/**
+ * Body for the ingress incident_open alert. Deliberately minimal — the
+ * thread will carry the actual lifecycle.
+ */
+export function format_incident_open_body(web_url: string): string {
+  return `${web_url}\n\nStatus: received — spawning triage`;
+}
+
+/** Body for "triage session started" thread update. */
+export function format_triaging_body(): string {
+  return "\u{1f50d} Triage session started";
+}
+
+/**
+ * Body for the verdict thread update. Tags the user when severity is P0.
+ */
+export function format_verdict_body(verdict: {
+  severity: "P0" | "P1" | "P2";
+  auto_fixable: boolean;
+  github_issue: number | null;
+  fix_approach: string | null;
+}): string {
+  const needs_tag = verdict.severity === "P0";
+  const tag = needs_tag ? `${USER_MENTION} ` : "";
+  const summary = verdict.fix_approach ?? "(no fix summary)";
+  const lines = [`✅ ${tag}Verdict: ${verdict.severity} — ${summary}`];
+  if (verdict.github_issue != null) {
+    lines.push(`GitHub: #${String(verdict.github_issue)}`);
+  } else {
+    lines.push("No GitHub issue created");
+  }
+  const fix_note = verdict.auto_fixable
+    ? `Auto-fix: yes — ${verdict.fix_approach ?? "approach TBD"}`
+    : "Auto-fix: no";
+  lines.push(fix_note);
+  return lines.join("\n");
+}
+
+/**
+ * Body for the "no verdict parsed" thread update. Always tags the user
+ * and appends the last 20 lines of Ray's output (code-blocked) so the
+ * user can see what went wrong.
+ */
+export function format_no_verdict_body(output_lines: string[] | undefined): string {
+  const tail = (output_lines ?? []).slice(-20).join("\n");
+  const tail_block =
+    tail.length > 0 ? `\n\n**Last 20 lines of output:**\n\`\`\`\n${tail}\n\`\`\`` : "";
+  return `⚠️ ${USER_MENTION} Ray completed but didn't emit a verdict block.${tail_block}`;
+}
+
+/** Body for "session crashed" thread update. */
+export function format_session_failed_body(error: string): string {
+  return `❌ ${USER_MENTION} Triage session crashed: ${error}`;
+}
+
+/** Body for "auto-fix session spawned" thread update. */
+export function format_fix_spawned_body(): string {
+  return "\u{1f6e0}️ Auto-fix session spawned (Bob, Opus)";
+}
+
+/** Body for "auto-fix exhausted attempts" thread update. */
+export function format_fix_exhausted_body(attempts: number, last_pr_url?: string | null): string {
+  const suffix = last_pr_url ? ` Last PR: ${last_pr_url}` : "";
+  return `❌ ${USER_MENTION} Auto-fix failed after ${String(attempts)} attempts.${suffix}`;
+}
+
+/** Body for "fix PR merged — incident resolved" thread update. */
+export function format_fix_merged_body(pr_number: number): string {
+  return `Fix PR #${String(pr_number)} merged`;
+}
+
 // ── Test helpers ──
 
 /**

--- a/packages/daemon/src/sentry-triage.ts
+++ b/packages/daemon/src/sentry-triage.ts
@@ -28,7 +28,17 @@ import type { AlertRouter } from "./alert-router.js";
 import type { DiscordBot } from "./discord.js";
 import type { EntityRegistry } from "./registry.js";
 import { MAX_SENTRY_FIX_ATTEMPTS, build_sentry_fix_prompt } from "./review-utils.js";
-import { get_cached_issue_details } from "./sentry-alert-format.js";
+import {
+  format_fix_exhausted_body,
+  format_fix_merged_body,
+  format_fix_spawned_body,
+  format_incident_open_body,
+  format_no_verdict_body,
+  format_session_failed_body,
+  format_verdict_body,
+  get_cached_issue_details,
+  truncate_title,
+} from "./sentry-alert-format.js";
 import { type SentryIssueDetails, fetch_sentry_issue_details } from "./sentry-api.js";
 import * as sentry from "./sentry.js";
 import type { ActiveSession, ClaudeSessionManager, SessionResult } from "./session.js";
@@ -142,6 +152,10 @@ export interface SentryTriageRecord {
   fix_attempts?: number;
   fix_session_id?: string;
   fix_status?: "pending" | "fixing" | "fixed" | "failed";
+  // Incident thread tracking (#310)
+  thread_id?: string;
+  alert_message_id?: string;
+  last_fix_pr_url?: string;
 }
 
 export interface SentryTriageState {
@@ -572,24 +586,37 @@ async function spawn_triage_session(
     const verdict = parse_triage_verdict(result.output_lines);
 
     if (verdict) {
-      // Post triage verdict to #alerts
+      // Route verdict into the incident thread if we have one (#310);
+      // fall back to the legacy top-level action_required alert if not.
       if (ctx.alert_router) {
-        const fix_note = verdict.auto_fixable
-          ? `Auto-fix: yes → ${verdict.fix_approach ?? "approach TBD"}`
-          : "Auto-fix: no";
-        const issue_note = verdict.github_issue
-          ? `GitHub: #${String(verdict.github_issue)}`
-          : "No GitHub issue created";
-
-        void ctx.alert_router
-          .post_alert({
-            entity_id,
-            tier:
-              verdict.severity === "P0" || verdict.severity === "P1"
-                ? "action_required"
-                : "routine",
-            title: `\u{1f50d} Sentry triage: ${verdict.severity} — ${issue_details.title}`,
-            body: [issue_details.web_url, issue_note, fix_note].join("\n"),
+        void load_triage_state(ctx.config)
+          .then((state) => {
+            const thread_id = state.triages[sentry_issue_id]?.thread_id;
+            if (thread_id) {
+              return ctx.alert_router!.post_alert({
+                entity_id,
+                tier: "incident_update",
+                incident_id: thread_id,
+                title: "",
+                body: format_verdict_body(verdict),
+              });
+            }
+            // Back-compat: no thread_id (pre-#310 state) → top-level alert.
+            const fix_note = verdict.auto_fixable
+              ? `Auto-fix: yes → ${verdict.fix_approach ?? "approach TBD"}`
+              : "Auto-fix: no";
+            const issue_note = verdict.github_issue
+              ? `GitHub: #${String(verdict.github_issue)}`
+              : "No GitHub issue created";
+            return ctx.alert_router!.post_alert({
+              entity_id,
+              tier:
+                verdict.severity === "P0" || verdict.severity === "P1"
+                  ? "action_required"
+                  : "routine",
+              title: `\u{1f50d} Sentry triage: ${verdict.severity} — ${issue_details.title}`,
+              body: [issue_details.web_url, issue_note, fix_note].join("\n"),
+            });
           })
           .catch((err) => {
             console.error(`[sentry-triage] Failed to post verdict alert: ${String(err)}`);
@@ -627,14 +654,28 @@ async function spawn_triage_session(
           );
         });
     } else {
-      // Post no-verdict alert to #alerts
+      // No verdict parsed \u2014 route to the incident thread if we have one
+      // (#310), with Ray's output tail so the user can diagnose the parse
+      // failure. Fall back to top-level alert for back-compat.
       if (ctx.alert_router) {
-        void ctx.alert_router
-          .post_alert({
-            entity_id,
-            tier: "action_required",
-            title: "\u26a0\ufe0f Sentry triage completed \u2014 no verdict parsed",
-            body: `Ray's session completed but didn't output a structured verdict.\n${issue_details.title}\n${issue_details.web_url}`,
+        void load_triage_state(ctx.config)
+          .then((state) => {
+            const thread_id = state.triages[sentry_issue_id]?.thread_id;
+            if (thread_id) {
+              return ctx.alert_router!.post_alert({
+                entity_id,
+                tier: "incident_update",
+                incident_id: thread_id,
+                title: "",
+                body: format_no_verdict_body(result.output_lines),
+              });
+            }
+            return ctx.alert_router!.post_alert({
+              entity_id,
+              tier: "action_required",
+              title: "\u26a0\ufe0f Sentry triage completed \u2014 no verdict parsed",
+              body: `Ray's session completed but didn't output a structured verdict.\n${issue_details.title}\n${issue_details.web_url}`,
+            });
           })
           .catch((err) => {
             console.error(`[sentry-triage] Failed to post no-verdict alert: ${String(err)}`);
@@ -668,12 +709,26 @@ async function spawn_triage_session(
 
     // Alert on session failure — more urgent than no-verdict since Ray didn't run at all
     if (ctx.alert_router) {
-      void ctx.alert_router
-        .post_alert({
-          entity_id,
-          tier: "action_required",
-          title: "\u274c Sentry triage session failed",
-          body: `Ray's triage session crashed.\n${issue_details.title}\n${issue_details.web_url}\nError: ${error}`,
+      // Route into incident thread if we have one (#310); fall back to
+      // top-level action_required for back-compat.
+      void load_triage_state(ctx.config)
+        .then((state) => {
+          const thread_id = state.triages[sentry_issue_id]?.thread_id;
+          if (thread_id) {
+            return ctx.alert_router!.post_alert({
+              entity_id,
+              tier: "incident_update",
+              incident_id: thread_id,
+              title: "",
+              body: format_session_failed_body(error),
+            });
+          }
+          return ctx.alert_router!.post_alert({
+            entity_id,
+            tier: "action_required",
+            title: "\u274c Sentry triage session failed",
+            body: `Ray's triage session crashed.\n${issue_details.title}\n${issue_details.web_url}\nError: ${error}`,
+          });
         })
         .catch((err) => {
           console.error(`[sentry-triage] Failed to post failure alert: ${String(err)}`);
@@ -722,6 +777,20 @@ async function spawn_sentry_fix(
       `[sentry-triage] Fix attempt cap reached for ${sentry_issue_id} ` +
         `(${String(current_attempts)}/${String(MAX_SENTRY_FIX_ATTEMPTS)}) — skipping auto-fix`,
     );
+    // Post exhaustion update into the incident thread (#310).
+    if (ctx.alert_router && record?.thread_id) {
+      await ctx.alert_router
+        .post_alert({
+          entity_id,
+          tier: "incident_update",
+          incident_id: record.thread_id,
+          title: "",
+          body: format_fix_exhausted_body(current_attempts, record.last_fix_pr_url ?? null),
+        })
+        .catch((err) => {
+          console.error(`[sentry-triage] Failed to post fix-exhaustion update: ${String(err)}`);
+        });
+    }
     return;
   }
 
@@ -776,6 +845,21 @@ async function spawn_sentry_fix(
     { fix_session_id: fix_session.session_id },
     ctx.config,
   );
+
+  // Post "fix spawned" update into the incident thread (#310).
+  if (ctx.alert_router && record?.thread_id) {
+    void ctx.alert_router
+      .post_alert({
+        entity_id,
+        tier: "incident_update",
+        incident_id: record.thread_id,
+        title: "",
+        body: format_fix_spawned_body(),
+      })
+      .catch((err) => {
+        console.error(`[sentry-triage] Failed to post fix-spawned update: ${String(err)}`);
+      });
+  }
 
   // ── Fix session lifecycle listeners ──
 
@@ -905,6 +989,7 @@ export async function handle_sentry_triage_event(
       `[sentry-triage] At capacity (${String(MAX_CONCURRENT_TRIAGES)} concurrent) — ` +
         `queuing issue ${sentry_issue_id}`,
     );
+    await open_incident_for_triage(sentry_issue_id, entity_id, issue_details, ctx);
     triage_queue.push({
       sentry_issue_id,
       entity_id,
@@ -916,6 +1001,7 @@ export async function handle_sentry_triage_event(
     return;
   }
 
+  await open_incident_for_triage(sentry_issue_id, entity_id, issue_details, ctx);
   await spawn_triage_session(
     sentry_issue_id,
     entity_id,
@@ -927,6 +1013,45 @@ export async function handle_sentry_triage_event(
   );
 }
 
+/**
+ * Open a Discord incident thread for a Sentry issue we're about to triage
+ * (#310). The thread carries the full lifecycle (triage start, verdict,
+ * fix spawn, fix merge). Persists `thread_id` + `alert_message_id` on the
+ * triage state so every subsequent update posts into this thread.
+ *
+ * Called only after gates pass (not dedup, not cooldown, not queue-full).
+ * If Discord is unavailable or no alerts channel is configured, returns
+ * without persisting — subsequent alerts fall back to top-level action_required.
+ */
+async function open_incident_for_triage(
+  sentry_issue_id: string,
+  entity_id: string,
+  issue_details: SentryIssueDetails,
+  ctx: SentryTriageContext,
+): Promise<void> {
+  if (!ctx.alert_router) return;
+  try {
+    const result = await ctx.alert_router.post_alert({
+      entity_id,
+      tier: "incident_open",
+      title: `\u{1f6a8} Sentry — ${truncate_title(issue_details.title, 80)}`,
+      body: format_incident_open_body(issue_details.web_url),
+    });
+    if (result.thread_id) {
+      await update_triage_state(
+        sentry_issue_id,
+        {
+          thread_id: result.thread_id,
+          alert_message_id: result.message_id ?? undefined,
+        },
+        ctx.config,
+      );
+    }
+  } catch (err) {
+    console.error(`[sentry-triage] Failed to open incident thread: ${String(err)}`);
+  }
+}
+
 // ── Test helpers ──
 
 /**
@@ -936,6 +1061,53 @@ export function _reset_for_test(): void {
   active_triages.clear();
   triage_queue.length = 0;
   state_write_lock = Promise.resolve();
+}
+
+/**
+ * Handle a fix PR being merged (#310).
+ *
+ * Called by the GitHub webhook handler when a merged PR's linked issues
+ * include one tracked by a Sentry triage. Finds every triage record whose
+ * `github_issue` matches, marks it `fix_status: fixed`, and calls
+ * `resolve_incident` to turn the top-level embed green and post a
+ * resolution message into the thread.
+ *
+ * Safe to call when no matching triage exists — it's a best-effort hook.
+ */
+export async function handle_sentry_fix_pr_merged(
+  pr_number: number,
+  linked_issue_numbers: number[],
+  ctx: SentryTriageContext,
+): Promise<void> {
+  if (linked_issue_numbers.length === 0) return;
+
+  const state = await load_triage_state(ctx.config);
+  const linked_set = new Set(linked_issue_numbers);
+
+  for (const [sentry_issue_id, record] of Object.entries(state.triages)) {
+    if (record.github_issue == null) continue;
+    if (!linked_set.has(record.github_issue)) continue;
+    if (record.fix_status === "fixed") continue;
+
+    await update_triage_state(
+      sentry_issue_id,
+      { fix_status: "fixed", last_fix_pr_url: `PR #${String(pr_number)}` },
+      ctx.config,
+    );
+
+    if (ctx.alert_router && record.thread_id) {
+      try {
+        await ctx.alert_router.resolve_incident(
+          record.thread_id,
+          format_fix_merged_body(pr_number),
+        );
+      } catch (err) {
+        console.error(
+          `[sentry-triage] Failed to resolve incident for ${sentry_issue_id}: ${String(err)}`,
+        );
+      }
+    }
+  }
 }
 
 /**

--- a/packages/daemon/src/sentry-triage.ts
+++ b/packages/daemon/src/sentry-triage.ts
@@ -35,6 +35,7 @@ import {
   format_incident_open_body,
   format_no_verdict_body,
   format_session_failed_body,
+  format_triaging_body,
   format_verdict_body,
   get_cached_issue_details,
   truncate_title,
@@ -570,6 +571,27 @@ async function spawn_triage_session(
     project_slug: project_info.slug,
     error_title: issue_details.title,
   });
+
+  // Post "triaging" update into the incident thread (#310).
+  // Mirrors the format_fix_spawned_body pattern in spawn_sentry_fix — read the
+  // thread_id set by open_incident_for_triage and post an incident_update.
+  if (ctx.alert_router) {
+    const { triages } = await load_triage_state(ctx.config);
+    const thread_id = triages[sentry_issue_id]?.thread_id;
+    if (thread_id) {
+      void ctx.alert_router
+        .post_alert({
+          entity_id,
+          tier: "incident_update",
+          incident_id: thread_id,
+          title: "",
+          body: format_triaging_body(),
+        })
+        .catch((err) => {
+          console.error(`[sentry-triage] Failed to post triaging update: ${String(err)}`);
+        });
+    }
+  }
 
   // ── Post-session listeners ──
 

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -4,7 +4,7 @@ import type { LobsterFarmConfig } from "@lobster-farm/shared";
 import { DAEMON_PORT } from "@lobster-farm/shared";
 import { type ArchetypeRole, expand_home } from "@lobster-farm/shared";
 import { persist_entity_config } from "./actions.js";
-import { ALERT_COLOR_RED, type AlertRouter } from "./alert-router.js";
+import type { AlertRouter } from "./alert-router.js";
 import type { CommanderProcess } from "./commander-process.js";
 import {
   AmbiguousUserError,
@@ -337,33 +337,22 @@ async function process_sentry_webhook(
   });
 
   // Route through the tiered alert system (#253).
-  // error/fatal + triage-worthy (created/regression) → incident_open (top-level embed + thread)
-  // warning/other or non-triage actions → routine (daily thread)
-  const sentry_level = (issue?.level as string) ?? "error";
+  // Triage-worthy (created/regression) events get their incident opened by
+  // the triage orchestrator (#310) — opening it here would create a duplicate
+  // top-level embed and a thread with no content. For non-triage events
+  // (resolved, unresolved, warnings) we still post a routine daily-thread entry.
   const is_triage_worthy = triage_actions.includes(action ?? "");
-  const is_high_severity = sentry_level === "fatal" || sentry_level === "error";
   const effective_entity_id = target_entity_id ?? ctx.registry.get_active()[0]?.entity.id ?? null;
 
-  if (ctx.alert_router && effective_entity_id) {
-    if (is_triage_worthy && is_high_severity) {
-      // Tier 3: incident thread for error/fatal triage events
-      await ctx.alert_router.post_alert({
-        entity_id: effective_entity_id,
-        tier: "incident_open",
-        title: `\u{1f534} Sentry [${sentry_level}]: ${error_title}`,
-        body: alert_message,
-        embed_color: ALERT_COLOR_RED,
-      });
-    } else {
-      // Tier 2: routine (resolved, unresolved, warnings, P2/P3)
-      await ctx.alert_router.post_alert({
-        entity_id: effective_entity_id,
-        tier: "routine",
-        title: `Sentry [${action ?? "event"}]`,
-        body: alert_message,
-      });
-    }
-  } else if (ctx.discord) {
+  if (ctx.alert_router && effective_entity_id && !is_triage_worthy) {
+    // Tier 2: routine (resolved, unresolved, warnings)
+    await ctx.alert_router.post_alert({
+      entity_id: effective_entity_id,
+      tier: "routine",
+      title: `Sentry [${action ?? "event"}]`,
+      body: alert_message,
+    });
+  } else if (!ctx.alert_router && ctx.discord) {
     // Fallback: no alert_router, use direct Discord send
     if (target_entity_id) {
       await ctx.discord.send_to_entity(target_entity_id, "alerts", alert_message, "system");

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -362,6 +362,15 @@ async function process_sentry_webhook(
         await ctx.discord.send_to_entity(first_active.entity.id, "alerts", alert_message, "system");
       }
     }
+  } else if (ctx.alert_router && !effective_entity_id && !is_triage_worthy) {
+    // Alert router is configured but there's no entity to route to (no active
+    // entities in the registry and no target_entity_id on the event). The
+    // previous implementation broadcast to all entities via send_to_all here,
+    // which was noisy; the intentional silence replaces it. Logging makes the
+    // drop observable so operators can diagnose "why didn't I see that alert?".
+    console.warn(
+      `[sentry-webhook] Dropping non-triage event — no effective entity_id (resource=${resource}, action=${action ?? "unknown"}, title=${error_title})`,
+    );
   }
 
   console.log(`[sentry-webhook] Processed: ${resource}.${action ?? "unknown"} — ${error_title}`);

--- a/packages/daemon/src/webhook-handler.ts
+++ b/packages/daemon/src/webhook-handler.ts
@@ -56,6 +56,7 @@ import {
   fetch_pr_mergeability,
   fetch_review_comments,
 } from "./review-utils.js";
+import { handle_sentry_fix_pr_merged } from "./sentry-triage.js";
 import * as sentry from "./sentry.js";
 import type { ClaudeSessionManager, SessionResult } from "./session.js";
 import { cleanup_after_merge } from "./worktree-cleanup.js";
@@ -1703,6 +1704,27 @@ async function handle_pr_merged(
 ): Promise<void> {
   // Close linked issues
   const issue_numbers = extract_linked_issues(pr.body, pr.title);
+
+  // Resolve any Sentry incidents tied to the linked issues (#310). Best-effort:
+  // failures are logged but never break the merge path.
+  if (issue_numbers.length > 0) {
+    try {
+      await handle_sentry_fix_pr_merged(pr.number, issue_numbers, {
+        session_manager: ctx.session_manager,
+        registry: ctx.registry,
+        discord: ctx.discord,
+        config: ctx.config,
+        alert_router: ctx.alert_router,
+      });
+    } catch (err) {
+      console.error(`[webhook] Sentry incident resolve failed: ${String(err)}`);
+      sentry.captureException(err, {
+        tags: { module: "webhook", action: "sentry_incident_resolve" },
+        contexts: { pr: { number: pr.number, title: pr.title } },
+      });
+    }
+  }
+
   if (issue_numbers.length === 0) {
     console.log(`[webhook] Merged PR #${String(pr.number)} has no linked issues to close`);
   } else {
@@ -1771,6 +1793,26 @@ async function post_auto_merge_cleanup(
 ): Promise<void> {
   // Close linked issues
   const issue_numbers = extract_linked_issues(pr.body, pr.title);
+
+  // Resolve any Sentry incidents tied to the linked issues (#310).
+  if (issue_numbers.length > 0) {
+    try {
+      await handle_sentry_fix_pr_merged(pr.number, issue_numbers, {
+        session_manager: ctx.session_manager,
+        registry: ctx.registry,
+        discord: ctx.discord,
+        config: ctx.config,
+        alert_router: ctx.alert_router,
+      });
+    } catch (err) {
+      console.error(`[webhook] Sentry incident resolve failed (auto-merge): ${String(err)}`);
+      sentry.captureException(err, {
+        tags: { module: "webhook", action: "auto_merge_sentry_resolve" },
+        contexts: { pr: { number: pr.number, title: pr.title } },
+      });
+    }
+  }
+
   if (issue_numbers.length > 0) {
     // Derive repo full name from entity registry
     const entity_config = ctx.registry


### PR DESCRIPTION
## Summary

Every Sentry error now gets one Discord incident thread carrying the full lifecycle. Ingress opens an incident (top-level embed + thread) via `incident_open` — every subsequent state transition (verdict, no-verdict, session crash, fix spawn, fix exhaustion) posts inside that thread via `incident_update`. When a state requires human action (P0, parse failure, session crash, fix-attempt exhaustion), the thread message tags the user so they get a ping. Fix PR merge triggers `resolve_incident`, turning the top-level embed green.

No-verdict fallback now includes the last 20 lines of Ray's output (code-blocked) so parse failures are diagnosable.

## Changes

- `sentry-triage.ts` — opens incident thread after gates pass, persists `thread_id` on triage state, routes every lifecycle update into the thread; new `handle_sentry_fix_pr_merged` resolves incidents on merge.
- `sentry-alert-format.ts` — `mention_user()` + 7 body formatters (incident_open, verdict, no-verdict, session-failed, fix-spawned, fix-exhausted, fix-merged).
- `server.ts` — removes the duplicate top-level `incident_open` for triage events (now owned by triage orchestrator).
- `webhook-handler.ts` — calls `handle_sentry_fix_pr_merged` from `handle_pr_merged` + `post_auto_merge_cleanup` when merged PRs link issues tracked by Sentry triage.

## Back-compat

Triage states persisted before this change lack `thread_id`; those fall back to the old `action_required` top-level alert path. Covered by test #11.

## Tests

11 new tests in `sentry-triage.test.ts` covering each state transition, user tagging, and back-compat. All 1099 daemon tests pass, typecheck clean, lint clean.

Closes #310