### PR TITLE
fix(daemon): SHA-aware skip logic in reviewer prompt

### DIFF
--- a/packages/daemon/src/__tests__/webhook-handler.test.ts
+++ b/packages/daemon/src/__tests__/webhook-handler.test.ts
@@ -1533,7 +1533,7 @@ describe("handle_github_webhook", () => {
       const spawn_args = (ctx.session_manager as any).spawn.mock.calls[0]![0];
       const prompt: string = spawn_args.prompt;
 
-      expect(prompt).toContain("Before posting, check for any existing reviews");
+      expect(prompt).toContain("Before posting, check for any existing bot reviews");
       expect(prompt).toContain('select(.user.login | endswith("[bot]"))');
       expect(prompt).toContain("gh api repos/test-org/lobster-farm/pulls/300/reviews");
     });
@@ -1797,6 +1797,82 @@ describe("handle_github_webhook", () => {
       it("does not include the linked-issue context section", () => {
         expect(prompt).not.toContain("## Linked Issue Context");
       });
+    });
+  });
+
+  // Regression: reviewer skips re-review after fix commits because its
+  // "skip if existing review" check is SHA-agnostic. A CHANGES_REQUESTED
+  // review on a superseded commit should NOT block a fresh review on the
+  // current head SHA. See issue #314, PR #311 as the triggering incident.
+  describe("build_reviewer_prompt SHA-aware skip logic (issue #314)", () => {
+    const make_pr_with_sha = (sha: string) => ({
+      number: 42,
+      title: "Test PR",
+      head: { ref: "feature/test", sha },
+      body: null,
+      user: { login: "testuser" },
+    });
+
+    it("includes the current PR head SHA in the rendered prompt", () => {
+      const sha = "00a22aff1234567890abcdef1234567890abcdef";
+      const prompt = build_reviewer_prompt(
+        make_pr_with_sha(sha),
+        "/tmp/repo",
+        "test-org/test-repo",
+        "",
+      );
+
+      expect(prompt).toContain(sha);
+    });
+
+    it("scopes the 'skip if review exists' instruction to the current head SHA", () => {
+      const sha = "00a22aff1234567890abcdef1234567890abcdef";
+      const prompt = build_reviewer_prompt(
+        make_pr_with_sha(sha),
+        "/tmp/repo",
+        "test-org/test-repo",
+        "",
+      );
+
+      // The instruction must tie the skip decision to the current head SHA.
+      // Prior reviews on older commits must be treated as stale.
+      expect(prompt).toMatch(/current head SHA/i);
+      expect(prompt.toLowerCase()).toContain("stale");
+      // The exact SHA must appear in the skip-instruction context.
+      expect(prompt).toContain(sha);
+    });
+
+    it("includes commit_id in the pre-existing-review jq query", () => {
+      const prompt = build_reviewer_prompt(
+        make_pr_with_sha("abc123"),
+        "/tmp/repo",
+        "test-org/test-repo",
+        "",
+      );
+
+      // The jq query must select commit_id so the reviewer can compare it
+      // to the current head SHA. Without this, there's no way to tell
+      // a stale review apart from a live one.
+      expect(prompt).toContain("commit_id");
+      // And the commit_id must appear in the reviews-API jq context, not
+      // just as a stray mention elsewhere.
+      expect(prompt).toMatch(/gh api repos\/[^\s]+\/reviews[^\n]*commit_id/);
+    });
+
+    it("does not instruct the reviewer to post review outcomes via `gh pr comment`", () => {
+      const prompt = build_reviewer_prompt(
+        make_pr_with_sha("abc123"),
+        "/tmp/repo",
+        "test-org/test-repo",
+        "## Acceptance Criteria\n- [ ] Do thing",
+      );
+
+      // Formal review states (approve / request-changes / comment as a
+      // review state) are posted via `gh pr review`. A plain `gh pr comment`
+      // is a PR comment, NOT a formal review — it does not update
+      // reviewDecision and does not unblock auto-merge. The #311 "Round 2
+      // Approved" plain-comment anomaly must not be reintroduced.
+      expect(prompt).not.toContain("gh pr comment");
     });
   });
 });

--- a/packages/daemon/src/webhook-handler.ts
+++ b/packages/daemon/src/webhook-handler.ts
@@ -1490,18 +1490,42 @@ export function build_reviewer_prompt(
   issue_context: string,
 ): string {
   const pr_num = String(pr.number);
+  const head_sha = pr.head.sha;
   const has_issue = issue_context.length > 0;
 
   // Header + linked issue context FIRST, so the reviewer reads the spec before
   // being told what to do with it.
+  //
+  // The pre-existing-review check is SHA-aware (see #314). Prior buggy
+  // behavior: the skip test ignored commit_id, so when fix commits pushed and
+  // a new reviewer session spawned, it saw the stale CHANGES_REQUESTED review
+  // on the OLD commit and exited silently — never posting a fresh review on
+  // the new head. Fix: scope the skip to reviews whose commit_id matches the
+  // current head SHA. Reviews on superseded commits are stale and must not
+  // block a fresh review.
   const lines: string[] = [
     `Review PR #${pr_num}: "${pr.title}" on branch ${pr.head.ref}.`,
     `Repository: ${repo_path}`,
+    `Current head SHA: ${head_sha}`,
     "",
-    "Before posting, check for any existing reviews you've already posted:",
-    `  gh api repos/${repo_full_name}/pulls/${pr_num}/reviews --jq '[.[] | select(.user.login | endswith("[bot]"))] | { count: length, reviews: map({state, submitted_at}) }'`,
-    "If a review already exists with state APPROVED or CHANGES_REQUESTED, skip posting",
-    "and go directly to the merge step (if approved) or stop (if changes requested).",
+    "Before posting, check for any existing bot reviews AND their commit_id:",
+    `  gh api repos/${repo_full_name}/pulls/${pr_num}/reviews --jq '[.[] | select(.user.login | endswith("[bot]")) | {state, submitted_at, commit_id}]'`,
+    "",
+    `Skip posting ONLY if a review already exists with state APPROVED or CHANGES_REQUESTED on the current head SHA: ${head_sha}.`,
+    "If prior reviews exist only on older commits, treat them as stale and",
+    "proceed with a fresh formal review on the current head. A CHANGES_REQUESTED",
+    "review on a superseded commit does NOT block a fresh review — the builder",
+    "has since pushed fix commits and the new head must be re-evaluated.",
+    "",
+    "When you DO post, use a FORMAL review state via `gh pr review` ONLY:",
+    `  gh pr review ${pr_num} --approve --body "<body>"`,
+    `  gh pr review ${pr_num} --request-changes --body "<body>"`,
+    `  gh pr review ${pr_num} --comment --body "<body>"`,
+    "Formal review states update reviewDecision and drive auto-merge. Plain PR",
+    "comments do NOT — they are invisible to the merge gate. Never substitute a",
+    "plain comment for a formal review state, even if a prior review already",
+    "exists and you are 'just adding a note'. If you have something to say about",
+    "the PR, say it via `gh pr review`.",
     "",
   ];
 


### PR DESCRIPTION
## Summary

- Reviewer prompt now injects the current PR head SHA as a template variable and scopes the "skip if existing review" check to reviews on that SHA. Prior reviews on superseded commits are treated as stale — the fresh session posts a new formal review on the current head.
- jq query rewritten to include `commit_id` so the reviewer can compare it to the current head.
- Posting language hardened: prompt explicitly directs the reviewer to `gh pr review` (formal review states) and explains that plain PR comments don't update `reviewDecision` and don't unblock auto-merge. Addresses the "Round 2 Approved" plain-comment anomaly seen on PR #311.

## Why

AutoReviewer was exiting silently on `pull_request.synchronize` events after a CHANGES_REQUESTED review. The old prompt asked the reviewer to stop if ANY prior bot review existed, ignoring whether the review applied to the current commit. Every PR that took more than one review round got stuck — #311 hit this today and was blocked for 4.5h.

## Test plan

- [x] 4 new TDD tests in `build_reviewer_prompt SHA-aware skip logic (issue #314)` — wrote tests, watched 3 fail red, implemented, watched them go green
- [x] All 1092 daemon tests pass
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm build` clean
- [ ] After merge + daemon restart: PR #311 gets a fresh reviewer spawn (via pr-cron within 5min or next webhook) that posts a formal APPROVED review and auto-merges

Closes #314