### PR TITLE
fix(sentry-triage): parse verdict from stream-json output

### DIFF
--- a/packages/daemon/src/__tests__/sentry-triage.test.ts
+++ b/packages/daemon/src/__tests__/sentry-triage.test.ts
@@ -892,6 +892,175 @@ describe("parse_triage_verdict", () => {
   it("returns null for empty output_lines", () => {
     expect(parse_triage_verdict([])).toBeNull();
   });
+
+  // ── Stream-JSON parsing (#316) ──
+  //
+  // The Claude CLI is invoked with --output-format stream-json (session.ts:212),
+  // so each captured line is a JSON event such as:
+  //   {"type":"assistant","message":{"content":[{"type":"text","text":"...verdict..."}]}}
+  // The verdict marker lives inside the .message.content[].text field where
+  // double quotes are escaped (\"). Plain indexOf-then-JSON.parse on the raw
+  // line picks up the marker but tries to parse the still-escaped tail as JSON
+  // and silently fails. The parser must first decode the stream-json envelope
+  // then search the unescaped text.
+
+  it("parses verdict from a stream-json assistant text block", () => {
+    const verdict_payload =
+      '{"severity":"P2","auto_fixable":false,"github_issue":265,"fix_approach":"On cold cache, return 503+Retry-After immediately instead of blocking on _cache_lock; frontend auto-retries."}';
+    const text = `**GitHub issue #265 filed.** Two options documented.\n\nSENTRY_TRIAGE_VERDICT:${verdict_payload}`;
+    const event = {
+      type: "assistant",
+      message: { content: [{ type: "text", text }] },
+      session_id: "922845b0-cfdd-4788-ba2e-b28b0d97623d",
+    };
+
+    const verdict = parse_triage_verdict([JSON.stringify(event)]);
+
+    expect(verdict).toEqual({
+      severity: "P2",
+      auto_fixable: false,
+      github_issue: 265,
+      fix_approach:
+        "On cold cache, return 503+Retry-After immediately instead of blocking on _cache_lock; frontend auto-retries.",
+    });
+  });
+
+  it("parses verdict when text block contains other content before the marker", () => {
+    const text =
+      "Lots of analysis here.\n" +
+      "Multiple paragraphs of diagnosis.\n" +
+      "Even an earlier note that mentions verdict-shaped strings in passing.\n\n" +
+      'SENTRY_TRIAGE_VERDICT:{"severity":"P1","auto_fixable":true,"github_issue":99,"fix_approach":"Add null guard"}';
+    const event = {
+      type: "assistant",
+      message: { content: [{ type: "text", text }] },
+    };
+
+    const verdict = parse_triage_verdict([JSON.stringify(event)]);
+
+    expect(verdict).toEqual({
+      severity: "P1",
+      auto_fixable: true,
+      github_issue: 99,
+      fix_approach: "Add null guard",
+    });
+  });
+
+  it("parses verdict when it is the final line of a multi-line text block", () => {
+    const text = [
+      "## Summary",
+      "The error originates in src/handler.ts.",
+      "",
+      "## Recommendation",
+      "Tracked in #142.",
+      "",
+      'SENTRY_TRIAGE_VERDICT:{"severity":"P2","auto_fixable":true,"github_issue":142,"fix_approach":"Wrap in try/catch"}',
+    ].join("\n");
+    const event = {
+      type: "assistant",
+      message: { content: [{ type: "text", text }] },
+    };
+
+    const verdict = parse_triage_verdict([JSON.stringify(event)]);
+
+    expect(verdict).toEqual({
+      severity: "P2",
+      auto_fixable: true,
+      github_issue: 142,
+      fix_approach: "Wrap in try/catch",
+    });
+  });
+
+  it("skips non-assistant stream-json events without error", () => {
+    const lines = [
+      JSON.stringify({ type: "system", subtype: "init", session_id: "abc" }),
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [{ type: "tool_use", id: "tu_1", name: "Bash", input: { command: "ls" } }],
+        },
+      }),
+      JSON.stringify({ type: "user", message: { content: [{ type: "tool_result" }] } }),
+      JSON.stringify({ type: "result", subtype: "success", duration_ms: 1234 }),
+    ];
+
+    expect(parse_triage_verdict(lines)).toBeNull();
+  });
+
+  it("scans stream-json lines in reverse — last verdict wins", () => {
+    const earlier = {
+      type: "assistant",
+      message: {
+        content: [
+          {
+            type: "text",
+            text: 'First pass.\nSENTRY_TRIAGE_VERDICT:{"severity":"P1","auto_fixable":false,"github_issue":1,"fix_approach":"draft"}',
+          },
+        ],
+      },
+    };
+    const later = {
+      type: "assistant",
+      message: {
+        content: [
+          {
+            type: "text",
+            text: 'Final answer.\nSENTRY_TRIAGE_VERDICT:{"severity":"P2","auto_fixable":true,"github_issue":2,"fix_approach":"final"}',
+          },
+        ],
+      },
+    };
+
+    const verdict = parse_triage_verdict([JSON.stringify(earlier), JSON.stringify(later)]);
+
+    expect(verdict).toEqual({
+      severity: "P2",
+      auto_fixable: true,
+      github_issue: 2,
+      fix_approach: "final",
+    });
+  });
+
+  it("falls back to plain-line parsing when output_lines mix non-JSON and stream-json", () => {
+    // Defensive: if the marker happens to land on a plain (non-JSON) line,
+    // the legacy indexOf path must still find it.
+    const lines = [
+      JSON.stringify({ type: "system", subtype: "init" }),
+      'SENTRY_TRIAGE_VERDICT:{"severity":"P0","auto_fixable":false,"github_issue":7,"fix_approach":null}',
+    ];
+
+    expect(parse_triage_verdict(lines)).toEqual({
+      severity: "P0",
+      auto_fixable: false,
+      github_issue: 7,
+      fix_approach: null,
+    });
+  });
+
+  it("walks multiple text blocks in a single assistant message", () => {
+    // Some assistant messages contain multiple text blocks (e.g. when the model
+    // emits text, tool_use, then more text). The verdict can be in any of them.
+    const event = {
+      type: "assistant",
+      message: {
+        content: [
+          { type: "text", text: "Initial framing." },
+          { type: "tool_use", id: "tu_1", name: "Read", input: { file_path: "/x" } },
+          {
+            type: "text",
+            text: 'Conclusion.\nSENTRY_TRIAGE_VERDICT:{"severity":"P1","auto_fixable":true,"github_issue":50,"fix_approach":"patch up"}',
+          },
+        ],
+      },
+    };
+
+    expect(parse_triage_verdict([JSON.stringify(event)])).toEqual({
+      severity: "P1",
+      auto_fixable: true,
+      github_issue: 50,
+      fix_approach: "patch up",
+    });
+  });
 });
 
 // ── Auto-fix spawning tests (#250) ──

--- a/packages/daemon/src/sentry-triage.ts
+++ b/packages/daemon/src/sentry-triage.ts
@@ -283,61 +283,124 @@ export interface TriageVerdict {
 const VERDICT_MARKER = "SENTRY_TRIAGE_VERDICT:";
 
 /**
+ * Validate and shape a parsed verdict payload. Returns null if any required
+ * field is missing or the wrong type. Same rules as the original parser.
+ */
+function validate_verdict(parsed: unknown): TriageVerdict | null {
+  if (!parsed || typeof parsed !== "object") return null;
+  const obj = parsed as Record<string, unknown>;
+
+  const severity = obj.severity;
+  if (severity !== "P0" && severity !== "P1" && severity !== "P2") return null;
+
+  if (typeof obj.auto_fixable !== "boolean") return null;
+
+  // github_issue must be null/undefined or a number — reject other types
+  if (
+    obj.github_issue !== null &&
+    obj.github_issue !== undefined &&
+    typeof obj.github_issue !== "number"
+  ) {
+    return null;
+  }
+  const github_issue = typeof obj.github_issue === "number" ? obj.github_issue : null;
+
+  const fix_approach = typeof obj.fix_approach === "string" ? obj.fix_approach : null;
+
+  return {
+    severity,
+    auto_fixable: obj.auto_fixable,
+    github_issue,
+    fix_approach,
+  };
+}
+
+/**
+ * Extract the verdict from a string that contains the marker. Slices from the
+ * marker, trims, and JSON.parses the trailing object literal. Returns null on
+ * any parse or validation failure.
+ */
+function extract_verdict_from_text(text: string): TriageVerdict | null {
+  // Use lastIndexOf so a verdict appearing after other (possibly verdict-shaped)
+  // text in the same string still wins — last marker is the authoritative one.
+  const marker_idx = text.lastIndexOf(VERDICT_MARKER);
+  if (marker_idx === -1) return null;
+
+  const json_str = text.slice(marker_idx + VERDICT_MARKER.length).trim();
+  try {
+    return validate_verdict(JSON.parse(json_str));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Stream-JSON event shape we care about. The Claude CLI emits one JSON event
+ * per line on stdout (see session.ts: `--output-format stream-json`); assistant
+ * messages carry the verdict inside `.message.content[].text`.
+ */
+interface StreamJsonAssistantEvent {
+  type: "assistant";
+  message?: {
+    content?: Array<{ type?: string; text?: string }>;
+  };
+}
+
+/**
  * Parse a structured verdict from Ray's triage output.
  *
- * Searches output_lines in reverse for the SENTRY_TRIAGE_VERDICT: marker,
- * then parses the JSON payload after it. Returns null on any failure
- * (missing marker, malformed JSON, missing required fields).
+ * Output capture path: session.ts spawns the Claude CLI with
+ * `--output-format stream-json`, so each line in `output_lines` is a JSON
+ * envelope like:
+ *   {"type":"assistant","message":{"content":[{"type":"text","text":"…SENTRY_TRIAGE_VERDICT:{…}"}]}}
  *
- * Null = no auto-fix = safe fallback.
+ * Strategy (per #316):
+ *   1. For each line (scanned in reverse — verdicts arrive last), try to parse
+ *      it as a stream-json event. If it's an assistant message, walk the
+ *      content blocks, pull `.text` from each text block, and look for the
+ *      verdict marker in those (already-unescaped) strings.
+ *   2. If the line is NOT valid JSON, fall back to the legacy plain-line
+ *      `indexOf` path. This preserves behavior for non-stream-json captures
+ *      (test fixtures, future capture-format changes).
+ *
+ * Null = no auto-fix = safe fallback (same contract as before).
  */
 export function parse_triage_verdict(output_lines: string[] | undefined): TriageVerdict | null {
   if (!output_lines || output_lines.length === 0) return null;
 
-  // Search in reverse — the verdict should be the last thing Ray outputs
   for (let i = output_lines.length - 1; i >= 0; i--) {
     const line = output_lines[i]!;
-    const marker_idx = line.indexOf(VERDICT_MARKER);
-    if (marker_idx === -1) continue;
 
-    const json_str = line.slice(marker_idx + VERDICT_MARKER.length).trim();
+    // Path 1: try stream-json envelope first.
+    let parsed_envelope: unknown;
     try {
-      const parsed = JSON.parse(json_str) as Record<string, unknown>;
-
-      // Validate required fields
-      const severity = parsed.severity;
-      if (severity !== "P0" && severity !== "P1" && severity !== "P2") return null;
-
-      if (typeof parsed.auto_fixable !== "boolean") return null;
-
-      const github_issue =
-        parsed.github_issue === null || parsed.github_issue === undefined
-          ? null
-          : typeof parsed.github_issue === "number"
-            ? parsed.github_issue
-            : null;
-
-      // github_issue must be null or a number — reject other types
-      if (
-        parsed.github_issue !== null &&
-        parsed.github_issue !== undefined &&
-        typeof parsed.github_issue !== "number"
-      ) {
-        return null;
-      }
-
-      const fix_approach = typeof parsed.fix_approach === "string" ? parsed.fix_approach : null;
-
-      return {
-        severity,
-        auto_fixable: parsed.auto_fixable,
-        github_issue,
-        fix_approach,
-      };
+      parsed_envelope = JSON.parse(line);
     } catch {
-      // Malformed JSON — safe fallback
-      return null;
+      parsed_envelope = undefined;
     }
+
+    if (parsed_envelope && typeof parsed_envelope === "object") {
+      const event = parsed_envelope as StreamJsonAssistantEvent;
+      if (event.type === "assistant") {
+        const blocks = event.message?.content ?? [];
+        // Walk text blocks in reverse — within a single message, the last
+        // text block holding the marker is authoritative (last-wins).
+        for (let b = blocks.length - 1; b >= 0; b--) {
+          const block = blocks[b];
+          if (!block || block.type !== "text" || typeof block.text !== "string") continue;
+          const verdict = extract_verdict_from_text(block.text);
+          if (verdict) return verdict;
+        }
+      }
+      // Stream-json line that wasn't an assistant text-bearing event (system,
+      // tool_use, tool_result, result, etc.) — skip without falling through to
+      // the plain-line path. The marker shouldn't appear in those.
+      continue;
+    }
+
+    // Path 2: legacy plain-line fallback (preserves pre-stream-json fixtures).
+    const verdict = extract_verdict_from_text(line);
+    if (verdict) return verdict;
   }
 
   return null;


### PR DESCRIPTION
## Summary

`parse_triage_verdict()` was running `indexOf(VERDICT_MARKER)` against the raw line captured from the Claude CLI. Since the CLI is invoked with `--output-format stream-json` (`session.ts:212`), each captured stdout line is actually a JSON envelope whose `.message.content[].text` carries the verdict — with every double quote escaped. `indexOf` found the marker, then `JSON.parse` choked on the still-escaped payload + trailing wrapper bytes, the `try/catch` swallowed it, and every triage in the past day silently fell back to "no verdict parsed". The auto-fix Bob handoff has been dead the whole time.

## Fix

`parse_triage_verdict()` now:

1. Tries `JSON.parse(line)` first. If the line is a `{type: "assistant"}` event, walks `message.content[]` and searches the *unescaped* `.text` of each text block for the marker. Slices, trims, `JSON.parse`s the payload, runs the existing field validation.
2. Falls back to the legacy plain-line `indexOf` path when a line is not valid JSON — preserves behavior for non-stream-json captures and the existing test fixtures.

Reverse scan + last-marker-wins semantics unchanged. No prompt changes, no marker changes, no session-manager changes.

## Test plan

- [x] All 64 existing `sentry-triage.test.ts` tests still pass
- [x] All 1111 daemon tests still pass
- [x] Typecheck clean (`tsc --noEmit`)
- [x] Biome lint clean
- [x] New cases added: stream-json assistant text block, marker preceded by other content, multi-line text with marker on final line, non-assistant events (system/tool_use/result) skipped silently, reverse-scan across multiple stream-json lines, mixed plain + stream-json fallback, multiple text blocks within one assistant message
- [x] Replayed real failing fixtures locally — sessions `922845b0`, `636f8164`, `292905f3`, `fd487e00` from sonar's failure window. `922845b0` returns `{severity: "P2", auto_fixable: false, github_issue: 265, fix_approach: "On cold cache..."}` exactly as the spec requires.

Closes #316