### PR TITLE
fix(commander): daemon-managed allowlist for Pat across multiple channels

### DIFF
--- a/packages/daemon/src/__tests__/commander-allowlist.test.ts
+++ b/packages/daemon/src/__tests__/commander-allowlist.test.ts
@@ -1,0 +1,458 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
+import type { LobsterFarmConfig } from "@lobster-farm/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock discord.js so DiscordBot can be instantiated without a live websocket.
+vi.mock("discord.js", async () => {
+  const actual = await vi.importActual<typeof import("discord.js")>("discord.js");
+  return {
+    ...actual,
+    Client: vi.fn().mockImplementation(() => ({
+      on: vi.fn(),
+      once: vi.fn(),
+      login: vi.fn(),
+      destroy: vi.fn(),
+      user: null,
+      channels: { fetch: vi.fn() },
+      guilds: { fetch: vi.fn() },
+      application: null,
+    })),
+  };
+});
+
+import { CommanderProcess } from "../commander-process.js";
+import { DiscordBot } from "../discord.js";
+import { EntityRegistry } from "../registry.js";
+
+/**
+ * The CommanderProcess writes to `<lobsterfarm_dir>/channels/pat/access.json`.
+ * Tests redirect lobsterfarm_dir to a fresh tmp dir so the real
+ * `~/.lobsterfarm/channels/pat/access.json` is never touched.
+ */
+function make_config(args: { user_id?: string; lobsterfarm_dir: string }): LobsterFarmConfig {
+  return LobsterFarmConfigSchema.parse({
+    user: { name: "Test" },
+    discord: args.user_id
+      ? { server_id: "111222333", user_id: args.user_id }
+      : { server_id: "111222333" },
+    paths: { lobsterfarm_dir: args.lobsterfarm_dir },
+  });
+}
+
+describe("CommanderProcess.ensure_channel_allowlisted", () => {
+  let tmp_dir: string;
+  let pat_dir: string;
+  let access_path: string;
+
+  beforeEach(async () => {
+    tmp_dir = join(tmpdir(), `commander-allowlist-test-${randomUUID()}`);
+    pat_dir = join(tmp_dir, "channels", "pat");
+    access_path = join(pat_dir, "access.json");
+    await mkdir(pat_dir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tmp_dir, { recursive: true }).catch(() => {});
+  });
+
+  it("seeds a full default access.json when the file is missing", async () => {
+    const commander = new CommanderProcess(
+      make_config({ user_id: "owner-1", lobsterfarm_dir: tmp_dir }),
+    );
+
+    await commander.ensure_channel_allowlisted("chan-A");
+
+    const content = JSON.parse(await readFile(access_path, "utf-8"));
+    expect(content.dmPolicy).toBe("allowlist");
+    expect(content.allowFrom).toEqual([]);
+    expect(content.pending).toEqual({});
+    expect(content.groups["chan-A"]).toEqual({
+      requireMention: true,
+      allowFrom: ["owner-1"],
+    });
+  });
+
+  it("writes the new entry shape with requireMention=true and allowFrom=[owner_id]", async () => {
+    const commander = new CommanderProcess(
+      make_config({ user_id: "owner-2", lobsterfarm_dir: tmp_dir }),
+    );
+
+    // Seed an existing access.json to verify additive behavior on a real file.
+    await writeFile(
+      access_path,
+      JSON.stringify({
+        dmPolicy: "allowlist",
+        allowFrom: ["owner-2"],
+        groups: {
+          "canonical-channel": { requireMention: false, allowFrom: [] },
+        },
+        pending: {},
+        ackReaction: "👀",
+        replyToMode: "first",
+        textChunkLimit: 2000,
+        chunkMode: "newline",
+      }),
+    );
+
+    await commander.ensure_channel_allowlisted("new-channel");
+
+    const content = JSON.parse(await readFile(access_path, "utf-8"));
+    // Existing entry preserved
+    expect(content.groups["canonical-channel"]).toEqual({
+      requireMention: false,
+      allowFrom: [],
+    });
+    // New entry has the spec'd shape
+    expect(content.groups["new-channel"]).toEqual({
+      requireMention: true,
+      allowFrom: ["owner-2"],
+    });
+    // Optional fields preserved verbatim
+    expect(content.ackReaction).toBe("👀");
+    expect(content.replyToMode).toBe("first");
+    expect(content.textChunkLimit).toBe(2000);
+    expect(content.chunkMode).toBe("newline");
+    expect(content.allowFrom).toEqual(["owner-2"]);
+  });
+
+  it("is a no-op when the channel is already in groups (no file mutation)", async () => {
+    const commander = new CommanderProcess(
+      make_config({ user_id: "owner-3", lobsterfarm_dir: tmp_dir }),
+    );
+
+    const initial = {
+      dmPolicy: "allowlist",
+      allowFrom: ["owner-3"],
+      groups: {
+        "already-here": { requireMention: false, allowFrom: [] },
+      },
+      pending: {},
+    };
+    const initial_json = JSON.stringify(initial, null, 2);
+    await writeFile(access_path, initial_json);
+    const stat_before = (await readFile(access_path, "utf-8")).length;
+
+    await commander.ensure_channel_allowlisted("already-here");
+
+    // Byte-equivalent — no rewrite happened. (If we had rewritten, the file
+    // would end with a trailing newline and use our normalized shape.)
+    const after = await readFile(access_path, "utf-8");
+    expect(after).toBe(initial_json);
+    expect(after.length).toBe(stat_before);
+    // And the existing entry is unchanged — requireMention NOT silently
+    // upgraded to true on an already-present channel.
+    const parsed = JSON.parse(after);
+    expect(parsed.groups["already-here"]).toEqual({
+      requireMention: false,
+      allowFrom: [],
+    });
+  });
+
+  it("moves a corrupt access.json aside and writes a fresh one", async () => {
+    const commander = new CommanderProcess(
+      make_config({ user_id: "owner-4", lobsterfarm_dir: tmp_dir }),
+    );
+
+    await writeFile(access_path, "{ this is not json");
+
+    await commander.ensure_channel_allowlisted("chan-X");
+
+    const fresh = JSON.parse(await readFile(access_path, "utf-8"));
+    expect(fresh.groups["chan-X"]).toEqual({
+      requireMention: true,
+      allowFrom: ["owner-4"],
+    });
+    expect(fresh.dmPolicy).toBe("allowlist");
+
+    // The corrupt file should still exist with the .corrupt-<ts> suffix.
+    const entries = await readdir(pat_dir);
+    const corrupt_files = entries.filter((e) => e.startsWith("access.json.corrupt-"));
+    expect(corrupt_files.length).toBe(1);
+  });
+
+  it("writes atomically via tmp + rename (no leftover tmp files)", async () => {
+    const commander = new CommanderProcess(
+      make_config({ user_id: "owner-5", lobsterfarm_dir: tmp_dir }),
+    );
+
+    await commander.ensure_channel_allowlisted("chan-1");
+    const entries = await readdir(pat_dir);
+    expect(entries).toContain("access.json");
+    // The tmp file uses a random suffix to avoid concurrent-write collisions;
+    // verify no stragglers landed in the dir.
+    expect(entries.filter((e) => e.startsWith("access.json.tmp")).length).toBe(0);
+  });
+
+  it("does not corrupt the file under concurrent calls (atomic rename)", async () => {
+    const commander = new CommanderProcess(
+      make_config({ user_id: "owner-6", lobsterfarm_dir: tmp_dir }),
+    );
+
+    // Fire 10 concurrent writes for distinct channels. The tmp+rename pattern
+    // means whichever goes last wins, but the file must always be valid JSON
+    // (no torn writes) and contain at least one of the channels.
+    const channels = Array.from({ length: 10 }, (_, i) => `chan-concurrent-${String(i)}`);
+    await Promise.all(channels.map((c) => commander.ensure_channel_allowlisted(c)));
+
+    const content = JSON.parse(await readFile(access_path, "utf-8"));
+    expect(content.dmPolicy).toBe("allowlist");
+    // At least one channel landed. We don't assert all 10 because read-modify-
+    // write under concurrency is last-write-wins; the goal of this test is
+    // "no corruption" not "no lost updates" — that's a documented caveat of
+    // the additive-allowlist design.
+    const present = channels.filter((c) => content.groups[c]);
+    expect(present.length).toBeGreaterThanOrEqual(1);
+    for (const c of present) {
+      expect(content.groups[c]).toEqual({
+        requireMention: true,
+        allowFrom: ["owner-6"],
+      });
+    }
+  });
+
+  it("is a no-op when no owner_id is configured (does not create access.json)", async () => {
+    const commander = new CommanderProcess(
+      make_config({ lobsterfarm_dir: tmp_dir }), // no user_id
+    );
+
+    await commander.ensure_channel_allowlisted("chan-Z");
+
+    const entries = await readdir(pat_dir);
+    expect(entries).not.toContain("access.json");
+  });
+
+  it("does not mutate already-allowlisted channels even if owner_id changed", async () => {
+    // Defense check: ensure_channel_allowlisted must NOT update allowFrom on
+    // an already-present entry. Pruning stays a manual operation.
+    const commander = new CommanderProcess(
+      make_config({ user_id: "new-owner", lobsterfarm_dir: tmp_dir }),
+    );
+    await writeFile(
+      access_path,
+      JSON.stringify({
+        dmPolicy: "allowlist",
+        allowFrom: ["new-owner"],
+        groups: {
+          "old-channel": { requireMention: true, allowFrom: ["old-owner"] },
+        },
+        pending: {},
+      }),
+    );
+
+    await commander.ensure_channel_allowlisted("old-channel");
+
+    const content = JSON.parse(await readFile(access_path, "utf-8"));
+    expect(content.groups["old-channel"]).toEqual({
+      requireMention: true,
+      allowFrom: ["old-owner"],
+    });
+  });
+
+  it("preserves all pre-existing groups across a write (additive only)", async () => {
+    const commander = new CommanderProcess(
+      make_config({ user_id: "owner-7", lobsterfarm_dir: tmp_dir }),
+    );
+    await writeFile(
+      access_path,
+      JSON.stringify({
+        dmPolicy: "allowlist",
+        allowFrom: ["owner-7"],
+        groups: {
+          "canonical-1": { requireMention: false, allowFrom: [] },
+          "canonical-2": { requireMention: true, allowFrom: ["someone-else"] },
+        },
+        pending: {},
+      }),
+    );
+
+    await commander.ensure_channel_allowlisted("third-channel");
+
+    const content = JSON.parse(await readFile(access_path, "utf-8"));
+    expect(Object.keys(content.groups).sort()).toEqual([
+      "canonical-1",
+      "canonical-2",
+      "third-channel",
+    ]);
+    expect(content.groups["canonical-1"]).toEqual({ requireMention: false, allowFrom: [] });
+    expect(content.groups["canonical-2"]).toEqual({
+      requireMention: true,
+      allowFrom: ["someone-else"],
+    });
+  });
+});
+
+// ── handle_message integration ──
+//
+// These tests verify the trigger gating in DiscordBot.handle_message:
+// only owner-authored messages in non-pool, non-command-center channels
+// reach ensure_channel_allowlisted.
+
+/** Minimal Discord Message stand-in. handle_message reads only these fields. */
+interface FakeMessage {
+  author: { bot: boolean; id: string; displayName: string };
+  channelId: string;
+  id: string;
+  content: string;
+  createdTimestamp: number;
+}
+
+function fake_message(opts: {
+  author_id: string;
+  channel_id: string;
+  bot?: boolean;
+  content?: string;
+}): FakeMessage {
+  return {
+    author: {
+      bot: opts.bot ?? false,
+      id: opts.author_id,
+      displayName: "tester",
+    },
+    channelId: opts.channel_id,
+    id: "msg-1",
+    content: opts.content ?? "hi",
+    createdTimestamp: Date.now(),
+  };
+}
+
+/**
+ * Test subclass that exposes handle_message and stubs the side effects we
+ * don't care about (typing loop, status embeds, command center lookup).
+ */
+class TestDiscordBot extends DiscordBot {
+  command_center_id: string | null = null;
+
+  async invoke_handle_message(msg: FakeMessage): Promise<void> {
+    await (this as unknown as { handle_message: (m: FakeMessage) => Promise<void> }).handle_message(
+      msg,
+    );
+  }
+
+  // No-op the side effects so handle_message can run headless.
+  override start_commander_typing_loop(): void {}
+  override async find_command_center_channel(): Promise<string | null> {
+    return this.command_center_id;
+  }
+  protected async send_status_embed(): Promise<void> {
+    // private in the real class — silence it with a structural override.
+  }
+}
+
+describe("DiscordBot.handle_message — Pat allowlist trigger", () => {
+  let tmp_dir: string;
+
+  beforeEach(async () => {
+    tmp_dir = join(tmpdir(), `discord-allowlist-test-${randomUUID()}`);
+    await mkdir(tmp_dir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tmp_dir, { recursive: true }).catch(() => {});
+  });
+
+  function make_bot(user_id: string | undefined): TestDiscordBot {
+    const config = make_config({ user_id, lobsterfarm_dir: tmp_dir });
+    const registry = new EntityRegistry(config);
+    return new TestDiscordBot(config, registry);
+  }
+
+  it("calls ensure_channel_allowlisted for owner messages in unmapped channels", async () => {
+    const bot = make_bot("owner-id");
+    const ensure = vi.fn().mockResolvedValue(undefined);
+    bot.set_commander({
+      ensure_channel_allowlisted: ensure,
+    } as unknown as CommanderProcess);
+
+    await bot.invoke_handle_message(
+      fake_message({ author_id: "owner-id", channel_id: "stray-channel" }),
+    );
+
+    expect(ensure).toHaveBeenCalledTimes(1);
+    expect(ensure).toHaveBeenCalledWith("stray-channel");
+  });
+
+  it("does not call ensure_channel_allowlisted for non-owner messages", async () => {
+    const bot = make_bot("owner-id");
+    const ensure = vi.fn().mockResolvedValue(undefined);
+    bot.set_commander({
+      ensure_channel_allowlisted: ensure,
+    } as unknown as CommanderProcess);
+
+    await bot.invoke_handle_message(
+      fake_message({ author_id: "someone-else", channel_id: "stray-channel" }),
+    );
+
+    expect(ensure).not.toHaveBeenCalled();
+  });
+
+  it("does not call ensure_channel_allowlisted in the command-center channel", async () => {
+    const bot = make_bot("owner-id");
+    bot.command_center_id = "cc-1";
+    const ensure = vi.fn().mockResolvedValue(undefined);
+    bot.set_commander({
+      ensure_channel_allowlisted: ensure,
+    } as unknown as CommanderProcess);
+
+    await bot.invoke_handle_message(fake_message({ author_id: "owner-id", channel_id: "cc-1" }));
+
+    expect(ensure).not.toHaveBeenCalled();
+  });
+
+  it("does not call ensure_channel_allowlisted when commander is not wired", async () => {
+    const bot = make_bot("owner-id");
+    // No set_commander call — _commander stays null.
+
+    // No throw expected. The call simply no-ops.
+    await bot.invoke_handle_message(
+      fake_message({ author_id: "owner-id", channel_id: "stray-channel" }),
+    );
+    // Nothing to assert on the mock — the absence of a crash is the test.
+  });
+
+  it("does not call ensure_channel_allowlisted when owner_id is not configured", async () => {
+    const bot = make_bot(undefined);
+    const ensure = vi.fn().mockResolvedValue(undefined);
+    bot.set_commander({
+      ensure_channel_allowlisted: ensure,
+    } as unknown as CommanderProcess);
+
+    await bot.invoke_handle_message(
+      fake_message({ author_id: "anyone", channel_id: "stray-channel" }),
+    );
+
+    expect(ensure).not.toHaveBeenCalled();
+  });
+
+  it("does not call ensure_channel_allowlisted for bot-authored messages", async () => {
+    const bot = make_bot("owner-id");
+    const ensure = vi.fn().mockResolvedValue(undefined);
+    bot.set_commander({
+      ensure_channel_allowlisted: ensure,
+    } as unknown as CommanderProcess);
+
+    await bot.invoke_handle_message(
+      fake_message({ author_id: "owner-id", channel_id: "stray-channel", bot: true }),
+    );
+
+    expect(ensure).not.toHaveBeenCalled();
+  });
+
+  it("swallows ensure_channel_allowlisted failures without throwing", async () => {
+    const bot = make_bot("owner-id");
+    const ensure = vi.fn().mockRejectedValue(new Error("disk full"));
+    bot.set_commander({
+      ensure_channel_allowlisted: ensure,
+    } as unknown as CommanderProcess);
+
+    await expect(
+      bot.invoke_handle_message(
+        fake_message({ author_id: "owner-id", channel_id: "stray-channel" }),
+      ),
+    ).resolves.toBeUndefined();
+    expect(ensure).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/daemon/src/commander-process.ts
+++ b/packages/daemon/src/commander-process.ts
@@ -1,7 +1,7 @@
 import { execFileSync, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
-import { readFile, unlink, writeFile } from "node:fs/promises";
+import { readFile, rename, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { LobsterFarmConfig } from "@lobster-farm/shared";
@@ -24,6 +24,66 @@ const BACKOFF_SCHEDULE = [0, 5_000, 15_000, 60_000, 300_000];
 const BACKOFF_RESET_MS = 10 * 60 * 1000; // 10 min stable → reset counter
 const MAX_RESTARTS = 5;
 const HEALTH_INTERVAL_MS = 10_000; // check every 10s
+
+/** Shape of Pat's access.json. Mirrors the Discord plugin's Access type
+ *  (server.ts:105-121). Fields beyond the defaults are optional — we
+ *  preserve any that exist on disk and never invent values for them. */
+interface PatGroupPolicy {
+  requireMention: boolean;
+  allowFrom: string[];
+}
+interface PatAccess {
+  dmPolicy: "pairing" | "allowlist" | "disabled";
+  allowFrom: string[];
+  groups: Record<string, PatGroupPolicy>;
+  pending: Record<string, unknown>;
+  mentionPatterns?: string[];
+  ackReaction?: string;
+  replyToMode?: "off" | "first" | "all";
+  textChunkLimit?: number;
+  chunkMode?: "length" | "newline";
+}
+
+/**
+ * Default access.json shape used when seeding a missing or corrupt file.
+ *
+ * `dmPolicy: 'allowlist'` matches the existing pat/access.json on disk
+ * and the daemon's single-user trust model. The plugin's own default is
+ * `'pairing'` (server.ts:123-130), but the commander runs in a context
+ * where the owner is already known via config.discord.user_id, so seeding
+ * `'allowlist'` here avoids a no-op pairing-code dance on first DM.
+ */
+function default_access(): PatAccess {
+  return {
+    dmPolicy: "allowlist",
+    allowFrom: [],
+    groups: {},
+    pending: {},
+  };
+}
+
+/**
+ * Normalize a parsed access.json so downstream code can mutate it safely.
+ *
+ * Defaults are applied for the required fields only — optional fields
+ * (mentionPatterns, ackReaction, replyToMode, textChunkLimit, chunkMode)
+ * are preserved when present and left undefined when absent. The plugin
+ * fills in its own runtime defaults for those, so we don't bake any in
+ * that could drift.
+ */
+function normalize_access(parsed: Partial<PatAccess>): PatAccess {
+  return {
+    dmPolicy: parsed.dmPolicy ?? "allowlist",
+    allowFrom: parsed.allowFrom ?? [],
+    groups: parsed.groups ?? {},
+    pending: parsed.pending ?? {},
+    mentionPatterns: parsed.mentionPatterns,
+    ackReaction: parsed.ackReaction,
+    replyToMode: parsed.replyToMode,
+    textChunkLimit: parsed.textChunkLimit,
+    chunkMode: parsed.chunkMode,
+  };
+}
 
 /**
  * Manages a persistent Claude Code session connected to Discord via the
@@ -75,6 +135,96 @@ export class CommanderProcess extends EventEmitter {
     } catch {
       /* ignore — file may not exist */
     }
+  }
+
+  /** Path to Pat's Discord plugin allowlist. */
+  private access_json_path(): string {
+    return join(this.state_dir(), "access.json");
+  }
+
+  /**
+   * Idempotently add a channel to Pat's `access.json.groups`.
+   *
+   * Pat's plugin gates inbound messages by `groups[channelId]`. When the
+   * daemon's bot sees the owner post in a channel Pat hasn't been keyed to,
+   * we add the channel here so a follow-up @-mention of Pat is delivered
+   * instead of dropped. `requireMention: true` keeps Pat silent unless pinged
+   * — the allowlist entry only authorizes delivery, it doesn't make Pat chatty.
+   *
+   * Additive only: existing `groups` entries are preserved across writes.
+   * The pool's `write_access_json` overwrite pattern would clobber Pat's
+   * canonical channel and is intentionally not reused here.
+   *
+   * No-op when the channel is already present (no file write, no log noise).
+   * Tolerates ENOENT (seeds full default access.json) and corrupt JSON
+   * (moves the bad file aside, mirroring the plugin's `readAccessFile`).
+   */
+  async ensure_channel_allowlisted(channel_id: string): Promise<void> {
+    const owner_id = this.config.discord?.user_id;
+    if (!owner_id) {
+      // No owner configured — silently skip. Adding an entry with an empty
+      // allowFrom would leave the group open to any sender, which is the
+      // wrong default in single-user trust mode.
+      return;
+    }
+
+    const target = this.access_json_path();
+    let access: PatAccess;
+    try {
+      const raw = await readFile(target, "utf-8");
+      try {
+        const parsed = JSON.parse(raw) as Partial<PatAccess>;
+        access = normalize_access(parsed);
+      } catch {
+        // Corrupt file. Move aside and seed defaults. Mirrors the plugin's
+        // readAccessFile recovery (server.ts:166-171) so the daemon and the
+        // plugin agree on what to do with a broken file.
+        try {
+          await rename(target, `${target}.corrupt-${String(Date.now())}`);
+        } catch {
+          /* ignore — best effort */
+        }
+        console.warn("[commander] access.json was corrupt, moved aside. Starting fresh.");
+        access = default_access();
+      }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+      access = default_access();
+    }
+
+    if (access.groups[channel_id]) {
+      // Already allowlisted — no-op. Skipping the write here is what makes
+      // the trigger in handle_message safe to call on every owner message.
+      return;
+    }
+
+    access.groups[channel_id] = {
+      requireMention: true,
+      allowFrom: [owner_id],
+    };
+
+    // Atomic write: tmp + rename, mode 0600. Matches the plugin's saveAccess
+    // (server.ts:195-201) so a torn write never leaves the plugin staring at
+    // a half-written file. The tmp suffix is per-call random so concurrent
+    // ensure_channel_allowlisted() calls don't race on a shared tmp path —
+    // each writer's rename is independent. Last writer wins on the final
+    // file (acceptable: the additive design accepts read-modify-write
+    // last-write-wins; the next call retries any lost update).
+    const tmp = `${target}.tmp.${randomUUID()}`;
+    try {
+      await writeFile(tmp, `${JSON.stringify(access, null, 2)}\n`, { mode: 0o600 });
+      await rename(tmp, target);
+    } catch (err) {
+      // Best-effort cleanup so a failed rename doesn't leave litter behind.
+      try {
+        await unlink(tmp);
+      } catch {
+        /* ignore */
+      }
+      throw err;
+    }
+
+    console.log(`[commander] Allowlisted channel ${channel_id} for Pat`);
   }
 
   /** Check if Pat's bot token is configured. */

--- a/packages/daemon/src/discord.ts
+++ b/packages/daemon/src/discord.ts
@@ -38,6 +38,7 @@ import {
   type TextChannel,
   type Webhook,
 } from "discord.js";
+import type { CommanderProcess } from "./commander-process.js";
 import { PAT_TMUX_SESSION } from "./commander-process.js";
 import { is_tmux_session_idle } from "./pool.js";
 import type { BotPool, PoolBot } from "./pool.js";
@@ -2430,10 +2431,21 @@ export class DiscordBot extends EventEmitter {
   }
 
   private _pool: BotPool | null = null;
+  private _commander: CommanderProcess | null = null;
 
   set_managers(_queue: TaskQueue): void {
     // Queue wiring deferred — will be used for slash-command task submission
     console.debug("[discord] set_managers called — queue wiring not yet implemented");
+  }
+
+  /**
+   * Wire the CommanderProcess so handle_message can keep Pat's access.json
+   * in sync when the owner posts in a daemon-watched channel that isn't a
+   * pool work room. See `ensure_channel_allowlisted` for the additive
+   * allowlist semantics. Issue #318.
+   */
+  set_commander(commander: CommanderProcess): void {
+    this._commander = commander;
   }
 
   set_pool(pool: BotPool): void {
@@ -2489,6 +2501,32 @@ export class DiscordBot extends EventEmitter {
       this.start_commander_typing_loop(message.channelId);
       void this.send_status_embed(message.channelId, "commander");
       return;
+    }
+
+    // Owner-authored message in a non-pool, non-command-center channel that
+    // the daemon's bot can see. Ensure Pat's allowlist contains this channel
+    // so a follow-up @-mention of Pat is delivered by the plugin's gate
+    // instead of dropped. Idempotent: skips on channels already allowlisted.
+    // Issue #318.
+    if (!entry && this._commander) {
+      const owner_id = this.config.discord?.user_id;
+      if (owner_id && message.author.id === owner_id) {
+        try {
+          await this._commander.ensure_channel_allowlisted(message.channelId);
+        } catch (err) {
+          // Don't let an allowlist write failure derail message handling for
+          // the rest of the daemon. Log + Sentry; the next owner message in
+          // the same channel will retry.
+          console.error(
+            `[discord] Failed to allowlist channel for Pat: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+          sentry.captureException(err, {
+            tags: { module: "discord", action: "ensure_channel_allowlisted" },
+          });
+        }
+      }
     }
 
     // Unmapped channels: ignore everything.

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -220,6 +220,15 @@ async function main(): Promise<void> {
 
   // Initialize Commander (persistent Claude Code session with Discord channel)
   const commander = new CommanderProcess(config);
+
+  // Wire commander into discord so handle_message can keep Pat's access.json
+  // in sync when the owner posts in non-pool channels (issue #318). Safe even
+  // when commander has no token — ensure_channel_allowlisted only runs on
+  // owner-authored messages that miss every other branch.
+  if (discord_connected) {
+    discord.set_commander(commander);
+  }
+
   if (await commander.has_token()) {
     try {
       await commander.start();


### PR DESCRIPTION
## Summary

- Adds `CommanderProcess.ensure_channel_allowlisted(channel_id)` — additive, idempotent, atomic. Reads existing `pat/access.json`, inserts a new `groups[channel_id]` entry with `requireMention: true` and `allowFrom: [owner_id]`, writes back via tmp + rename (mode 0600). Tolerates `ENOENT` (seeds defaults) and corrupt JSON (moves aside, mirroring the plugin's `readAccessFile`). Per-call random tmp suffix so concurrent writers don't race on rename.
- Hooks into `DiscordBot.handle_message`: when an owner-authored message lands in an unmapped channel that isn't the command-center, the daemon ensures that channel is on Pat's allowlist so the follow-up @-mention is delivered by the plugin's gate instead of dropped. Gated on `message.author.id === config.discord.user_id` — non-owner messages, bot messages, and command-center messages are unaffected.
- Wires `_commander` into `DiscordBot` analogously to `_pool` (`set_commander` setter, called from `index.ts` once the Discord bot is connected).

The pool's `write_access_json` is intentionally not reused — that pattern overwrites the entire file with a single channel, which would knock Pat's canonical command-center entry out of `groups` on every summon. This implementation preserves all pre-existing entries across writes.

## Why this is safe

The plugin author's "never edit access.json from agent input" warning (server.ts:461) is about agents mutating the file based on Discord-channel content. The daemon is OS-level orchestration code (it already manages `access.json` for pool bots) and the trigger gates on the configured owner ID. The new entry uses `requireMention: true` so even a stray allowlisted channel cannot make Pat speak unprompted.

## Caveat

Only works in channels where the daemon's bot is present. For ad-hoc DMs and foreign-server channels the daemon doesn't watch, the existing `/discord:access` pairing flow remains the answer.

**Activation requires a daemon restart** — Hunter or Karim should schedule.

## Test plan

- [x] 16 new unit tests in `packages/daemon/src/__tests__/commander-allowlist.test.ts` covering: missing-file seed, additive write, no-op when already allowlisted, no mutation of existing entries even on owner-id change, corrupt-file move-aside, atomic tmp+rename (no leftovers), concurrent write safety, no-op when no `owner_id` configured, full preservation of pre-existing groups, plus 7 `handle_message` gating tests (owner trigger, non-owner skip, command-center skip, no-commander skip, no-owner skip, bot-author skip, error swallow).
- [x] Full daemon suite: 1074/1074 pass.
- [x] `pnpm --filter @lobster-farm/daemon build` clean.
- [x] `tsc --noEmit` clean.
- [x] `biome check` clean.

## Manual verification (post-restart)

- [ ] Owner posts in a daemon-watched non-pool channel → `~/.lobsterfarm/channels/pat/access.json.groups` gains an entry with `requireMention: true` and `allowFrom: [owner_id]`.
- [ ] Subsequent `@Pat` mention in that channel is delivered (Pat replies).
- [ ] Pat does NOT speak unprompted in newly-allowlisted channels.
- [ ] Canonical channel (`1487620599609036866`) and any pre-existing entries remain intact across writes.

Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)