### PR TITLE
feat(hooks): block AskUserQuestion in Discord-bridged sessions

### DIFF
--- a/config/claude/agents/planner.md
+++ b/config/claude/agents/planner.md
@@ -23,3 +23,9 @@ Your specs are contracts. When {{BUILDER_NAME}} reads your GitHub issue, they sh
 You respect that implementation is expensive. Every feature you spec consumes real effort. You treat that budget like it's your own money — ruthlessly prioritizing what matters and cutting what doesn't.
 
 Casual. Curious. Sharp when it counts, warm when it matters. The kind of PM who makes the team better by asking the right questions at the right time.
+
+---
+
+## Discord-Bridged Sessions
+
+**Never call `AskUserQuestion` in Discord-bridged sessions.** The option picker is a local terminal UI and doesn't reach the user — it wedges the conversation. Send the question as a Discord reply with a numbered/lettered list and read the answer from the next inbound message.

--- a/config/claude/skills/coding-dna/SKILL.md
+++ b/config/claude/skills/coding-dna/SKILL.md
@@ -1076,6 +1076,12 @@ Loggers are configurable per-environment. In prod you want structured logs. In d
 
 ---
 
+## Communication
+
+**Never call `AskUserQuestion` in Discord-bridged sessions.** The option picker is a local terminal UI and doesn't reach the user — it wedges the conversation. Send the question as a Discord reply with a numbered/lettered list and read the answer from the next inbound message. (Enforced by the `block-askuserquestion-in-discord.py` PreToolUse hook, which detects bridged sessions via the `DISCORD_STATE_DIR` env var.)
+
+---
+
 ## Anti-Patterns — Things We Don't Do
 
 | Don't | Do Instead |

--- a/config/claude/skills/planning-dna/SKILL.md
+++ b/config/claude/skills/planning-dna/SKILL.md
@@ -143,6 +143,12 @@ Every task in a spec must be assigned to the correct agent. Never give work to t
 
 ---
 
+## Discord-Bridged Sessions
+
+**Never call `AskUserQuestion` in Discord-bridged sessions.** The option picker is a local terminal UI and doesn't reach the user — it wedges the conversation. Send the question as a Discord reply with a numbered/lettered list and read the answer from the next inbound message. (Enforced by the `block-askuserquestion-in-discord.py` PreToolUse hook, which detects bridged sessions via the `DISCORD_STATE_DIR` env var.)
+
+---
+
 ## Anti-Patterns
 
 - ❌ Specs that describe HOW to implement instead of WHAT to build — leave implementation to the Builder

--- a/config/hooks/README.md
+++ b/config/hooks/README.md
@@ -1,6 +1,6 @@
 # PreToolUse Hooks
 
-Claude Code hook scripts that run before tool invocations. Registered in `~/.claude/settings.json` under `hooks.PreToolUse` with a tool name matcher. Exit code 0 allows the tool call, exit code 2 blocks it with an error message on stderr.
+Claude Code hook scripts that run before tool invocations. Registered in `~/.claude/settings.json` under `hooks.PreToolUse` with a tool name matcher. Most hooks here are bash and use exit code 2 to block; `block-askuserquestion-in-discord.py` uses the structured JSON contract (`{"decision": "block", "reason": "..."}` on stdout, always exit 0) so the model receives the redirect message verbatim.
 
 ## Files
 
@@ -12,6 +12,8 @@ Claude Code hook scripts that run before tool invocations. Registered in `~/.cla
 
 - `entity-isolation.sh` -- Prevents cross-entity filesystem access for pool bot sessions. Identifies the session's self-entity from `CLAUDE_PROJECT_DIR` (or the hook input `cwd` as a fallback), enumerates sibling entities under `~/.lobsterfarm/entities/`, and blocks Bash commands or Read/Edit/Write/NotebookEdit file paths that reference another entity. Fails open for platform-level sessions (e.g., Pat) that aren't scoped to an entity, when no sibling entities exist, and when jq is missing or input is malformed. Deployed to `~/.claude/hooks/` by `lf init` and registered in `~/.claude/settings.json` with matcher `Bash|Read|Edit|Write|NotebookEdit`.
 
+- `block-askuserquestion-in-discord.py` -- Blocks the `AskUserQuestion` tool in Discord-bridged sessions. Detection signal is the `DISCORD_STATE_DIR` env var, which the daemon exports for pool bots, Pat, and channel-bound Gary tmux sessions. When both conditions match (tool name is `AskUserQuestion` AND `DISCORD_STATE_DIR` is set), the hook prints a structured block decision whose `reason` redirects the model to `mcp__plugin_discord_discord__reply` — Claude Code shows this message to the model as the tool result. Registered with matcher `AskUserQuestion`. Fails open (allows the call) on empty/malformed stdin, missing/non-string tool_name, and any unexpected exception — a crashing global hook would freeze every Claude session on this machine, so silent allow is the only safe failure mode.
+
 ### tests/
 
 - `test-scan-bash-secrets.sh` -- Test suite for the Bash secret scanner. Exercises each pattern category with both positive (should block) and negative (should allow) cases.
@@ -21,3 +23,5 @@ Claude Code hook scripts that run before tool invocations. Registered in `~/.cla
 - `test-protect-branch.sh` -- Test suite for the branch protector. Tests blocking on main/master, allowing on feature branches, files outside repo, and fail-open edge cases.
 
 - `test-entity-isolation.sh` -- Test suite for the entity isolation hook. Uses a fake `HOME` with multiple entity directories to cover same-entity allowed, cross-entity blocked (Bash + Read/Edit/Write/NotebookEdit), platform-level sessions allowed, `CLAUDE_PROJECT_DIR` vs `cwd` fallback, and fail-open edge cases (empty/malformed stdin, missing fields, missing jq).
+
+- `test-block-askuserquestion-in-discord.sh` -- Test suite for the AskUserQuestion blocker. Covers the block path (Discord-bridged + AskUserQuestion), allow paths (other tools, no DISCORD_STATE_DIR, the discord reply tool itself), and the P0 fail-open contract on every form of malformed input (empty/whitespace stdin, non-JSON, JSON non-objects, empty objects, missing/null/non-string `tool_name`, empty `DISCORD_STATE_DIR` string).

--- a/config/hooks/block-askuserquestion-in-discord.py
+++ b/config/hooks/block-askuserquestion-in-discord.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""block-askuserquestion-in-discord.py — PreToolUse hook.
+
+Blocks `AskUserQuestion` tool calls in Discord-bridged Claude Code sessions.
+Discord-bridged sessions are detected by the presence of the `DISCORD_STATE_DIR`
+environment variable, which the LobsterFarm daemon exports when spawning pool
+bot, Pat, and channel-bound Gary tmux sessions.
+
+The `AskUserQuestion` tool renders a terminal-only option picker that never
+reaches the Discord user — so calling it wedges the conversation. This hook
+blocks the call and instructs the model to ask via
+`mcp__plugin_discord_discord__reply` instead.
+
+Contract (https://docs.claude.com/en/docs/claude-code/hooks):
+  - PreToolUse JSON arrives on stdin.
+  - Block by printing `{"decision": "block", "reason": "..."}` to stdout.
+  - Allow by exiting 0 with empty stdout.
+
+Safety: this hook is registered globally and runs before every tool call on the
+machine. A crashing or hanging hook would freeze every Claude session, so the
+contract here is fail-open: any malformed input, missing field, or unexpected
+exception exits 0 silently. Blocking only ever happens on the exact path where
+both DISCORD_STATE_DIR is set AND the tool is AskUserQuestion.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+DENIAL_REASON = (
+    "AskUserQuestion is not supported in Discord-bridged sessions — the option "
+    "picker renders only in the local TTY and is invisible to the user. Ask the "
+    "user via the `mcp__plugin_discord_discord__reply` tool with a numbered/"
+    "lettered list instead, and read their answer from the next incoming "
+    "`<channel>` block."
+)
+
+
+def main() -> int:
+    try:
+        raw = sys.stdin.read()
+    except Exception:
+        return 0
+
+    if not raw or not raw.strip():
+        return 0
+
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        return 0
+
+    if not isinstance(payload, dict):
+        return 0
+
+    tool_name = payload.get("tool_name")
+    if tool_name != "AskUserQuestion":
+        return 0
+
+    if not os.environ.get("DISCORD_STATE_DIR"):
+        return 0
+
+    try:
+        json.dump({"decision": "block", "reason": DENIAL_REASON}, sys.stdout)
+        sys.stdout.write("\n")
+    except Exception:
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        # Last-ditch fail-open: never crash a global hook.
+        sys.exit(0)

--- a/config/hooks/tests/test-block-askuserquestion-in-discord.sh
+++ b/config/hooks/tests/test-block-askuserquestion-in-discord.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# test-block-askuserquestion-in-discord.sh — Tests for the AskUserQuestion
+# PreToolUse hook.
+#
+# Usage: bash config/hooks/tests/test-block-askuserquestion-in-discord.sh
+#
+# Each test feeds a JSON hook event to the hook via stdin (with or without
+# DISCORD_STATE_DIR set in the env) and asserts:
+#   - exit code is always 0 (hook is fail-open / advisory-block via JSON)
+#   - stdout contains a `decision: block` JSON object iff the hook should block
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/../block-askuserquestion-in-discord.py"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+# Helpers -------------------------------------------------------------------
+
+# Run the hook with the given stdin and env, and check the outcome.
+# $1 = test name
+# $2 = expected behavior — "block" or "allow"
+# $3 = "discord" if DISCORD_STATE_DIR should be set, "no-discord" otherwise
+# $4 = JSON payload (passed as a string arg so counters live in the parent shell)
+run_test() {
+  local name="$1"
+  local expected="$2"
+  local discord_mode="$3"
+  local payload="$4"
+  TOTAL=$((TOTAL + 1))
+
+  local stdout exit_code
+  if [ "$discord_mode" = "discord" ]; then
+    stdout="$(printf '%s' "$payload" | DISCORD_STATE_DIR=/tmp/test-discord-state python3 "$HOOK" 2>/dev/null)"
+    exit_code=$?
+  else
+    # Explicitly unset so the parent shell's env can't leak in.
+    stdout="$(printf '%s' "$payload" | env -u DISCORD_STATE_DIR python3 "$HOOK" 2>/dev/null)"
+    exit_code=$?
+  fi
+
+  # The hook must always exit 0 — blocking is signaled via stdout JSON.
+  if [ "$exit_code" -ne 0 ]; then
+    echo "  FAIL: $name (hook exited $exit_code, must always exit 0)"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  local is_block="no"
+  if echo "$stdout" | grep -q '"decision"[[:space:]]*:[[:space:]]*"block"'; then
+    is_block="yes"
+  fi
+
+  case "$expected" in
+    block)
+      if [ "$is_block" = "yes" ]; then
+        # Confirm the redirect message names the right MCP tool.
+        if echo "$stdout" | grep -q 'mcp__plugin_discord_discord__reply'; then
+          echo "  PASS: $name"
+          PASS=$((PASS + 1))
+        else
+          echo "  FAIL: $name (blocked but reason missing mcp__plugin_discord_discord__reply redirect)"
+          echo "        stdout: $stdout"
+          FAIL=$((FAIL + 1))
+        fi
+      else
+        echo "  FAIL: $name (expected block, got allow)"
+        echo "        stdout: $stdout"
+        FAIL=$((FAIL + 1))
+      fi
+      ;;
+    allow)
+      if [ "$is_block" = "no" ]; then
+        echo "  PASS: $name"
+        PASS=$((PASS + 1))
+      else
+        echo "  FAIL: $name (expected allow, got block)"
+        echo "        stdout: $stdout"
+        FAIL=$((FAIL + 1))
+      fi
+      ;;
+  esac
+}
+
+# --- MUST BLOCK — Discord-bridged + AskUserQuestion ------------------------
+
+echo ""
+echo "=== MUST BLOCK — Discord-bridged AskUserQuestion ==="
+echo ""
+
+ASK_PAYLOAD='{"tool_name":"AskUserQuestion","tool_input":{"question":"Pick one","options":["a","b"]},"session_id":"s","cwd":"/tmp","hook_event_name":"PreToolUse"}'
+READ_PAYLOAD='{"tool_name":"Read","tool_input":{"file_path":"/tmp/x"},"session_id":"s","cwd":"/tmp","hook_event_name":"PreToolUse"}'
+BASH_PAYLOAD='{"tool_name":"Bash","tool_input":{"command":"ls"},"session_id":"s","cwd":"/tmp","hook_event_name":"PreToolUse"}'
+REPLY_PAYLOAD='{"tool_name":"mcp__plugin_discord_discord__reply","tool_input":{"chat_id":"1","content":"hi"},"session_id":"s","cwd":"/tmp","hook_event_name":"PreToolUse"}'
+
+run_test "AskUserQuestion + DISCORD_STATE_DIR set" "block" "discord" "$ASK_PAYLOAD"
+
+# --- MUST ALLOW — non-Discord sessions or other tools ---------------------
+
+echo ""
+echo "=== MUST ALLOW — not Discord-bridged or not AskUserQuestion ==="
+echo ""
+
+run_test "AskUserQuestion + no DISCORD_STATE_DIR (regular CLI session)" "allow" "no-discord" "$ASK_PAYLOAD"
+run_test "Read tool + DISCORD_STATE_DIR set (other tools must pass through)" "allow" "discord" "$READ_PAYLOAD"
+run_test "Bash tool + DISCORD_STATE_DIR set" "allow" "discord" "$BASH_PAYLOAD"
+run_test "Discord reply tool + DISCORD_STATE_DIR set (must not block itself)" "allow" "discord" "$REPLY_PAYLOAD"
+
+# --- FAIL-OPEN — malformed / unexpected input (P0) -------------------------
+# A crashing hook would freeze every Claude session on this machine. Every
+# pathological input must allow.
+
+echo ""
+echo "=== FAIL-OPEN — malformed input (P0) ==="
+echo ""
+
+run_test "Empty stdin + DISCORD_STATE_DIR set" "allow" "discord" ""
+run_test "Whitespace-only stdin + DISCORD_STATE_DIR set" "allow" "discord" "   "
+run_test "Malformed JSON + DISCORD_STATE_DIR set" "allow" "discord" "not json at all"
+run_test "JSON array (not object) + DISCORD_STATE_DIR set" "allow" "discord" "[1,2,3]"
+run_test "JSON string (not object) + DISCORD_STATE_DIR set" "allow" "discord" '"a string"'
+run_test "Empty object + DISCORD_STATE_DIR set" "allow" "discord" "{}"
+run_test "Missing tool_name + DISCORD_STATE_DIR set" "allow" "discord" '{"tool_input":{"question":"x"}}'
+run_test "Null tool_name + DISCORD_STATE_DIR set" "allow" "discord" '{"tool_name":null}'
+run_test "Numeric tool_name + DISCORD_STATE_DIR set" "allow" "discord" '{"tool_name":42}'
+
+# Empty DISCORD_STATE_DIR string should be treated as unset.
+TOTAL=$((TOTAL + 1))
+stdout="$(DISCORD_STATE_DIR="" python3 "$HOOK" 2>/dev/null <<'JSON'
+{"tool_name":"AskUserQuestion","tool_input":{"question":"x"}}
+JSON
+)"
+exit_code=$?
+if [ "$exit_code" -eq 0 ] && ! echo "$stdout" | grep -q '"decision"[[:space:]]*:[[:space:]]*"block"'; then
+  echo "  PASS: Empty DISCORD_STATE_DIR string treated as unset"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: Empty DISCORD_STATE_DIR string should not trigger block (exit=$exit_code, stdout=$stdout)"
+  FAIL=$((FAIL + 1))
+fi
+
+# --- Summary ---------------------------------------------------------------
+
+echo ""
+echo "=============================="
+echo "Results: $PASS passed, $FAIL failed, $TOTAL total"
+echo "=============================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Two-layer fix for the AskUserQuestion wedge that has been stalling pool bots (three confirmed incidents in one morning per the issue):

- **Hard guard** — new PreToolUse hook `config/hooks/block-askuserquestion-in-discord.py`. Detects Discord-bridged sessions via the `DISCORD_STATE_DIR` env var (exported by the daemon for every pool bot, Pat, and channel-bound Gary tmux), and denies the tool with a structured `{"decision":"block","reason":...}` payload that redirects the model to `mcp__plugin_discord_discord__reply`. Registered in `~/.claude/settings.json` under `hooks.PreToolUse` with matcher `AskUserQuestion`.
- **Soft teaching** — a "Discord-Bridged Sessions" paragraph added with consistent wording to `config/claude/agents/planner.md`, `config/claude/skills/planning-dna/SKILL.md`, and `config/claude/skills/coding-dna/SKILL.md` so agents know *why* the tool is blocked and don't fight the guard.

## Safety

The hook is registered globally and runs before every tool call on the machine. A crash would freeze every Claude session. The hook is **fail-open on every error path**: empty stdin, malformed JSON, non-object payloads, missing or non-string `tool_name`, any unexpected exception — all silently return exit 0 with empty stdout (= allow). The only path that produces a block decision is the exact combination of `tool_name == "AskUserQuestion"` AND `DISCORD_STATE_DIR` non-empty. 15-case test suite under `config/hooks/tests/test-block-askuserquestion-in-discord.sh` exercises this contract end to end and was verified to catch regressions (intentionally inverting the hook's condition produces 3 failures).

## In-repo vs. out-of-repo

This PR diff contains the **templates** that `lf init` deploys to `~/.claude/`:

- `config/hooks/block-askuserquestion-in-discord.py` (new)
- `config/hooks/tests/test-block-askuserquestion-in-discord.sh` (new)
- `config/hooks/README.md` (updated)
- `config/claude/agents/planner.md`, `config/claude/skills/{planning,coding}-dna/SKILL.md` (DNA paragraph added)

The matching changes have been **applied to the live `~/.claude/`** directly so they take effect on the running machine without waiting for the next `lf init`:

- Copied `block-askuserquestion-in-discord.py` to `~/.claude/hooks/` (chmod +x)
- Registered a new `PreToolUse` entry in `~/.claude/settings.json` with matcher `AskUserQuestion` and `python3 ~/.claude/hooks/block-askuserquestion-in-discord.py`
- Mirrored the DNA paragraph into the live `~/.claude/agents/gary.md`, `~/.claude/skills/planning-dna/SKILL.md`, `~/.claude/skills/coding-dna/SKILL.md`

Per Jax's hard constraint, the daemon was **not restarted** and no pool bot tmux sessions were killed. The fix is forward-looking — new sessions spawned after this PR (and after the live edits above) inherit both the hook and the DNA guidance naturally as bots cycle.

## Verification

- [x] Unit tests pass: 15/15 (`bash config/hooks/tests/test-block-askuserquestion-in-discord.sh`)
- [x] Regression check: intentionally broke the hook's `DISCORD_STATE_DIR` check, tests caught it (3 failures), restored, back to green
- [x] Manual E2E — bridged: `DISCORD_STATE_DIR=/tmp/hooktest claude -p "use the AskUserQuestion tool ..."` — the model received the denial message verbatim, including the redirect to `mcp__plugin_discord_discord__reply`, and produced a numbered list in plain text instead
- [x] Manual E2E — unbridged: `env -u DISCORD_STATE_DIR claude -p "call AskUserQuestion ..."` — the tool was invoked (no hook block); only the expected harness "no TTY" error came back
- [x] DNA paragraphs use consistent wording across all three files
- [ ] Pool bot session restart to confirm live behavior — intentionally skipped per Jax's hard constraint (no daemon/pool-bot restarts). Forward-looking only; new sessions inherit naturally as bots cycle.

Closes #324