### PR TITLE
fix(daemon): per-entity sub --resume + onboarding wedge (#327)

### DIFF
--- a/docs/per-entity-subscriptions.md
+++ b/docs/per-entity-subscriptions.md
@@ -109,6 +109,53 @@ The injection happens at two points in the daemon:
 
 Both paths log which config directory is being used at spawn time.
 
+### First-launch preparation (issue #327)
+
+Before any pool-bot spawn under a per-entity `claude_config_dir`, the daemon
+runs two idempotent fixes to make `--resume` and the interactive TUI work
+cleanly. Both happen automatically — no manual setup is required beyond
+`claude auth login`. The work runs at most once per `(entity, config_dir)`
+pair per daemon process and is cached in memory thereafter.
+
+1. **Session JSONL migration.** Claude Code stores session transcripts at
+   `$CLAUDE_CONFIG_DIR/projects/<encoded-cwd>/<session-id>.jsonl`. Sessions
+   that were originally written under the default `~/.claude` (before the
+   entity switched to a per-entity sub) are invisible to the new config dir,
+   so `--resume` would silently drop the bot into the onboarding wizard.
+
+   On first launch, the daemon mirrors every project dir under
+   `~/.claude/projects/` whose slug contains the entity_id into
+   `<config_dir>/projects/`. Existing destination dirs are preserved
+   (`cp -rn` semantics) so the migration is safe to re-run.
+
+2. **Onboarding-completion patch.** A freshly-authed config dir has
+   `oauthAccount` populated but `hasCompletedOnboarding`, `theme`, and
+   `bypassPermissionsModeAccepted` are all unset. Headless `-p` mode skips
+   onboarding, but pool bots launch interactively (TUI) and would stall on
+   the first picker.
+
+   On first launch, the daemon patches `<config_dir>/.claude.json` to set
+   the three idle-bypass fields. Only missing/falsy fields are written —
+   existing user preferences are preserved. The theme is sourced from the
+   user's primary `~/.claude.json` with `dark-ansi` as fallback.
+   `oauthAccount` is never touched.
+
+3. **Config-dir-aware JSONL guard.** The existing "drop --resume when the
+   transcript is missing" guard (issue #256) is now config-dir-aware. For
+   entities with `subscription.claude_config_dir` set, the guard looks in
+   `<config_dir>/projects/` instead of `~/.claude/projects/`. If the JSONL
+   is genuinely missing even after the migration, the daemon drops `--resume`
+   and spawns a fresh session — avoiding the wedge while sacrificing one
+   session's continuity (recoverable; daemon-crash on recycle is not).
+
+Both fixes fail open: any I/O error is logged and execution continues. The
+worst case is one bot losing session context — the daemon never hard-crashes
+on a recycle because of these helpers.
+
+Legacy entities that were manually migrated before issue #327 landed
+(canal-street, sonar) don't need any change. The new code is idempotent and
+will no-op against the already-prepared dirs.
+
 ## Troubleshooting
 
 ### Verify which subscription a session is using

--- a/packages/daemon/src/__tests__/claude-config-migration.test.ts
+++ b/packages/daemon/src/__tests__/claude-config-migration.test.ts
@@ -1,0 +1,375 @@
+/**
+ * Tests for per-entity CLAUDE_CONFIG_DIR migration helpers (issue #327).
+ *
+ * Covers:
+ *  - Project-dir migration: copies, scoping, idempotency, fail-open
+ *  - Onboarding-field patch: writes when missing, preserves existing values,
+ *    fail-open when .claude.json is absent
+ *  - Combined ensure helper: idempotent across calls, cached per process
+ *  - Config-dir-aware JSONL existence check
+ *
+ * All tests use throwaway tempdirs as both "fake HOME" and "fake config dir"
+ * so we never touch the real `~/.claude` or any live per-entity sub dir.
+ */
+
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoisted holder so vi.mock (also hoisted) can share the same reference with
+// beforeEach below. The module under test imports `homedir` directly; we
+// redirect it to a per-test tempdir so we never touch the real ~/.claude.
+const home_holder = vi.hoisted(() => ({ value: "" }));
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return {
+    ...actual,
+    homedir: () => home_holder.value,
+  };
+});
+
+import {
+  _reset_prepared_cache_for_tests,
+  ensure_onboarding_fields,
+  ensure_per_entity_config_dir_ready,
+  migrate_entity_project_dirs,
+  session_jsonl_exists_anywhere_in,
+} from "../claude-config-migration.js";
+
+let config_dir: string;
+
+beforeEach(async () => {
+  home_holder.value = await mkdtemp(join(tmpdir(), "claude-config-home-"));
+  config_dir = await mkdtemp(join(tmpdir(), "claude-config-dir-"));
+  _reset_prepared_cache_for_tests();
+
+  // Safety: the mock must be active. If homedir() doesn't return our tempdir,
+  // refuse to run so we never accidentally read/write the real ~/.claude.
+  if (homedir() !== home_holder.value) {
+    throw new Error(
+      `homedir mock not active (got ${homedir()}, expected ${home_holder.value}) — refusing to run tests`,
+    );
+  }
+});
+
+afterEach(async () => {
+  await rm(home_holder.value, { recursive: true, force: true });
+  await rm(config_dir, { recursive: true, force: true });
+});
+
+/** Seed a fake `~/.claude/projects/` with the given project slugs. */
+async function seed_project_dirs(
+  slugs: Array<{ name: string; session_id: string }>,
+): Promise<void> {
+  const projects_dir = join(home_holder.value, ".claude", "projects");
+  await mkdir(projects_dir, { recursive: true });
+  for (const { name, session_id } of slugs) {
+    const dir = join(projects_dir, name);
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, `${session_id}.jsonl`), '{"type":"user"}\n', "utf-8");
+  }
+}
+
+/** Seed the user's primary `~/.claude.json` with a theme. */
+async function seed_user_config(theme: string | undefined): Promise<void> {
+  const path = join(home_holder.value, ".claude.json");
+  const data = theme !== undefined ? { theme } : {};
+  await writeFile(path, JSON.stringify(data), "utf-8");
+}
+
+// ── migrate_entity_project_dirs ──
+
+describe("migrate_entity_project_dirs", () => {
+  it("copies project dirs whose slug contains the entity_id", async () => {
+    await seed_project_dirs([
+      {
+        name: "-Users-farm--lobsterfarm-entities-canal-street-repos-app",
+        session_id: "aaaa-1111",
+      },
+      {
+        name: "-Users-farm--lobsterfarm-entities-canal-street-repos-app-worktrees-feat",
+        session_id: "bbbb-2222",
+      },
+      // unrelated entity — must NOT be copied
+      {
+        name: "-Users-farm--lobsterfarm-entities-other-entity-repos-app",
+        session_id: "cccc-3333",
+      },
+    ]);
+
+    const migrated = await migrate_entity_project_dirs("canal-street", config_dir);
+
+    expect(migrated).toHaveLength(2);
+    expect(migrated.sort()).toEqual([
+      "-Users-farm--lobsterfarm-entities-canal-street-repos-app",
+      "-Users-farm--lobsterfarm-entities-canal-street-repos-app-worktrees-feat",
+    ]);
+
+    // JSONLs are present in the destination
+    await expect(
+      access(
+        join(
+          config_dir,
+          "projects",
+          "-Users-farm--lobsterfarm-entities-canal-street-repos-app",
+          "aaaa-1111.jsonl",
+        ),
+      ),
+    ).resolves.toBeUndefined();
+
+    // Unrelated entity's projects were NOT copied
+    await expect(
+      access(
+        join(config_dir, "projects", "-Users-farm--lobsterfarm-entities-other-entity-repos-app"),
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("is idempotent — second call copies nothing new", async () => {
+    await seed_project_dirs([
+      {
+        name: "-Users-farm--lobsterfarm-entities-canal-street-repos-app",
+        session_id: "aaaa-1111",
+      },
+    ]);
+
+    const first = await migrate_entity_project_dirs("canal-street", config_dir);
+    const second = await migrate_entity_project_dirs("canal-street", config_dir);
+
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(0);
+  });
+
+  it("returns empty list when ~/.claude/projects/ is missing (fail-open)", async () => {
+    // No seeding — no projects dir at all.
+    const migrated = await migrate_entity_project_dirs("canal-street", config_dir);
+    expect(migrated).toEqual([]);
+  });
+
+  it("creates <config_dir>/projects/ if absent", async () => {
+    await seed_project_dirs([
+      {
+        name: "-Users-farm--lobsterfarm-entities-canal-street-repos-app",
+        session_id: "aaaa-1111",
+      },
+    ]);
+
+    await migrate_entity_project_dirs("canal-street", config_dir);
+
+    await expect(access(join(config_dir, "projects"))).resolves.toBeUndefined();
+  });
+
+  it("does not overwrite existing destination dir (preserves whatever's there)", async () => {
+    await seed_project_dirs([
+      {
+        name: "-Users-farm--lobsterfarm-entities-canal-street-repos-app",
+        session_id: "aaaa-1111",
+      },
+    ]);
+
+    // Pre-create destination with different content
+    const dst = join(
+      config_dir,
+      "projects",
+      "-Users-farm--lobsterfarm-entities-canal-street-repos-app",
+    );
+    await mkdir(dst, { recursive: true });
+    await writeFile(join(dst, "preexisting.jsonl"), "preserved", "utf-8");
+
+    const migrated = await migrate_entity_project_dirs("canal-street", config_dir);
+
+    expect(migrated).toEqual([]);
+    // Preexisting file is still there, source JSONL is NOT copied in.
+    const preserved = await readFile(join(dst, "preexisting.jsonl"), "utf-8");
+    expect(preserved).toBe("preserved");
+    await expect(access(join(dst, "aaaa-1111.jsonl"))).rejects.toThrow();
+  });
+});
+
+// ── ensure_onboarding_fields ──
+
+describe("ensure_onboarding_fields", () => {
+  it("patches missing fields when .claude.json exists with only oauthAccount", async () => {
+    await seed_user_config("light-daltonized");
+
+    // Simulate the post-`claude auth login` state
+    const claude_json = join(config_dir, ".claude.json");
+    await writeFile(
+      claude_json,
+      JSON.stringify({
+        oauthAccount: { emailAddress: "test@example.com" },
+        hasCompletedOnboarding: null,
+      }),
+      "utf-8",
+    );
+
+    const wrote = await ensure_onboarding_fields(config_dir);
+    expect(wrote).toBe(true);
+
+    const patched = JSON.parse(await readFile(claude_json, "utf-8")) as Record<string, unknown>;
+    expect(patched.hasCompletedOnboarding).toBe(true);
+    expect(patched.theme).toBe("light-daltonized");
+    expect(patched.bypassPermissionsModeAccepted).toBe(true);
+    // oauthAccount must be preserved untouched
+    expect(patched.oauthAccount).toEqual({ emailAddress: "test@example.com" });
+  });
+
+  it("falls back to dark-ansi when user's ~/.claude.json has no theme", async () => {
+    await seed_user_config(undefined);
+
+    const claude_json = join(config_dir, ".claude.json");
+    await writeFile(claude_json, JSON.stringify({ oauthAccount: {} }), "utf-8");
+
+    await ensure_onboarding_fields(config_dir);
+
+    const patched = JSON.parse(await readFile(claude_json, "utf-8")) as Record<string, unknown>;
+    expect(patched.theme).toBe("dark-ansi");
+  });
+
+  it("preserves existing truthy values (idempotent)", async () => {
+    await seed_user_config("dark-ansi");
+
+    const claude_json = join(config_dir, ".claude.json");
+    await writeFile(
+      claude_json,
+      JSON.stringify({
+        oauthAccount: {},
+        hasCompletedOnboarding: true,
+        theme: "user-custom-theme",
+        bypassPermissionsModeAccepted: true,
+      }),
+      "utf-8",
+    );
+
+    const wrote = await ensure_onboarding_fields(config_dir);
+    expect(wrote).toBe(false);
+
+    const after = JSON.parse(await readFile(claude_json, "utf-8")) as Record<string, unknown>;
+    expect(after.theme).toBe("user-custom-theme");
+  });
+
+  it("returns false (fail-open) when .claude.json is missing", async () => {
+    // No file at all — we must not crash, must not create a fresh file
+    // (would race with `claude auth login` and risk wiping oauthAccount).
+    const wrote = await ensure_onboarding_fields(config_dir);
+    expect(wrote).toBe(false);
+    await expect(access(join(config_dir, ".claude.json"))).rejects.toThrow();
+  });
+
+  it("only patches the missing field when others are already set", async () => {
+    await seed_user_config("dark-ansi");
+
+    const claude_json = join(config_dir, ".claude.json");
+    await writeFile(
+      claude_json,
+      JSON.stringify({
+        oauthAccount: {},
+        hasCompletedOnboarding: true,
+        theme: "existing-theme",
+        // bypassPermissionsModeAccepted intentionally missing
+      }),
+      "utf-8",
+    );
+
+    await ensure_onboarding_fields(config_dir);
+
+    const patched = JSON.parse(await readFile(claude_json, "utf-8")) as Record<string, unknown>;
+    expect(patched.theme).toBe("existing-theme"); // preserved
+    expect(patched.bypassPermissionsModeAccepted).toBe(true); // added
+  });
+});
+
+// ── ensure_per_entity_config_dir_ready ──
+
+describe("ensure_per_entity_config_dir_ready", () => {
+  it("runs migration + onboarding patch on first call, no-ops on second", async () => {
+    await seed_user_config("dark-ansi");
+    await seed_project_dirs([
+      {
+        name: "-Users-farm--lobsterfarm-entities-canal-street",
+        session_id: "aaaa-1111",
+      },
+    ]);
+    const claude_json = join(config_dir, ".claude.json");
+    await writeFile(claude_json, JSON.stringify({ oauthAccount: {} }), "utf-8");
+
+    await ensure_per_entity_config_dir_ready("canal-street", config_dir);
+
+    // Migration ran
+    await expect(
+      access(
+        join(
+          config_dir,
+          "projects",
+          "-Users-farm--lobsterfarm-entities-canal-street",
+          "aaaa-1111.jsonl",
+        ),
+      ),
+    ).resolves.toBeUndefined();
+
+    // Onboarding patched
+    const after = JSON.parse(await readFile(claude_json, "utf-8")) as Record<string, unknown>;
+    expect(after.hasCompletedOnboarding).toBe(true);
+
+    // Second call is a cache hit — verify by mutating the source and confirming
+    // it does NOT get re-copied.
+    await writeFile(
+      join(
+        home_holder.value,
+        ".claude",
+        "projects",
+        "-Users-farm--lobsterfarm-entities-canal-street",
+        "bbbb-2222.jsonl",
+      ),
+      '{"x":1}\n',
+      "utf-8",
+    );
+    await ensure_per_entity_config_dir_ready("canal-street", config_dir);
+    await expect(
+      access(
+        join(
+          config_dir,
+          "projects",
+          "-Users-farm--lobsterfarm-entities-canal-street",
+          "bbbb-2222.jsonl",
+        ),
+      ),
+    ).rejects.toThrow();
+  });
+});
+
+// ── session_jsonl_exists_anywhere_in ──
+
+describe("session_jsonl_exists_anywhere_in", () => {
+  it("finds JSONL under the per-entity config dir's projects/ when config_dir is set", async () => {
+    const projects = join(config_dir, "projects", "-some-path");
+    await mkdir(projects, { recursive: true });
+    await writeFile(join(projects, "abc-123.jsonl"), "{}", "utf-8");
+
+    expect(await session_jsonl_exists_anywhere_in(config_dir, "abc-123")).toBe(true);
+    expect(await session_jsonl_exists_anywhere_in(config_dir, "missing")).toBe(false);
+  });
+
+  it("falls back to ~/.claude/projects/ when config_dir is null", async () => {
+    const projects = join(home_holder.value, ".claude", "projects", "-some-path");
+    await mkdir(projects, { recursive: true });
+    await writeFile(join(projects, "abc-123.jsonl"), "{}", "utf-8");
+
+    expect(await session_jsonl_exists_anywhere_in(null, "abc-123")).toBe(true);
+  });
+
+  it("does NOT find a JSONL in ~/.claude/projects/ when looking in a per-entity dir", async () => {
+    // This is the bug — make sure the new helper is strict about its scope.
+    const projects = join(home_holder.value, ".claude", "projects", "-some-path");
+    await mkdir(projects, { recursive: true });
+    await writeFile(join(projects, "abc-123.jsonl"), "{}", "utf-8");
+
+    // config_dir is set but empty — the JSONL exists in HOME only
+    expect(await session_jsonl_exists_anywhere_in(config_dir, "abc-123")).toBe(false);
+  });
+
+  it("returns false (no crash) when projects/ does not exist", async () => {
+    expect(await session_jsonl_exists_anywhere_in(config_dir, "anything")).toBe(false);
+  });
+});

--- a/packages/daemon/src/__tests__/per-entity-sub-resume.test.ts
+++ b/packages/daemon/src/__tests__/per-entity-sub-resume.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Pool-side wiring tests for per-entity Claude sub --resume fix (issue #327).
+ *
+ * Covers the daemon behavior that flips between the default ~/.claude and a
+ * per-entity CLAUDE_CONFIG_DIR. We don't re-test the migration helpers
+ * themselves here (see claude-config-migration.test.ts) — instead we verify
+ * the BotPool wires them in correctly:
+ *
+ *  - check_session_jsonl_exists_anywhere(session_id, entity_id) routes to the
+ *    entity's per-entity dir when one is configured, falls back to ~/.claude
+ *    otherwise.
+ *  - On crash-restart, a missing JSONL in the per-entity dir cleanly drops
+ *    --resume and spawns fresh (the backstop path).
+ *  - ensure_per_entity_config_dir_ready() is invoked at assign-time when the
+ *    entity has a subscription override.
+ */
+
+import { EventEmitter } from "node:events";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type EntityConfig,
+  EntityConfigSchema,
+  type LobsterFarmConfig,
+  LobsterFarmConfigSchema,
+} from "@lobster-farm/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Capture spawn calls (tmux start) — we assert on the env to confirm
+// CLAUDE_CONFIG_DIR flows through.
+let spawn_calls: Array<{ command: string; args: string[]; options: Record<string, unknown> }> = [];
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: vi.fn((...args: unknown[]) => {
+      spawn_calls.push({
+        command: args[0] as string,
+        args: args[1] as string[],
+        options: args[2] as Record<string, unknown>,
+      });
+      const emitter = new EventEmitter();
+      setTimeout(() => emitter.emit("close", 0), 0);
+      return emitter;
+    }),
+  };
+});
+
+import {
+  _reset_prepared_cache_for_tests,
+  ensure_per_entity_config_dir_ready,
+} from "../claude-config-migration.js";
+import { BotPool } from "../pool.js";
+import type { PoolBot } from "../pool.js";
+
+// ── Test helpers ──
+
+let temp_dir: string;
+let per_entity_config_dir: string;
+
+function make_config(): LobsterFarmConfig {
+  return LobsterFarmConfigSchema.parse({
+    user: { name: "Test" },
+    paths: { lobsterfarm_dir: temp_dir },
+  });
+}
+
+function make_entity_config(overrides: {
+  id: string;
+  claude_config_dir?: string;
+}): EntityConfig {
+  return EntityConfigSchema.parse({
+    entity: {
+      id: overrides.id,
+      name: overrides.id,
+      repos: [],
+      channels: { category_id: "", list: [] },
+      memory: { path: `/tmp/test-memory/${overrides.id}` },
+      secrets: { vault_name: `entity-${overrides.id}` },
+      ...(overrides.claude_config_dir
+        ? { subscription: { claude_config_dir: overrides.claude_config_dir } }
+        : {}),
+    },
+  });
+}
+
+class MockRegistry {
+  private entities = new Map<string, EntityConfig>();
+  add(c: EntityConfig): void {
+    this.entities.set(c.entity.id, c);
+  }
+  get(id: string): EntityConfig | undefined {
+    return this.entities.get(id);
+  }
+}
+
+class Pool extends BotPool {
+  inject_bots(bots: PoolBot[]): void {
+    (this as unknown as { bots: PoolBot[] }).bots = bots;
+  }
+  inject_registry(r: MockRegistry): void {
+    (this as unknown as { registry: MockRegistry }).registry = r;
+  }
+  protected override is_bot_idle(): boolean {
+    return true;
+  }
+  call_check_anywhere(session_id: string, entity_id?: string | null): Promise<boolean> {
+    return (
+      this as unknown as {
+        check_session_jsonl_exists_anywhere: (s: string, e?: string | null) => Promise<boolean>;
+      }
+    ).check_session_jsonl_exists_anywhere(session_id, entity_id);
+  }
+}
+
+function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
+  return {
+    state: "free",
+    channel_id: null,
+    entity_id: null,
+    archetype: null,
+    channel_type: null,
+    session_id: null,
+    session_confirmed: true,
+    tmux_session: `pool-${String(overrides.id)}`,
+    last_active: null,
+    assigned_at: null,
+    state_dir: `/tmp/test-pool-${String(overrides.id)}`,
+    model: null,
+    effort: null,
+    last_avatar_archetype: null,
+    last_avatar_set_at: null,
+    ...overrides,
+  };
+}
+
+/** Stub the FS/tmux side effects that aren't relevant to these tests. */
+function stub_side_effects(pool: Pool): void {
+  vi.spyOn(
+    pool as unknown as { kill_tmux: (s: string) => void },
+    "kill_tmux" as never,
+  ).mockImplementation(() => {});
+  vi.spyOn(
+    pool as unknown as { write_access_json: (d: string, c: string | null) => Promise<void> },
+    "write_access_json" as never,
+  ).mockResolvedValue(undefined);
+  vi.spyOn(
+    pool as unknown as { set_bot_nickname: (d: string, a: string) => Promise<void> },
+    "set_bot_nickname" as never,
+  ).mockResolvedValue(undefined);
+  vi.spyOn(
+    pool as unknown as { set_bot_avatar: (b: PoolBot, a: string) => Promise<void> },
+    "set_bot_avatar" as never,
+  ).mockResolvedValue(undefined);
+  vi.spyOn(
+    pool as unknown as { is_tmux_alive: (s: string) => boolean },
+    "is_tmux_alive" as never,
+  ).mockReturnValue(true);
+  vi.spyOn(
+    pool as unknown as { park_bot: (b: PoolBot) => Promise<void> },
+    "park_bot" as never,
+  ).mockImplementation(async (bot: PoolBot) => {
+    bot.state = "parked";
+  });
+}
+
+// ── Setup ──
+
+let config: LobsterFarmConfig;
+let pool: Pool;
+let registry: MockRegistry;
+
+beforeEach(async () => {
+  temp_dir = await mkdtemp(join(tmpdir(), "per-entity-sub-test-"));
+  per_entity_config_dir = await mkdtemp(join(tmpdir(), "per-entity-config-"));
+  spawn_calls = [];
+  _reset_prepared_cache_for_tests();
+
+  config = make_config();
+  pool = new Pool(config);
+  registry = new MockRegistry();
+  stub_side_effects(pool);
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await rm(temp_dir, { recursive: true, force: true });
+  await rm(per_entity_config_dir, { recursive: true, force: true });
+});
+
+// ── Tests ──
+
+describe("check_session_jsonl_exists_anywhere — config-dir-aware (#327)", () => {
+  it("looks in the per-entity dir's projects/ when entity has subscription set", async () => {
+    // Seed a JSONL inside the per-entity config dir.
+    const slug_dir = join(per_entity_config_dir, "projects", "-some-encoded-cwd");
+    await mkdir(slug_dir, { recursive: true });
+    await writeFile(join(slug_dir, "sess-abc.jsonl"), "{}\n", "utf-8");
+
+    registry.add(
+      make_entity_config({
+        id: "rengen-test",
+        claude_config_dir: per_entity_config_dir,
+      }),
+    );
+    pool.inject_registry(registry);
+
+    // Entity has subscription → check routes to per-entity dir.
+    expect(await pool.call_check_anywhere("sess-abc", "rengen-test")).toBe(true);
+    // Phantom session → not found.
+    expect(await pool.call_check_anywhere("sess-missing", "rengen-test")).toBe(false);
+  });
+
+  it("falls back to ~/.claude/projects/ when entity has no subscription", async () => {
+    // Entity exists but has no claude_config_dir.
+    registry.add(make_entity_config({ id: "default-entity" }));
+    pool.inject_registry(registry);
+
+    // We don't seed anything → should return false from ~/.claude/projects/
+    // (cannot guarantee what's in the real ~/.claude on the test machine, but
+    // a randomly-generated session id is guaranteed absent).
+    const random_id = `sess-${Math.random().toString(36).slice(2)}-not-real`;
+    expect(await pool.call_check_anywhere(random_id, "default-entity")).toBe(false);
+  });
+
+  it("does NOT find a JSONL that lives only in ~/.claude when entity has per-entity sub", async () => {
+    // This is the core #327 bug: the daemon was looking in ~/.claude/projects/
+    // for a session that exists ONLY there, even when the entity is configured
+    // to use a per-entity sub. After the fix, the check should route to the
+    // per-entity dir and correctly NOT find the session — triggering the
+    // backstop "drop --resume, spawn fresh" path.
+    registry.add(
+      make_entity_config({
+        id: "rengen-test",
+        claude_config_dir: per_entity_config_dir,
+      }),
+    );
+    pool.inject_registry(registry);
+
+    // Per-entity dir is empty → check returns false even though the session
+    // might exist under the default ~/.claude (we can't easily inject there).
+    expect(await pool.call_check_anywhere("sess-default-only", "rengen-test")).toBe(false);
+  });
+});
+
+describe("assign() invokes ensure_per_entity_config_dir_ready (#327)", () => {
+  it("calls the migration helper at assign-time when entity has subscription", async () => {
+    // Seed a .claude.json in the per-entity dir so ensure_onboarding_fields
+    // has something to patch (otherwise it bails out gracefully).
+    await writeFile(
+      join(per_entity_config_dir, ".claude.json"),
+      JSON.stringify({ oauthAccount: { emailAddress: "x@y.z" } }),
+      "utf-8",
+    );
+
+    registry.add(
+      make_entity_config({
+        id: "rengen-test",
+        claude_config_dir: per_entity_config_dir,
+      }),
+    );
+    pool.inject_registry(registry);
+    pool.inject_bots([make_bot({ id: 1, state: "free" })]);
+
+    await pool.assign("ch-test", "rengen-test", "builder", undefined, "work_room");
+
+    // Side effect: ensure_onboarding_fields wrote hasCompletedOnboarding into .claude.json
+    const { readFile } = await import("node:fs/promises");
+    const patched = JSON.parse(
+      await readFile(join(per_entity_config_dir, ".claude.json"), "utf-8"),
+    ) as Record<string, unknown>;
+    expect(patched.hasCompletedOnboarding).toBe(true);
+    expect(patched.bypassPermissionsModeAccepted).toBe(true);
+    // oauthAccount preserved
+    expect(patched.oauthAccount).toEqual({ emailAddress: "x@y.z" });
+
+    // CLAUDE_CONFIG_DIR flowed through to the spawn env
+    const tmux_call = spawn_calls.find((c) => c.command === "tmux");
+    expect(tmux_call).toBeDefined();
+    const env = tmux_call!.options.env as Record<string, string>;
+    expect(env.CLAUDE_CONFIG_DIR).toBe(per_entity_config_dir);
+  });
+
+  it("does NOT invoke the helper when entity has no subscription", async () => {
+    registry.add(make_entity_config({ id: "default-entity" }));
+    pool.inject_registry(registry);
+    pool.inject_bots([make_bot({ id: 1, state: "free" })]);
+
+    await pool.assign("ch-test", "default-entity", "builder", undefined, "work_room");
+
+    // No CLAUDE_CONFIG_DIR in spawn env
+    const tmux_call = spawn_calls.find((c) => c.command === "tmux");
+    expect(tmux_call).toBeDefined();
+    const env = tmux_call!.options.env as Record<string, string>;
+    expect(env.CLAUDE_CONFIG_DIR).toBeUndefined();
+  });
+});
+
+describe("ensure_per_entity_config_dir_ready — fail-open behavior", () => {
+  it("does not throw when the per-entity dir has no .claude.json", async () => {
+    // Helper should log a warning and continue, not throw.
+    await expect(
+      ensure_per_entity_config_dir_ready("some-entity", per_entity_config_dir),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not throw when the config_dir itself does not exist (mkdir handles it)", async () => {
+    const missing = join(per_entity_config_dir, "subdir-that-doesnt-exist-yet");
+    await expect(
+      ensure_per_entity_config_dir_ready("some-entity", missing),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/daemon/src/claude-config-migration.ts
+++ b/packages/daemon/src/claude-config-migration.ts
@@ -1,0 +1,249 @@
+/**
+ * Per-entity CLAUDE_CONFIG_DIR migration helpers (issue #327).
+ *
+ * Per-entity Claude Max subscriptions (set via `subscription.claude_config_dir`
+ * in entity config) inject `CLAUDE_CONFIG_DIR=<path>` into pool-bot spawn
+ * environments so each entity uses an isolated OAuth account. That works fine
+ * for fresh sessions but breaks `--resume` and interactive TUI launch in two
+ * ways:
+ *
+ *  1. Claude Code looks up session JSONL transcripts under
+ *     `$CLAUDE_CONFIG_DIR/projects/<encoded-cwd>/<session-id>.jsonl`. Sessions
+ *     written under the *default* `~/.claude` before the entity switched to a
+ *     per-entity sub are invisible to the new config dir — `--resume` then
+ *     silently drops the bot into the onboarding wizard instead of failing
+ *     loud. We solve this by mirroring the entity's project dirs into the
+ *     per-entity `projects/` on first launch.
+ *
+ *  2. A freshly-authed config dir has `oauthAccount` populated (because
+ *     `claude auth login` ran) but `hasCompletedOnboarding`, `theme`, and
+ *     `bypassPermissionsModeAccepted` are all unset. Headless `-p` skips the
+ *     onboarding wizard, but the pool-bot launch path is interactive (TUI),
+ *     so it stalls on the first picker. We pre-populate the three idle-bypass
+ *     fields once per config dir.
+ *
+ * Both operations are idempotent (cheap and safe to re-run on every relevant
+ * spawn) and fail-open (a copy failure logs a warning rather than crashing
+ * the daemon — the worst case is one bot losing session continuity, which is
+ * recoverable; the daemon hard-crashing on a recycle is not).
+ *
+ * `oauthAccount` is never touched — that's auth state and the user owns it.
+ */
+
+import type { Dirent } from "node:fs";
+import { access, cp, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** Default theme used when the user's `~/.claude.json` doesn't expose one. */
+const DEFAULT_THEME = "dark-ansi";
+
+/** Per-process cache of config dirs we've already prepared. Both fixes are
+ * idempotent on disk, but skipping the work on subsequent spawns saves a few
+ * stat/readFile calls per recycle. */
+const prepared: Set<string> = new Set();
+
+/** Reset the prepared-set. Test-only. */
+export function _reset_prepared_cache_for_tests(): void {
+  prepared.clear();
+}
+
+/** Read the user's `theme` setting from `~/.claude.json`, falling back to the
+ * default. Used to mirror the user's TUI preference into a per-entity config
+ * dir so bots don't get a jarring color scheme. */
+async function read_user_theme(): Promise<string> {
+  const user_config_path = join(homedir(), ".claude.json");
+  try {
+    const raw = await readFile(user_config_path, "utf-8");
+    const parsed = JSON.parse(raw) as { theme?: unknown };
+    if (typeof parsed.theme === "string" && parsed.theme.length > 0) {
+      return parsed.theme;
+    }
+  } catch {
+    // Missing or unreadable — fall through to default.
+  }
+  return DEFAULT_THEME;
+}
+
+/** Mirror an entity's project transcript directories from `~/.claude/projects/`
+ * into `<config_dir>/projects/`. Only directories whose slug *contains* the
+ * entity_id are copied — this scopes the migration so we never accidentally
+ * leak unrelated session history across subscriptions.
+ *
+ * Idempotent: skips entries that already exist in the destination (cp -rn
+ * semantics via `force: false`).
+ *
+ * Fail-open: any I/O error is logged and swallowed — the caller proceeds
+ * without `--resume` rather than the daemon crashing on a recycle.
+ *
+ * Returns the names of project dirs that were newly migrated this call.
+ */
+export async function migrate_entity_project_dirs(
+  entity_id: string,
+  config_dir: string,
+): Promise<string[]> {
+  const src_root = join(homedir(), ".claude", "projects");
+  const dst_root = join(config_dir, "projects");
+  const migrated: string[] = [];
+
+  let entries: Dirent[];
+  try {
+    entries = await readdir(src_root, { withFileTypes: true });
+  } catch {
+    // ~/.claude/projects missing — nothing to migrate, not an error.
+    return migrated;
+  }
+
+  try {
+    await mkdir(dst_root, { recursive: true });
+  } catch (err) {
+    console.warn(
+      `[claude-config] Could not create ${dst_root} for entity ${entity_id}: ${String(err)} — skipping migration`,
+    );
+    return migrated;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    // Match project slugs that contain the entity_id. Claude Code encodes a
+    // path like `/Users/farm/.lobsterfarm/entities/<id>/...` as
+    // `-Users-farm--lobsterfarm-entities-<id>-...` (every `/` and `.`
+    // becomes `-`), so a plain substring check on entity_id is sufficient.
+    if (!entry.name.includes(entity_id)) continue;
+
+    const src = join(src_root, entry.name);
+    const dst = join(dst_root, entry.name);
+
+    // Skip if destination already exists (idempotency).
+    try {
+      await access(dst);
+      continue;
+    } catch {
+      // Doesn't exist yet — copy.
+    }
+
+    try {
+      await cp(src, dst, { recursive: true, force: false, errorOnExist: false });
+      migrated.push(entry.name);
+    } catch (err) {
+      console.warn(
+        `[claude-config] Failed to migrate ${entry.name} for entity ${entity_id}: ${String(err)} — continuing`,
+      );
+    }
+  }
+
+  if (migrated.length > 0) {
+    console.log(
+      `[claude-config] Migrated ${String(migrated.length)} project dir(s) for entity ${entity_id} into ${config_dir}: ${migrated.join(", ")}`,
+    );
+  }
+
+  return migrated;
+}
+
+/** Pre-populate onboarding-completion markers in `<config_dir>/.claude.json`
+ * so interactive (TUI) launches don't stall on the wizard.
+ *
+ * Writes only fields that are missing/falsy — never overwrites a user's
+ * existing preference. Never touches `oauthAccount`. Theme is sourced from
+ * `~/.claude.json` (the user's primary config) with `dark-ansi` as fallback.
+ *
+ * Fail-open: any error is logged and swallowed.
+ *
+ * Returns true iff the file was written this call (false = already populated
+ * or write failed).
+ */
+export async function ensure_onboarding_fields(config_dir: string): Promise<boolean> {
+  const path = join(config_dir, ".claude.json");
+
+  let current: Record<string, unknown> = {};
+  try {
+    const raw = await readFile(path, "utf-8");
+    current = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    // Missing or unparseable. We don't create a fresh `.claude.json` from
+    // scratch — that would race with `claude auth login` and risk wiping
+    // `oauthAccount`. Bail out; the next spawn will retry.
+    console.warn(
+      `[claude-config] ${path} missing or unreadable — skipping onboarding patch (run \`claude auth login\` against this dir first)`,
+    );
+    return false;
+  }
+
+  const target_theme = await read_user_theme();
+
+  const needs_onboarding = current.hasCompletedOnboarding !== true;
+  const needs_theme = typeof current.theme !== "string" || current.theme.length === 0;
+  const needs_bypass = current.bypassPermissionsModeAccepted !== true;
+
+  if (!needs_onboarding && !needs_theme && !needs_bypass) {
+    return false;
+  }
+
+  const patched = {
+    ...current,
+    ...(needs_onboarding ? { hasCompletedOnboarding: true } : {}),
+    ...(needs_theme ? { theme: target_theme } : {}),
+    ...(needs_bypass ? { bypassPermissionsModeAccepted: true } : {}),
+  };
+
+  try {
+    await writeFile(path, `${JSON.stringify(patched, null, 2)}\n`, "utf-8");
+    console.log(
+      `[claude-config] Patched onboarding fields in ${path}` +
+        ` (onboarding=${String(needs_onboarding)}, theme=${String(needs_theme)}, bypass=${String(needs_bypass)})`,
+    );
+    return true;
+  } catch (err) {
+    console.warn(
+      `[claude-config] Failed to patch onboarding fields in ${path}: ${String(err)} — continuing`,
+    );
+    return false;
+  }
+}
+
+/** Run both fixes for a per-entity config dir. Idempotent and cached per
+ * daemon process — the on-disk work runs at most once per (entity, config_dir)
+ * pair per daemon lifetime. Subsequent calls are a no-op cache hit.
+ *
+ * Safe to call on every pool-bot spawn that resolves a per-entity config dir.
+ */
+export async function ensure_per_entity_config_dir_ready(
+  entity_id: string,
+  config_dir: string,
+): Promise<void> {
+  const key = `${entity_id}::${config_dir}`;
+  if (prepared.has(key)) return;
+  prepared.add(key);
+
+  await migrate_entity_project_dirs(entity_id, config_dir);
+  await ensure_onboarding_fields(config_dir);
+}
+
+/** Config-dir-aware version of `session_jsonl_exists_anywhere`. When
+ * `config_dir` is provided, looks under `<config_dir>/projects/`; otherwise
+ * falls back to `~/.claude/projects/`. */
+export async function session_jsonl_exists_anywhere_in(
+  config_dir: string | null,
+  session_id: string,
+): Promise<boolean> {
+  const projects_root = config_dir
+    ? join(config_dir, "projects")
+    : join(homedir(), ".claude", "projects");
+  const filename = `${session_id}.jsonl`;
+  try {
+    const entries = await readdir(projects_root, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      try {
+        await access(join(projects_root, entry.name, filename));
+        return true;
+      } catch {
+        // not in this project dir
+      }
+    }
+  } catch {
+    // projects/ missing or unreadable — treat as "not found"
+  }
+  return false;
+}

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -8,6 +8,10 @@ import type { ArchetypeRole, LobsterFarmConfig } from "@lobster-farm/shared";
 import { DEFAULT_ARCHETYPES, entity_dir, expand_home, lobsterfarm_dir } from "@lobster-farm/shared";
 import type { ChannelType } from "@lobster-farm/shared";
 import { notify } from "./actions.js";
+import {
+  ensure_per_entity_config_dir_ready,
+  session_jsonl_exists_anywhere_in,
+} from "./claude-config-migration.js";
 import { resolve_binary } from "./env.js";
 import { resolve_effort, resolve_model_id } from "./models.js";
 import { load_pool_state, save_pool_state } from "./persistence.js";
@@ -432,12 +436,35 @@ export class BotPool extends EventEmitter {
   }
 
   /** Protected wrappers around JSONL existence checks so tests can override
-   * without touching the real filesystem. Defaults to the module-level helpers
-   * which read from `~/.claude/projects/`. */
-  protected check_session_jsonl_exists(working_dir: string, session_id: string): Promise<boolean> {
+   * without touching the real filesystem. When `entity_id` is supplied and the
+   * entity has a `subscription.claude_config_dir` configured, the check is
+   * routed to `<config_dir>/projects/` instead of `~/.claude/projects/` —
+   * essential for entities running on a per-entity Claude Max sub (#327).
+   * Without that routing, the JSONL guard would look in the wrong directory
+   * and silently mis-detect every resumed session as phantom. */
+  protected check_session_jsonl_exists(
+    working_dir: string,
+    session_id: string,
+    entity_id?: string | null,
+  ): Promise<boolean> {
+    const config_dir = entity_id ? this.resolve_claude_config_dir(entity_id) : null;
+    if (config_dir) {
+      // Per-entity sub: scan every slug under the configured projects/ dir.
+      // We don't restrict to working_dir's slug because the JSONL may live
+      // under a worktree slug that differs from the entity_dir we're booting
+      // into now — same logic as the "_anywhere" variant.
+      return session_jsonl_exists_anywhere_in(config_dir, session_id);
+    }
     return session_jsonl_exists(working_dir, session_id);
   }
-  protected check_session_jsonl_exists_anywhere(session_id: string): Promise<boolean> {
+  protected check_session_jsonl_exists_anywhere(
+    session_id: string,
+    entity_id?: string | null,
+  ): Promise<boolean> {
+    const config_dir = entity_id ? this.resolve_claude_config_dir(entity_id) : null;
+    if (config_dir) {
+      return session_jsonl_exists_anywhere_in(config_dir, session_id);
+    }
     return session_jsonl_exists_anywhere(session_id);
   }
 
@@ -556,7 +583,10 @@ export class BotPool extends EventEmitter {
     const now = Date.now();
     let history_dropped = 0;
     for (const [key, session_id] of Object.entries(saved_state.session_history)) {
-      const exists = await this.check_session_jsonl_exists_anywhere(session_id);
+      // `key` is `${entity_id}:${channel_id}` — split out entity_id so the
+      // JSONL check resolves to the entity's per-entity sub dir (#327).
+      const entity_id_from_key = key.split(":")[0] ?? null;
+      const exists = await this.check_session_jsonl_exists_anywhere(session_id, entity_id_from_key);
       if (!exists) {
         console.warn(
           `[pool] Dropping phantom session_history entry ${key} → ${session_id.slice(0, 8)} (no JSONL on disk)`,
@@ -620,7 +650,10 @@ export class BotPool extends EventEmitter {
       // in a feature worktree that differs from entity_dir.
       let restored_session_id = entry.session_id;
       if (restored_session_id) {
-        const exists = await this.check_session_jsonl_exists_anywhere(restored_session_id);
+        const exists = await this.check_session_jsonl_exists_anywhere(
+          restored_session_id,
+          entry.entity_id,
+        );
         if (!exists) {
           console.warn(
             `[pool] pool-${String(entry.id)}: persisted session ${restored_session_id.slice(0, 8)} has no JSONL on disk — dropping to prevent --resume crash loop`,
@@ -823,9 +856,12 @@ export class BotPool extends EventEmitter {
         }
 
         // Resolve per-entity CLAUDE_CONFIG_DIR (if configured) so this session
-        // uses the entity's own Claude Max subscription.
+        // uses the entity's own Claude Max subscription. Pre-flight the dir
+        // (migrate JSONLs from the default ~/.claude, patch onboarding fields)
+        // before spawn so --resume and the interactive TUI both come up clean (#327).
         const resume_claude_config = this.resolve_claude_config_dir(candidate.entity_id);
         if (resume_claude_config) {
+          await ensure_per_entity_config_dir_ready(candidate.entity_id, resume_claude_config);
           extra_env.CLAUDE_CONFIG_DIR = resume_claude_config;
           console.log(
             `[pool] Resuming pool-${String(bot.id)} with CLAUDE_CONFIG_DIR=${resume_claude_config} (entity: ${candidate.entity_id})`,
@@ -1106,9 +1142,12 @@ export class BotPool extends EventEmitter {
       }
 
       // Resolve per-entity CLAUDE_CONFIG_DIR (if configured) so this session
-      // uses the entity's own Claude Max subscription.
+      // uses the entity's own Claude Max subscription. Pre-flight the dir
+      // (migrate JSONLs from the default ~/.claude, patch onboarding fields)
+      // before spawn so --resume and the interactive TUI both come up clean (#327).
       const assign_claude_config = this.resolve_claude_config_dir(entity_id);
       if (assign_claude_config) {
+        await ensure_per_entity_config_dir_ready(entity_id, assign_claude_config);
         extra_env.CLAUDE_CONFIG_DIR = assign_claude_config;
         console.log(
           `[pool] Assigning pool-${String(bot.id)} with CLAUDE_CONFIG_DIR=${assign_claude_config} (entity: ${entity_id})`,
@@ -1686,7 +1725,7 @@ export class BotPool extends EventEmitter {
     const working_dir = entity_dir(this.config.paths, entity_id);
     let resume_id: string;
     let is_resume: boolean;
-    if (session_id && (await this.check_session_jsonl_exists_anywhere(session_id))) {
+    if (session_id && (await this.check_session_jsonl_exists_anywhere(session_id, entity_id))) {
       resume_id = session_id;
       is_resume = true;
     } else {
@@ -1712,9 +1751,12 @@ export class BotPool extends EventEmitter {
       }
 
       // Resolve per-entity CLAUDE_CONFIG_DIR (if configured) so the restarted
-      // session uses the entity's own Claude Max subscription.
+      // session uses the entity's own Claude Max subscription. Pre-flight the
+      // dir (migrate JSONLs from default ~/.claude, patch onboarding fields)
+      // so --resume and the interactive TUI both come up clean (#327).
       const crash_claude_config = this.resolve_claude_config_dir(entity_id);
       if (crash_claude_config) {
+        await ensure_per_entity_config_dir_ready(entity_id, crash_claude_config);
         extra_env.CLAUDE_CONFIG_DIR = crash_claude_config;
         console.log(
           `[pool] Restarting pool-${String(bot.id)} with CLAUDE_CONFIG_DIR=${crash_claude_config} (entity: ${entity_id})`,
@@ -1846,7 +1888,7 @@ export class BotPool extends EventEmitter {
     // original bug self-perpetuated: the next assignment would pull the dead
     // UUID out of history and re-enter the crash loop (issue #256).
     if (bot.session_id && bot.session_confirmed && channel_id && entity_id) {
-      const exists = await this.check_session_jsonl_exists_anywhere(bot.session_id);
+      const exists = await this.check_session_jsonl_exists_anywhere(bot.session_id, entity_id);
       if (exists) {
         const key = `${entity_id}:${channel_id}`;
         this.session_history.set(key, bot.session_id);
@@ -1996,7 +2038,13 @@ export class BotPool extends EventEmitter {
         return;
       }
 
-      const exists = await this.check_session_jsonl_exists(working_dir, session_id);
+      // Pass entity_id so the existence check routes to the per-entity
+      // CLAUDE_CONFIG_DIR when the entity has a subscription override (#327).
+      const exists = await this.check_session_jsonl_exists(
+        working_dir,
+        session_id,
+        current.entity_id,
+      );
 
       // Re-check after await: bot may have been reassigned during the async
       // suspension — cancel_session_watcher only stops future ticks, not an


### PR DESCRIPTION
## Summary

Per-entity Claude Max subscriptions (`subscription.claude_config_dir`) work fine for fresh sessions but wedge pool bots on every daemon recycle that hits a per-entity entity. Two root causes, both fixed forward-looking in `pool.ts`:

1. **Session JSONLs aren't visible to the per-entity dir.** Claude Code looks them up under `$CLAUDE_CONFIG_DIR/projects/`, but transcripts written before the entity switched subs live under `~/.claude/projects/`. `--resume` then silently drops the bot into the onboarding wizard instead of failing loud.
2. **Freshly-authed config dirs are missing the three idle-bypass markers.** After `claude auth login` lands, `oauthAccount` is set but `hasCompletedOnboarding`, `theme`, and `bypassPermissionsModeAccepted` are all unset. Headless `-p` skips onboarding; the interactive (TUI) pool-bot launch path stalls on the first picker.

Fix is a new `claude-config-migration.ts` module with three idempotent, fail-open helpers:

- `migrate_entity_project_dirs()` — mirrors `~/.claude/projects/<slug-containing-entity_id>/` into `<config_dir>/projects/`. `cp -rn` semantics (won't overwrite). Scopes by substring match on `entity_id` so we never leak unrelated entities' session history across subs.
- `ensure_onboarding_fields()` — patches the three idle-bypass markers in `<config_dir>/.claude.json`. Never touches `oauthAccount`. Sources theme from user's `~/.claude.json` with `dark-ansi` fallback.
- `session_jsonl_exists_anywhere_in()` — config-dir-aware JSONL existence check used to back the existing #256 "drop `--resume` if missing" guard.

Wired into `pool.ts` at all three CLAUDE_CONFIG_DIR resolution sites (assign, resume from parked, crash-restart) and at all four JSONL-guard sites. Per-process cache means the disk work runs at most once per `(entity, config_dir)` pair per daemon lifetime.

## Acceptance criteria mapping

- [x] **Pool bot respawn comes up MCP-attached, not in onboarding** — migration + onboarding patch land before tmux spawn, removes both wedge causes.
- [x] **Session continuity preserved** — JSONLs are mirrored, so `--resume <session-id>` finds the transcript under the per-entity dir.
- [x] **Backstop: drop `--resume` if JSONL still missing** — existing #256 guard now config-dir-aware; falls back to fresh spawn instead of wedging.
- [x] **First-launch onboarding bypass** — `ensure_onboarding_fields` populates the three markers when missing.
- [x] **Tests** — 15 unit tests for the helpers (`claude-config-migration.test.ts`) + 7 pool-wiring tests (`per-entity-sub-resume.test.ts`). All 1126 existing tests still pass.
- [x] **Docs updated** — new "First-launch preparation (issue #327)" section in `docs/per-entity-subscriptions.md`.

## Tested live vs. relies on daemon restart

- **Tested live (unit + integration):** the three helpers in isolation against throwaway tempdirs (15 tests), and the BotPool wiring (7 tests) — covers config-dir-aware JSONL routing, migration invocation at `assign()`, fail-open paths.
- **Tested live (manual):** the currently-running canal-street bots (pool-4/8/9/10) are already on the rengen sub via a manual migration done earlier — JSONLs are already copied and `.claude.json` already patched. This PR's code is idempotent and will no-op against those already-prepared dirs.
- **Relies on next daemon restart:** the daemon was deliberately NOT restarted as part of this work. Forward-looking only — any future entity that flips to a per-entity sub will get the automatic migration+patch on the first pool-bot spawn after the next daemon recycle.

## Manual test runbook

Once this lands and the daemon is restarted at the user's discretion:

1. Pick a canal-street pool bot (e.g. pool-4).
2. `tmux kill-session -t pool-4` — simulate a crash.
3. Watch `~/.lobsterfarm/logs/daemon.log`:
   - Should see `[pool] Restarting pool-4 with CLAUDE_CONFIG_DIR=/Users/farm/.lobsterfarm/shared/claude-config-rengen/ (entity: canal-street)`.
   - Should NOT see a `[claude-config] Migrated ...` line (idempotent — already migrated manually).
   - Should NOT see a `[claude-config] Patched onboarding fields ...` line (already patched).
4. `tmux attach -t pool-4` — confirm the bot comes up MCP-attached at the idle prompt, NOT in the onboarding wizard.
5. Send a message in the Discord channel — confirm the bot responds and references prior conversation history (session continuity verified).
6. For a true first-launch test: set up a brand-new entity with `subscription.claude_config_dir` pointing at a fresh dir, `claude auth login` against it, then watch a pool bot spawn for that entity — `[claude-config] Migrated ...` and `[claude-config] Patched onboarding fields ...` should both appear in the daemon log on the first spawn, then never again.

## Test plan

- [ ] `pnpm -F @lobster-farm/daemon test` — passes (verified locally, 1133 tests).
- [ ] `pnpm -F @lobster-farm/daemon typecheck` — passes (verified locally).
- [ ] `pnpm lint` — passes (verified locally).
- [ ] After merge + next daemon restart: kill a canal-street pool bot, watch it respawn at the MCP-attached idle prompt (not the onboarding wizard).

Closes #327