### PR TITLE
chore(daemon): bump opus model id to claude-opus-4-8

### DIFF
--- a/packages/daemon/src/__tests__/session.test.ts
+++ b/packages/daemon/src/__tests__/session.test.ts
@@ -31,7 +31,7 @@ describe("build_model_flags", () => {
   it("maps opus/high to correct flags", () => {
     const flags = build_model_flags({ model: "opus", think: "high" });
     expect(flags).toContain("--model");
-    expect(flags).toContain("claude-opus-4-7");
+    expect(flags).toContain("claude-opus-4-8");
     expect(flags).toContain("--effort");
     expect(flags).toContain("high");
   });
@@ -52,7 +52,7 @@ describe("build_model_flags", () => {
   it("maps opus/xhigh to correct flags", () => {
     const flags = build_model_flags({ model: "opus", think: "xhigh" });
     expect(flags).toContain("--model");
-    expect(flags).toContain("claude-opus-4-7");
+    expect(flags).toContain("claude-opus-4-8");
     expect(flags).toContain("--effort");
     expect(flags).toContain("xhigh");
   });
@@ -60,7 +60,7 @@ describe("build_model_flags", () => {
   it("maps opus/max to correct flags", () => {
     const flags = build_model_flags({ model: "opus", think: "max" });
     expect(flags).toContain("--model");
-    expect(flags).toContain("claude-opus-4-7");
+    expect(flags).toContain("claude-opus-4-8");
     expect(flags).toContain("--effort");
     expect(flags).toContain("max");
   });
@@ -100,7 +100,7 @@ describe("ClaudeSessionManager", () => {
       expect(args).toContain("--agent");
       expect(args).toContain("bob"); // default builder name
       expect(args).toContain("--model");
-      expect(args).toContain("claude-opus-4-7");
+      expect(args).toContain("claude-opus-4-8");
       expect(args).toContain("--permission-mode");
       expect(args).toContain("bypassPermissions");
       expect(args).toContain("--session-id");

--- a/packages/daemon/src/models.ts
+++ b/packages/daemon/src/models.ts
@@ -2,7 +2,7 @@ import type { ModelName, ModelTier, ThinkLevel } from "@lobster-farm/shared";
 
 /** Map abstract model names to Claude CLI model identifiers. */
 const MODEL_IDS: Record<ModelName, string> = {
-  opus: "claude-opus-4-7",
+  opus: "claude-opus-4-8",
   sonnet: "claude-sonnet-4-6",
   haiku: "claude-haiku-4-5-20251001",
 };


### PR DESCRIPTION
## Summary
- Update the `opus` tier in `packages/daemon/src/models.ts` to resolve to `claude-opus-4-8` (was `claude-opus-4-7`).
- Update the four corresponding `claude-opus-4-7` assertions in `packages/daemon/src/__tests__/session.test.ts` to `claude-opus-4-8`.
- Verified with `grep -rn "claude-opus-4-7" packages/` — zero remaining references in live code or tests.

## Rollout
Forward-looking only. Currently-running Opus sessions (canal-street, etc.) stay on 4-7 until their natural next restart. No daemon restart, pool bot recycle, or tmux kill is part of this change. Sessions spawned after the daemon next picks up this build will resolve `opus` -> `claude-opus-4-8`.

## Test plan
- [x] `pnpm -F @lobster-farm/daemon test` — 1133/1133 passing
- [x] `pnpm -F @lobster-farm/daemon typecheck` — clean
- [x] `pnpm -F @lobster-farm/daemon build` — clean
- [x] `pnpm -w lint` (biome) — clean

Closes #329