### PR TITLE
refactor(daemon): un-hardcode model versions — pass tier aliases to --model

### DIFF
--- a/packages/daemon/src/__tests__/session.test.ts
+++ b/packages/daemon/src/__tests__/session.test.ts
@@ -31,20 +31,20 @@ describe("build_model_flags", () => {
   it("maps opus/high to correct flags", () => {
     const flags = build_model_flags({ model: "opus", think: "high" });
     expect(flags).toContain("--model");
-    expect(flags).toContain("claude-opus-4-8");
+    expect(flags).toContain("opus");
     expect(flags).toContain("--effort");
     expect(flags).toContain("high");
   });
 
   it("maps sonnet/standard to correct flags", () => {
     const flags = build_model_flags({ model: "sonnet", think: "standard" });
-    expect(flags).toContain("claude-sonnet-4-6");
+    expect(flags).toContain("sonnet");
     expect(flags).toContain("medium");
   });
 
   it("maps haiku/none to model only", () => {
     const flags = build_model_flags({ model: "haiku", think: "none" });
-    expect(flags).toContain("claude-haiku-4-5-20251001");
+    expect(flags).toContain("haiku");
     expect(flags).toContain("--effort");
     expect(flags).toContain("low");
   });
@@ -52,7 +52,7 @@ describe("build_model_flags", () => {
   it("maps opus/xhigh to correct flags", () => {
     const flags = build_model_flags({ model: "opus", think: "xhigh" });
     expect(flags).toContain("--model");
-    expect(flags).toContain("claude-opus-4-8");
+    expect(flags).toContain("opus");
     expect(flags).toContain("--effort");
     expect(flags).toContain("xhigh");
   });
@@ -60,7 +60,7 @@ describe("build_model_flags", () => {
   it("maps opus/max to correct flags", () => {
     const flags = build_model_flags({ model: "opus", think: "max" });
     expect(flags).toContain("--model");
-    expect(flags).toContain("claude-opus-4-8");
+    expect(flags).toContain("opus");
     expect(flags).toContain("--effort");
     expect(flags).toContain("max");
   });
@@ -100,7 +100,7 @@ describe("ClaudeSessionManager", () => {
       expect(args).toContain("--agent");
       expect(args).toContain("bob"); // default builder name
       expect(args).toContain("--model");
-      expect(args).toContain("claude-opus-4-8");
+      expect(args).toContain("opus");
       expect(args).toContain("--permission-mode");
       expect(args).toContain("bypassPermissions");
       expect(args).toContain("--session-id");

--- a/packages/daemon/src/models.ts
+++ b/packages/daemon/src/models.ts
@@ -1,11 +1,4 @@
-import type { ModelName, ModelTier, ThinkLevel } from "@lobster-farm/shared";
-
-/** Map abstract model names to Claude CLI model identifiers. */
-const MODEL_IDS: Record<ModelName, string> = {
-  opus: "claude-opus-4-8",
-  sonnet: "claude-sonnet-4-6",
-  haiku: "claude-haiku-4-5-20251001",
-};
+import type { ModelTier, ThinkLevel } from "@lobster-farm/shared";
 
 /**
  * Map think levels to Claude CLI effort flags.
@@ -21,9 +14,17 @@ const EFFORT_MAP: Record<ThinkLevel, string | null> = {
   max: "max",
 };
 
-/** Resolve a ModelTier to a Claude CLI model ID string. */
+/**
+ * Resolve a ModelTier to a Claude CLI --model value.
+ *
+ * Returns the bare tier alias ("opus"/"sonnet"/"haiku") rather than a pinned
+ * version ID. The Claude CLI treats these aliases as "the latest model" in each
+ * family, so sessions always track the current default — e.g. `opus` resolves
+ * to the latest Opus with its 1M context window — without us having to bump a
+ * hardcoded version string here whenever a new model ships.
+ */
 export function resolve_model_id(tier: ModelTier): string {
-  return MODEL_IDS[tier.model];
+  return tier.model;
 }
 
 /** Resolve a ThinkLevel to a Claude CLI effort flag value, or null if not applicable. */


### PR DESCRIPTION
## What

`resolve_model_id()` in `packages/daemon/src/models.ts` now returns the bare tier alias (`opus`/`sonnet`/`haiku`) instead of a pinned version ID.

Before:
```
opus   -> claude-opus-4-8
sonnet -> claude-sonnet-4-6
haiku  -> claude-haiku-4-5-20251001
```
After: `--model opus` / `--model sonnet` / `--model haiku` — the CLI resolves each to the latest model in that family.

## Why

- **No more version-string maintenance** when new models ship.
- **Matches intent** — we want the latest opus (with its 1M context window), which the `opus` alias gives us.
- **Zero behavioral change today** — `opus` already resolves to `claude-opus-4-8[1m]`, which is what every live session already runs.

## Safety

- Context-window resolution (`session-context.ts`) ignores the model string and always returns 1M — unaffected.
- Tests updated to assert the aliases. Full daemon suite: **1135 passed**. Typecheck + biome clean.

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)