### PR TITLE
revert: roll back #335 (worktree guard) and #340 (model alias passing)

### DIFF
--- a/packages/daemon/src/__tests__/session.test.ts
+++ b/packages/daemon/src/__tests__/session.test.ts
@@ -31,20 +31,20 @@ describe("build_model_flags", () => {
   it("maps opus/high to correct flags", () => {
     const flags = build_model_flags({ model: "opus", think: "high" });
     expect(flags).toContain("--model");
-    expect(flags).toContain("opus");
+    expect(flags).toContain("claude-opus-4-8");
     expect(flags).toContain("--effort");
     expect(flags).toContain("high");
   });
 
   it("maps sonnet/standard to correct flags", () => {
     const flags = build_model_flags({ model: "sonnet", think: "standard" });
-    expect(flags).toContain("sonnet");
+    expect(flags).toContain("claude-sonnet-4-6");
     expect(flags).toContain("medium");
   });
 
   it("maps haiku/none to model only", () => {
     const flags = build_model_flags({ model: "haiku", think: "none" });
-    expect(flags).toContain("haiku");
+    expect(flags).toContain("claude-haiku-4-5-20251001");
     expect(flags).toContain("--effort");
     expect(flags).toContain("low");
   });
@@ -52,7 +52,7 @@ describe("build_model_flags", () => {
   it("maps opus/xhigh to correct flags", () => {
     const flags = build_model_flags({ model: "opus", think: "xhigh" });
     expect(flags).toContain("--model");
-    expect(flags).toContain("opus");
+    expect(flags).toContain("claude-opus-4-8");
     expect(flags).toContain("--effort");
     expect(flags).toContain("xhigh");
   });
@@ -60,7 +60,7 @@ describe("build_model_flags", () => {
   it("maps opus/max to correct flags", () => {
     const flags = build_model_flags({ model: "opus", think: "max" });
     expect(flags).toContain("--model");
-    expect(flags).toContain("opus");
+    expect(flags).toContain("claude-opus-4-8");
     expect(flags).toContain("--effort");
     expect(flags).toContain("max");
   });
@@ -100,7 +100,7 @@ describe("ClaudeSessionManager", () => {
       expect(args).toContain("--agent");
       expect(args).toContain("bob"); // default builder name
       expect(args).toContain("--model");
-      expect(args).toContain("opus");
+      expect(args).toContain("claude-opus-4-8");
       expect(args).toContain("--permission-mode");
       expect(args).toContain("bypassPermissions");
       expect(args).toContain("--session-id");

--- a/packages/daemon/src/__tests__/worktree-cleanup.test.ts
+++ b/packages/daemon/src/__tests__/worktree-cleanup.test.ts
@@ -58,7 +58,6 @@ function make_porcelain(
     head?: string;
     branch?: string;
     bare?: boolean;
-    locked?: boolean;
   }>
 ): string {
   return entries
@@ -67,7 +66,6 @@ function make_porcelain(
       lines.push(`HEAD ${e.head ?? "abc1234567890"}`);
       if (e.branch) lines.push(`branch ${e.branch}`);
       if (e.bare) lines.push("bare");
-      if (e.locked) lines.push("locked");
       return lines.join("\n");
     })
     .join("\n\n");
@@ -265,7 +263,6 @@ describe("parse_worktree_list", () => {
       head: "abc123",
       branch: "refs/heads/main",
       bare: false,
-      locked: false,
     });
   });
 
@@ -300,24 +297,6 @@ describe("parse_worktree_list", () => {
 
     const entries = parse_worktree_list(output);
     expect(entries[0]!.bare).toBe(true);
-  });
-
-  it("recognizes locked worktree entries (bare and with reason)", () => {
-    const output = [
-      "worktree /repo/.claude/worktrees/agent-1",
-      "HEAD abc123",
-      "branch refs/heads/feature/a",
-      "locked",
-      "",
-      "worktree /repo/.claude/worktrees/agent-2",
-      "HEAD def456",
-      "branch refs/heads/feature/b",
-      "locked in-flight build",
-    ].join("\n");
-
-    const entries = parse_worktree_list(output);
-    expect(entries[0]!.locked).toBe(true);
-    expect(entries[1]!.locked).toBe(true);
   });
 });
 
@@ -473,54 +452,45 @@ describe("cleanup_after_merge", () => {
     expect(removed_paths).not.toContain("/repo/.claude/worktrees/agent-999-other");
   });
 
-  it("does NOT remove a worktree with an active session inside it (in-flight guard)", async () => {
+  it("relocates sessions before removing worktree", async () => {
     const porcelain = make_porcelain(
       { path: "/repo", branch: "refs/heads/main" },
       { path: "/repo/worktrees/my-feature", branch: "refs/heads/feature/my-feature" },
     );
     setup_git_mocks({ worktree_list: porcelain });
 
-    // A live pane has its cwd inside the worktree → it's an active build.
-    // `-F #{pane_current_path}` yields just the path per line.
+    // Track call order: relocation (execFileSync for list-panes) must happen
+    // before worktree removal (execFile for git worktree remove).
+    const call_order: string[] = [];
+
     mock_exec_file_sync.mockImplementation((cmd: string, args: string[]) => {
       if (cmd === "tmux" && args[0] === "list-panes") {
-        return "/repo/worktrees/my-feature/src\n";
+        call_order.push("tmux:list-panes");
+        return "session1 %0 /repo/worktrees/my-feature/src\n";
+      }
+      if (cmd === "tmux" && args[0] === "send-keys") {
+        call_order.push("tmux:send-keys");
+        return "";
       }
       return "";
     });
 
-    await cleanup_after_merge("/repo", "feature/my-feature");
-
-    // The in-flight guard must prevent the force-remove entirely.
-    const remove_called = mock_exec_file.mock.calls.some(
-      (c: unknown[]) =>
-        (c[1] as string[])[0] === "worktree" &&
-        (c[1] as string[])[1] === "remove" &&
-        (c[1] as string[])[2] === "/repo/worktrees/my-feature",
-    );
-    expect(remove_called).toBe(false);
-  });
-
-  it("does NOT remove a locked worktree (in-flight guard)", async () => {
-    const porcelain = make_porcelain(
-      { path: "/repo", branch: "refs/heads/main" },
-      {
-        path: "/repo/.claude/worktrees/agent-x",
-        branch: "refs/heads/feature/my-feature",
-        locked: true,
-      },
-    );
-    setup_git_mocks({ worktree_list: porcelain });
+    const original_impl = mock_exec_file.getMockImplementation()!;
+    mock_exec_file.mockImplementation((cmd: string, args: string[], opts: unknown) => {
+      if (cmd === "git" && args[0] === "worktree" && args[1] === "remove") {
+        call_order.push("git:worktree-remove");
+      }
+      return original_impl(cmd, args, opts);
+    });
 
     await cleanup_after_merge("/repo", "feature/my-feature");
 
-    const remove_called = mock_exec_file.mock.calls.some(
-      (c: unknown[]) =>
-        (c[1] as string[])[0] === "worktree" &&
-        (c[1] as string[])[1] === "remove" &&
-        (c[1] as string[])[2] === "/repo/.claude/worktrees/agent-x",
-    );
-    expect(remove_called).toBe(false);
+    // Relocation must precede removal
+    const relocation_idx = call_order.indexOf("tmux:list-panes");
+    const removal_idx = call_order.indexOf("git:worktree-remove");
+    expect(relocation_idx).toBeGreaterThanOrEqual(0);
+    expect(removal_idx).toBeGreaterThanOrEqual(0);
+    expect(relocation_idx).toBeLessThan(removal_idx);
   });
 
   it("does not throw when .claude/worktrees/ does not exist", async () => {

--- a/packages/daemon/src/models.ts
+++ b/packages/daemon/src/models.ts
@@ -1,4 +1,11 @@
-import type { ModelTier, ThinkLevel } from "@lobster-farm/shared";
+import type { ModelName, ModelTier, ThinkLevel } from "@lobster-farm/shared";
+
+/** Map abstract model names to Claude CLI model identifiers. */
+const MODEL_IDS: Record<ModelName, string> = {
+  opus: "claude-opus-4-8",
+  sonnet: "claude-sonnet-4-6",
+  haiku: "claude-haiku-4-5-20251001",
+};
 
 /**
  * Map think levels to Claude CLI effort flags.
@@ -14,17 +21,9 @@ const EFFORT_MAP: Record<ThinkLevel, string | null> = {
   max: "max",
 };
 
-/**
- * Resolve a ModelTier to a Claude CLI --model value.
- *
- * Returns the bare tier alias ("opus"/"sonnet"/"haiku") rather than a pinned
- * version ID. The Claude CLI treats these aliases as "the latest model" in each
- * family, so sessions always track the current default — e.g. `opus` resolves
- * to the latest Opus with its 1M context window — without us having to bump a
- * hardcoded version string here whenever a new model ships.
- */
+/** Resolve a ModelTier to a Claude CLI model ID string. */
 export function resolve_model_id(tier: ModelTier): string {
-  return tier.model;
+  return MODEL_IDS[tier.model];
 }
 
 /** Resolve a ThinkLevel to a Claude CLI effort flag value, or null if not applicable. */

--- a/packages/daemon/src/worktree-cleanup.ts
+++ b/packages/daemon/src/worktree-cleanup.ts
@@ -83,31 +83,6 @@ export function relocate_sessions_from_path(target_path: string, safe_path: stri
   return relocated;
 }
 
-/**
- * Check whether any live tmux pane has its cwd inside `target_path`.
- *
- * Used as an in-flight guard: a worktree with an active session/build inside
- * it must never be force-removed, even mid-merge. Best-effort — if tmux is
- * unavailable we return false (no evidence of activity) rather than throwing.
- */
-export function has_active_session_in_path(target_path: string): boolean {
-  const target_prefix = target_path.endsWith("/") ? target_path : `${target_path}/`;
-
-  let pane_lines: string[];
-  try {
-    const result = execFileSync("tmux", ["list-panes", "-a", "-F", "#{pane_current_path}"], {
-      encoding: "utf-8",
-      timeout: 5000,
-    });
-    pane_lines = result.trim().split("\n").filter(Boolean);
-  } catch {
-    // tmux not running or no sessions — no evidence of an active build.
-    return false;
-  }
-
-  return pane_lines.some((cwd) => cwd === target_path || cwd.startsWith(target_prefix));
-}
-
 // ── Parsed worktree entry from `git worktree list --porcelain` ──
 
 interface WorktreeEntry {
@@ -119,8 +94,6 @@ interface WorktreeEntry {
   branch: string | null;
   /** True if this is the main working tree. */
   bare: boolean;
-  /** True if the worktree is locked (`git worktree lock` / a `locked` file). */
-  locked: boolean;
 }
 
 /**
@@ -144,7 +117,6 @@ export function parse_worktree_list(output: string): WorktreeEntry[] {
     let head = "";
     let branch: string | null = null;
     let bare = false;
-    let locked = false;
 
     for (const line of lines) {
       if (line.startsWith("worktree ")) {
@@ -155,14 +127,11 @@ export function parse_worktree_list(output: string): WorktreeEntry[] {
         branch = line.slice("branch ".length);
       } else if (line === "bare") {
         bare = true;
-      } else if (line === "locked" || line.startsWith("locked ")) {
-        // Porcelain emits a bare "locked" line, or "locked <reason>".
-        locked = true;
       }
     }
 
     if (path) {
-      entries.push({ path, head, branch, bare, locked });
+      entries.push({ path, head, branch, bare });
     }
   }
 
@@ -176,39 +145,6 @@ export function parse_worktree_list(output: string): WorktreeEntry[] {
 function short_branch(ref: string): string {
   const prefix = "refs/heads/";
   return ref.startsWith(prefix) ? ref.slice(prefix.length) : ref;
-}
-
-/**
- * Check whether the worktree at `worktree_path` is locked.
- *
- * The harness (EnterWorktree) marks every active agent build with a git
- * `locked` file. We treat a locked worktree as in-flight and must never
- * force-remove it. Best-effort — on any error we conservatively report
- * `true` (assume in-flight) so cleanup never destroys an active build.
- */
-export async function is_worktree_locked(
-  repo_path: string,
-  worktree_path: string,
-): Promise<boolean> {
-  try {
-    const { stdout } = await exec("git", ["worktree", "list", "--porcelain"], {
-      cwd: repo_path,
-      timeout: GIT_TIMEOUT_MS,
-    });
-    const normalized = worktree_path.replace(/\/+$/, "");
-    const entry = parse_worktree_list(stdout).find(
-      (e) => e.path.replace(/\/+$/, "") === normalized,
-    );
-    // Unknown path → not a registered worktree here → let normal removal proceed.
-    return entry ? entry.locked : false;
-  } catch (err) {
-    // Couldn't determine lock state — fail safe: treat as in-flight, skip removal.
-    console.error(
-      `[worktree-cleanup] Could not determine lock state for ${worktree_path}, ` +
-        `treating as in-flight: ${String(err instanceof Error ? err.message : err)}`,
-    );
-    return true;
-  }
 }
 
 // ── Core cleanup function ──
@@ -227,22 +163,6 @@ export async function remove_worktree(
   branch: string,
 ): Promise<boolean> {
   let removed_worktree = false;
-
-  // In-flight guard: never force-remove a worktree that is locked (the harness
-  // marks active agent builds with a git `locked` file) or that has a live
-  // session/build with its cwd inside it. This is what protects in-progress
-  // builds from being reaped when an unrelated PR merges or during the stale
-  // sweep — the failure mode that destroyed #155/#174.
-  if (await is_worktree_locked(repo_path, worktree_path)) {
-    console.warn(`[worktree-cleanup] Skipping locked (in-flight) worktree: ${worktree_path}`);
-    return false;
-  }
-  if (has_active_session_in_path(worktree_path)) {
-    console.warn(
-      `[worktree-cleanup] Skipping worktree with an active session/build: ${worktree_path}`,
-    );
-    return false;
-  }
 
   // Step 1: Remove the worktree
   try {
@@ -341,10 +261,13 @@ export async function cleanup_after_merge(repo_path: string, branch: string): Pr
   // 1. Check git worktree list for a worktree on this branch
   const worktree_path = await find_worktree_for_branch(repo_path, branch);
   if (worktree_path) {
-    // remove_worktree refuses to remove a locked or in-use worktree, so we do
-    // NOT relocate sessions out first — relocating would move a live build's
-    // pane away and defeat the in-flight guard. If the worktree is genuinely
-    // idle, there's nothing to relocate anyway.
+    // Relocate any sessions whose cwd is inside this worktree before removal
+    const relocated = relocate_sessions_from_path(worktree_path, repo_path);
+    if (relocated > 0) {
+      console.log(
+        `[worktree-cleanup] Relocated ${String(relocated)} session(s) from ${worktree_path}`,
+      );
+    }
     await remove_worktree(repo_path, worktree_path, branch);
   } else {
     console.log(`[worktree-cleanup] No git worktree found for branch: ${branch}`);
@@ -392,9 +315,13 @@ async function cleanup_claude_worktrees(repo_path: string, branch: string): Prom
       if (entry.name.includes(branch_slug)) {
         const wt_path = join(claude_wt_dir, entry.name);
         console.log(`[worktree-cleanup] Found .claude/worktrees/ match: ${wt_path}`);
-        // remove_worktree refuses locked / in-use worktrees; don't relocate
-        // first (it would defeat the in-flight guard). Agent worktrees here
-        // carry a `locked` file, so an active build is skipped outright.
+        // Relocate any sessions whose cwd is inside this worktree before removal
+        const relocated = relocate_sessions_from_path(wt_path, repo_path);
+        if (relocated > 0) {
+          console.log(
+            `[worktree-cleanup] Relocated ${String(relocated)} session(s) from ${wt_path}`,
+          );
+        }
         await remove_worktree(repo_path, wt_path, branch);
       }
     }


### PR DESCRIPTION
Closes #341

Reverts **#335** and **#340** per decision — neither is needed.

- **#335** (worktree-cleanup in-flight guard): the entity-side locked-`.claude/worktrees/` convention already covers the reaping hazard; the daemon guard is redundant. Was never deployed, so source-only.
- **#340** (model tier aliases → `--model`): was a dead-end attempt at the ECONNRESET wedge (solved separately). Reverting restores #330's pinned IDs (opus → claude-opus-4-8).

Both reverts clean; build + typecheck pass; full daemon suite green (1133 tests). No runtime change until next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)