### PR TITLE
feat(daemon): MCP connection verification + auto-reconnect healthcheck, staggered boot resumes

### DIFF
--- a/packages/daemon/src/__tests__/commander-mcp-health.test.ts
+++ b/packages/daemon/src/__tests__/commander-mcp-health.test.ts
@@ -199,6 +199,48 @@ describe("CommanderProcess MCP health (issue #345)", () => {
       await c.check_mcp_health();
       expect(mock_run_cycle).toHaveBeenCalledTimes(MCP_GIVEUP_THRESHOLD);
     });
+
+    it("reports recovery after a kill+resume fallback, once", async () => {
+      const c = make_commander();
+      c.last_started_at = new Date(Date.now() - MCP_GRACE_PERIOD_MS - 1000);
+      mock_has_mcp_child.mockReturnValue(false);
+      mock_run_cycle.mockResolvedValue("fell_back");
+
+      await c.check_mcp_health();
+      await c.check_mcp_health(); // cycle runs, falls back
+
+      const sentry = await import("../sentry.js");
+      expect(sentry.captureMessage).not.toHaveBeenCalled(); // below give-up threshold
+
+      // Crash-restart brought the session back with a live MCP child.
+      mock_has_mcp_child.mockReturnValue(true);
+      await c.check_mcp_health();
+
+      expect(sentry.captureMessage).toHaveBeenCalledWith(
+        "Commander MCP recovered after kill+resume fallback",
+        "info",
+        expect.anything(),
+      );
+
+      await c.check_mcp_health();
+      expect(sentry.captureMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it("stays silent when recovery came from a routine Step 1 reconnect", async () => {
+      const c = make_commander();
+      c.last_started_at = new Date(Date.now() - MCP_GRACE_PERIOD_MS - 1000);
+      mock_has_mcp_child.mockReturnValue(false);
+      mock_run_cycle.mockResolvedValue("reconnected");
+
+      await c.check_mcp_health();
+      await c.check_mcp_health();
+
+      mock_has_mcp_child.mockReturnValue(true);
+      await c.check_mcp_health();
+
+      const sentry = await import("../sentry.js");
+      expect(sentry.captureMessage).not.toHaveBeenCalled();
+    });
   });
 
   describe("verify_mcp_post_spawn", () => {

--- a/packages/daemon/src/__tests__/commander-mcp-health.test.ts
+++ b/packages/daemon/src/__tests__/commander-mcp-health.test.ts
@@ -1,0 +1,246 @@
+import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
+import type { LobsterFarmConfig } from "@lobster-farm/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  MCP_GIVEUP_THRESHOLD,
+  MCP_GRACE_PERIOD_MS,
+  MCP_RECOVERY_COOLDOWN_MS,
+} from "../mcp-health.js";
+
+// Mock sentry — commander-process.ts imports it directly.
+vi.mock("../sentry.js", () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  addBreadcrumb: vi.fn(),
+}));
+
+// Mock node:child_process's execFileSync — used by check_mcp_health()'s
+// fallback kill_fn (`tmux kill-session`). ESM module namespaces aren't
+// spy-able directly, so this needs vi.mock rather than vi.spyOn.
+vi.mock("node:child_process", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:child_process")>();
+  return { ...original, execFileSync: vi.fn() };
+});
+
+// Mock pool.js's is_tmux_session_idle — commander-process.ts reuses it for
+// idle detection. Mocking the whole module would be wrong (pool.ts is huge
+// and unrelated); only this one named export is used here.
+vi.mock("../pool.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../pool.js")>();
+  return {
+    ...original,
+    is_tmux_session_idle: vi.fn().mockReturnValue(true),
+  };
+});
+
+// Partially mock mcp-health.js: keep the pure state-machine functions real,
+// replace the tmux/pgrep-driving functions with controllable mocks.
+vi.mock("../mcp-health.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../mcp-health.js")>();
+  return {
+    ...original,
+    has_mcp_child: vi.fn().mockReturnValue(true),
+    run_mcp_recovery_cycle: vi.fn().mockResolvedValue("reconnected"),
+    wait_for_mcp_child: vi.fn().mockResolvedValue(true),
+  };
+});
+
+function make_config(): LobsterFarmConfig {
+  return LobsterFarmConfigSchema.parse({
+    user: { name: "Test" },
+    paths: { lobsterfarm_dir: "/tmp" },
+  });
+}
+
+/** Minimal typed view onto CommanderProcess internals under test. Avoids a
+ * blanket `any` — each field/method used below is named explicitly. */
+interface CommanderInternals {
+  last_started_at: Date | null;
+  mcp_state: Map<number, unknown>;
+  check_mcp_health(): Promise<void>;
+  verify_mcp_post_spawn(): Promise<boolean>;
+  is_idle(): boolean;
+}
+
+describe("CommanderProcess MCP health (issue #345)", () => {
+  let CommanderProcess: typeof import("../commander-process.js").CommanderProcess;
+  let mock_has_mcp_child: ReturnType<typeof vi.fn>;
+  let mock_run_cycle: ReturnType<typeof vi.fn>;
+  let mock_wait: ReturnType<typeof vi.fn>;
+  let mock_is_idle: ReturnType<typeof vi.fn>;
+  let kill_spy: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const mod = await import("../commander-process.js");
+    CommanderProcess = mod.CommanderProcess;
+
+    const mcp_health = await import("../mcp-health.js");
+    mock_has_mcp_child = mcp_health.has_mcp_child as unknown as ReturnType<typeof vi.fn>;
+    mock_run_cycle = mcp_health.run_mcp_recovery_cycle as unknown as ReturnType<typeof vi.fn>;
+    mock_wait = mcp_health.wait_for_mcp_child as unknown as ReturnType<typeof vi.fn>;
+    mock_has_mcp_child.mockReturnValue(true);
+    mock_run_cycle.mockReset().mockResolvedValue("reconnected");
+    mock_wait.mockReset().mockResolvedValue(true);
+
+    const pool = await import("../pool.js");
+    mock_is_idle = pool.is_tmux_session_idle as unknown as ReturnType<typeof vi.fn>;
+    mock_is_idle.mockReturnValue(true);
+
+    const child_process = await import("node:child_process");
+    kill_spy = child_process.execFileSync as unknown as ReturnType<typeof vi.fn>;
+    (kill_spy as ReturnType<typeof vi.fn>).mockReset().mockReturnValue("");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function make_commander(): InstanceType<typeof CommanderProcess> & CommanderInternals {
+    const commander = new CommanderProcess(make_config());
+    return commander as unknown as InstanceType<typeof CommanderProcess> & CommanderInternals;
+  }
+
+  describe("check_mcp_health", () => {
+    it("does nothing when the MCP child is present", async () => {
+      const c = make_commander();
+      c.last_started_at = new Date(Date.now() - MCP_GRACE_PERIOD_MS - 1000);
+      mock_has_mcp_child.mockReturnValue(true);
+
+      await c.check_mcp_health();
+      await c.check_mcp_health();
+
+      expect(mock_run_cycle).not.toHaveBeenCalled();
+    });
+
+    it("does not act within the grace period after a fresh start", async () => {
+      const c = make_commander();
+      c.last_started_at = new Date();
+      mock_has_mcp_child.mockReturnValue(false);
+
+      await c.check_mcp_health();
+
+      expect(mock_run_cycle).not.toHaveBeenCalled();
+    });
+
+    it("runs a recovery cycle once consecutive fails cross the threshold", async () => {
+      const c = make_commander();
+      c.last_started_at = new Date(Date.now() - MCP_GRACE_PERIOD_MS - 1000);
+      mock_has_mcp_child.mockReturnValue(false);
+
+      await c.check_mcp_health(); // 1st fail
+      await c.check_mcp_health(); // 2nd fail — fires
+
+      expect(mock_run_cycle).toHaveBeenCalledTimes(1);
+      expect(mock_run_cycle.mock.calls[0][0]).toBe("pat");
+    });
+
+    it("defers while mid-turn (not idle)", async () => {
+      const c = make_commander();
+      c.last_started_at = new Date(Date.now() - MCP_GRACE_PERIOD_MS - 1000);
+      mock_has_mcp_child.mockReturnValue(false);
+      mock_is_idle.mockReturnValue(false);
+
+      await c.check_mcp_health();
+      await c.check_mcp_health();
+      await c.check_mcp_health();
+
+      expect(mock_run_cycle).not.toHaveBeenCalled();
+    });
+
+    it("kills the tmux session via the fallback callback when Reconnect is exhausted", async () => {
+      const c = make_commander();
+      c.last_started_at = new Date(Date.now() - MCP_GRACE_PERIOD_MS - 1000);
+      mock_has_mcp_child.mockReturnValue(false);
+      mock_run_cycle.mockImplementation(async (_session: string, kill_fn: () => void) => {
+        kill_fn();
+        return "fell_back";
+      });
+
+      await c.check_mcp_health();
+      await c.check_mcp_health();
+
+      expect(kill_spy).toHaveBeenCalledWith(
+        "tmux",
+        ["kill-session", "-t", "pat"],
+        expect.objectContaining({ stdio: "ignore" }),
+      );
+    });
+
+    it("gives up after MCP_GIVEUP_THRESHOLD failed cycles and captures to sentry, without spamming further cycles", async () => {
+      const c = make_commander();
+      c.last_started_at = new Date(Date.now() - MCP_GRACE_PERIOD_MS - 1000);
+      mock_has_mcp_child.mockReturnValue(false);
+      mock_run_cycle.mockResolvedValue("fell_back");
+
+      let now = Date.now();
+      const real_now = Date.now;
+      vi.spyOn(Date, "now").mockImplementation(() => now);
+
+      await c.check_mcp_health(); // 1st fail
+      for (let i = 0; i < MCP_GIVEUP_THRESHOLD; i++) {
+        now += MCP_RECOVERY_COOLDOWN_MS + 1000;
+        await c.check_mcp_health();
+      }
+
+      vi.spyOn(Date, "now").mockImplementation(real_now);
+
+      expect(mock_run_cycle).toHaveBeenCalledTimes(MCP_GIVEUP_THRESHOLD);
+
+      const sentry = await import("../sentry.js");
+      expect(sentry.captureMessage).toHaveBeenCalledWith(
+        "Commander MCP recovery gave up",
+        "error",
+        expect.anything(),
+      );
+
+      // Silent afterward — no further recovery cycles fire.
+      now += MCP_RECOVERY_COOLDOWN_MS + 1000;
+      await c.check_mcp_health();
+      expect(mock_run_cycle).toHaveBeenCalledTimes(MCP_GIVEUP_THRESHOLD);
+    });
+  });
+
+  describe("verify_mcp_post_spawn", () => {
+    it("returns true immediately when the MCP child appears within the grace wait", async () => {
+      mock_wait.mockResolvedValue(true);
+      const c = make_commander();
+
+      const result = await c.verify_mcp_post_spawn();
+
+      expect(result).toBe(true);
+      expect(mock_run_cycle).not.toHaveBeenCalled();
+    });
+
+    it("falls through to a scripted reconnect when the grace wait times out", async () => {
+      mock_wait.mockResolvedValue(false);
+      mock_run_cycle.mockResolvedValue("reconnected");
+      const c = make_commander();
+
+      const result = await c.verify_mcp_post_spawn();
+
+      expect(result).toBe(true);
+      expect(mock_run_cycle.mock.calls[0][0]).toBe("pat");
+    });
+
+    it("returns false without killing tmux when both the wait and reconnect fail", async () => {
+      mock_wait.mockResolvedValue(false);
+      mock_run_cycle.mockImplementation(async (_session: string, kill_fn: () => void) => {
+        // Post-spawn recovery must pass a no-op kill_fn — killing a session
+        // we just spawned would defeat the point of "post-spawn verify".
+        kill_fn();
+        return "fell_back";
+      });
+      const c = make_commander();
+
+      const result = await c.verify_mcp_post_spawn();
+
+      expect(result).toBe(false);
+      expect(kill_spy).not.toHaveBeenCalledWith(
+        "tmux",
+        ["kill-session", "-t", "pat"],
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/packages/daemon/src/__tests__/helpers/test-bot-pool-base.ts
+++ b/packages/daemon/src/__tests__/helpers/test-bot-pool-base.ts
@@ -21,4 +21,15 @@ export class BotPoolTestBase extends BotPool {
   protected override watch_session_confirmation(bot: PoolBot): void {
     bot.session_confirmed = true;
   }
+  /** Default to "MCP healthy" (issue #345) — these tests don't exercise
+   * MCP verification and would otherwise incur real tmux/pgrep calls and
+   * multi-second wait loops against fake tmux session names. Test files
+   * that need to exercise MCP detection/recovery should extend BotPool
+   * directly (see pool-mcp-health.test.ts). */
+  protected override async check_mcp_health(): Promise<void> {
+    /* no-op */
+  }
+  protected override async verify_mcp_post_spawn(): Promise<boolean> {
+    return true;
+  }
 }

--- a/packages/daemon/src/__tests__/mcp-health.test.ts
+++ b/packages/daemon/src/__tests__/mcp-health.test.ts
@@ -118,6 +118,7 @@ describe("process_mcp_health_tick", () => {
       consecutive_fails: 0,
       last_action_ms: null,
       cycle_fail_timestamps: [],
+      last_fell_back_at: null,
       given_up: false,
     });
   });
@@ -227,11 +228,95 @@ describe("record_cycle_outcome", () => {
       consecutive_fails: 5,
       last_action_ms: 1000,
       cycle_fail_timestamps: [100, 200, 300],
+      last_fell_back_at: null,
       given_up: true,
     });
     const result = process_mcp_health_tick(1, true, true, MCP_GRACE_PERIOD_MS, 2000, state);
     expect(result).toEqual({ action: "none" });
     expect(state.get(1)?.given_up).toBe(false);
+  });
+
+  it("stamps last_fell_back_at on a fell_back outcome", () => {
+    const state = new Map<number, McpRecoveryState>();
+    record_cycle_outcome(1, "fell_back", 5000, state);
+    expect(state.get(1)?.last_fell_back_at).toBe(5000);
+  });
+
+  it("does not stamp last_fell_back_at on a reconnected outcome", () => {
+    const state = new Map<number, McpRecoveryState>();
+    record_cycle_outcome(1, "reconnected", 5000, state);
+    expect(state.get(1)?.last_fell_back_at ?? null).toBeNull();
+  });
+});
+
+// ── Post-Step-2 recovery signal (spec: #alerts on successful recovery after
+//    a fallback — silent for routine Step 1 reconnects) ──
+
+describe("process_mcp_health_tick post-fallback recovery signal", () => {
+  it("reports notify_recovered on the first healthy tick after a fell_back cycle", () => {
+    const state = new Map<number, McpRecoveryState>();
+    process_mcp_health_tick(1, false, true, MCP_GRACE_PERIOD_MS, 0, state); // 1st fail
+    process_mcp_health_tick(1, false, true, MCP_GRACE_PERIOD_MS, 1000, state); // fires recover
+    record_cycle_outcome(1, "fell_back", 1000, state);
+
+    const recovered = process_mcp_health_tick(1, true, true, MCP_GRACE_PERIOD_MS, 2000, state);
+    expect(recovered).toEqual({ action: "notify_recovered" });
+  });
+
+  it("only reports the recovery once — later healthy ticks stay silent", () => {
+    const state = new Map<number, McpRecoveryState>();
+    record_cycle_outcome(1, "fell_back", 1000, state);
+
+    expect(process_mcp_health_tick(1, true, true, MCP_GRACE_PERIOD_MS, 2000, state)).toEqual({
+      action: "notify_recovered",
+    });
+    expect(process_mcp_health_tick(1, true, true, MCP_GRACE_PERIOD_MS, 3000, state)).toEqual({
+      action: "none",
+    });
+  });
+
+  it("stays silent on a healthy tick with no prior fallback (routine Step 1 reconnect)", () => {
+    const state = new Map<number, McpRecoveryState>();
+    process_mcp_health_tick(1, false, true, MCP_GRACE_PERIOD_MS, 0, state);
+    process_mcp_health_tick(1, false, true, MCP_GRACE_PERIOD_MS, 1000, state);
+    record_cycle_outcome(1, "reconnected", 1000, state);
+
+    const result = process_mcp_health_tick(1, true, true, MCP_GRACE_PERIOD_MS, 2000, state);
+    expect(result).toEqual({ action: "none" });
+  });
+
+  it("survives the grace period of the respawned session (the real Step 2 path)", () => {
+    // Step 2 kills tmux; crash-recovery respawns with a fresh assigned_at, so
+    // the next ticks land inside the grace window before the bot reads healthy.
+    const state = new Map<number, McpRecoveryState>();
+    record_cycle_outcome(1, "fell_back", 1000, state);
+
+    process_mcp_health_tick(1, false, true, 0, 2000, state); // respawned, still warming
+    process_mcp_health_tick(1, true, true, 5_000, 3000, state); // healthy but in grace
+
+    const recovered = process_mcp_health_tick(1, true, true, MCP_GRACE_PERIOD_MS, 70_000, state);
+    expect(recovered).toEqual({ action: "notify_recovered" });
+  });
+
+  it("clears the rest of the anti-thrash slate when reporting a recovery", () => {
+    const state = new Map<number, McpRecoveryState>();
+    state.set(1, {
+      consecutive_fails: 4,
+      last_action_ms: 500,
+      cycle_fail_timestamps: [100, 200],
+      last_fell_back_at: 200,
+      given_up: true,
+    });
+
+    process_mcp_health_tick(1, true, true, MCP_GRACE_PERIOD_MS, 2000, state);
+
+    expect(state.get(1)).toEqual({
+      consecutive_fails: 0,
+      last_action_ms: null,
+      cycle_fail_timestamps: [],
+      last_fell_back_at: null,
+      given_up: false,
+    });
   });
 });
 
@@ -242,6 +327,7 @@ describe("prune_mcp_state", () => {
       consecutive_fails: 1,
       last_action_ms: null,
       cycle_fail_timestamps: [],
+      last_fell_back_at: null,
       given_up: false,
     };
     state.set(1, { ...blank });

--- a/packages/daemon/src/__tests__/mcp-health.test.ts
+++ b/packages/daemon/src/__tests__/mcp-health.test.ts
@@ -399,6 +399,10 @@ describe("attempt_mcp_reconnect", () => {
     const result = await attempt_mcp_reconnect("pool-1", driver);
 
     expect(result).toEqual({ ok: false, reason: "child_still_missing" });
+    // The TUI stays open after the Reconnect action, so it must be dismissed
+    // even on failure — otherwise the next attempt's `/mcp` keystrokes land
+    // inside the still-open panel and can fire a stray menu action.
+    expect(driver.send).toHaveBeenCalledWith("pool-1", "Escape");
   });
 
   it("happy path: full sequence confirms reconnect and re-verifies the process signal", async () => {

--- a/packages/daemon/src/__tests__/mcp-health.test.ts
+++ b/packages/daemon/src/__tests__/mcp-health.test.ts
@@ -1,0 +1,461 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  MCP_GIVEUP_THRESHOLD,
+  MCP_GRACE_PERIOD_MS,
+  MCP_MAX_RECONNECT_ATTEMPTS,
+  MCP_RECOVERY_COOLDOWN_MS,
+  attempt_mcp_reconnect,
+  classify_mcp_failure,
+  encode_cache_slug,
+  has_mcp_child,
+  process_mcp_health_tick,
+  prune_mcp_state,
+  record_cycle_outcome,
+  run_mcp_recovery_cycle,
+  selection_line,
+  wait_for_mcp_child,
+} from "../mcp-health.js";
+import type { McpDriver, McpRecoveryState } from "../mcp-health.js";
+
+// ── has_mcp_child (process-level detection) ──
+
+describe("has_mcp_child", () => {
+  it("returns true when the pane PID has a bun child process", () => {
+    const pane_pid_fn = vi.fn().mockReturnValue(4242);
+    const has_children_fn = vi.fn().mockReturnValue(true);
+
+    expect(has_mcp_child("pool-1", pane_pid_fn, has_children_fn)).toBe(true);
+    expect(pane_pid_fn).toHaveBeenCalledWith("pool-1");
+    expect(has_children_fn).toHaveBeenCalledWith(4242);
+  });
+
+  it("returns false when the pane has no children", () => {
+    const pane_pid_fn = vi.fn().mockReturnValue(4242);
+    const has_children_fn = vi.fn().mockReturnValue(false);
+
+    expect(has_mcp_child("pool-1", pane_pid_fn, has_children_fn)).toBe(false);
+  });
+
+  it("returns false when the pane PID can't be resolved (dead/unreadable session)", () => {
+    const pane_pid_fn = vi.fn().mockReturnValue(null);
+    const has_children_fn = vi.fn();
+
+    expect(has_mcp_child("pool-1", pane_pid_fn, has_children_fn)).toBe(false);
+    expect(has_children_fn).not.toHaveBeenCalled();
+  });
+});
+
+// ── classify_mcp_failure (corroborating signal, diagnosis only) ──
+
+describe("classify_mcp_failure", () => {
+  it("classifies as never-spawned when the MCP log dir is absent", () => {
+    const exists_fn = vi.fn().mockReturnValue(false);
+    expect(classify_mcp_failure("/Users/farm/entities/acme", exists_fn)).toBe("never-spawned");
+  });
+
+  it("classifies as died when the MCP log dir exists but the process is gone", () => {
+    const exists_fn = vi.fn().mockReturnValue(true);
+    expect(classify_mcp_failure("/Users/farm/entities/acme", exists_fn)).toBe("died");
+  });
+});
+
+describe("encode_cache_slug", () => {
+  it("replaces every slash and dot with a dash, matching the real cache dir naming", () => {
+    expect(encode_cache_slug("/Users/farm/.lobsterfarm/entities/lobster-farm")).toBe(
+      "-Users-farm--lobsterfarm-entities-lobster-farm",
+    );
+  });
+});
+
+// ── selection_line ──
+
+describe("selection_line", () => {
+  it("finds the line containing the ❯ selection cursor", () => {
+    const pane = [
+      "Manage MCP servers",
+      "  computer-use",
+      "❯ plugin:discord",
+      "  claude-design",
+    ].join("\n");
+    expect(selection_line(pane)).toBe("❯ plugin:discord");
+  });
+
+  it("returns null when no line has a selection cursor", () => {
+    expect(selection_line("nothing here\njust text")).toBeNull();
+  });
+});
+
+// ── process_mcp_health_tick (continuous-monitoring state machine) ──
+
+describe("process_mcp_health_tick", () => {
+  it("does not flag a session younger than the grace period", () => {
+    const state = new Map<number, McpRecoveryState>();
+    const result = process_mcp_health_tick(1, false, true, MCP_GRACE_PERIOD_MS - 1, 0, state);
+    expect(result).toEqual({ action: "none" });
+  });
+
+  it("does not act on a single failed tick — requires consecutive fails", () => {
+    const state = new Map<number, McpRecoveryState>();
+    const result = process_mcp_health_tick(1, false, true, MCP_GRACE_PERIOD_MS, 0, state);
+    expect(result).toEqual({ action: "none" });
+    expect(state.get(1)?.consecutive_fails).toBe(1);
+  });
+
+  it("returns recover after the min-consecutive-fails threshold, when idle", () => {
+    const state = new Map<number, McpRecoveryState>();
+    process_mcp_health_tick(1, false, true, MCP_GRACE_PERIOD_MS, 0, state); // 1st fail
+    const result = process_mcp_health_tick(1, false, true, MCP_GRACE_PERIOD_MS, 1000, state); // 2nd fail
+    expect(result).toEqual({ action: "recover" });
+  });
+
+  it("clears all state when the bot is healthy", () => {
+    const state = new Map<number, McpRecoveryState>();
+    process_mcp_health_tick(1, false, true, MCP_GRACE_PERIOD_MS, 0, state);
+    process_mcp_health_tick(1, false, true, MCP_GRACE_PERIOD_MS, 1000, state); // now failing, would recover
+    const result = process_mcp_health_tick(1, true, true, MCP_GRACE_PERIOD_MS, 2000, state);
+    expect(result).toEqual({ action: "none" });
+    expect(state.get(1)).toEqual({
+      consecutive_fails: 0,
+      last_action_ms: null,
+      cycle_fail_timestamps: [],
+      given_up: false,
+    });
+  });
+
+  it("defers to the next tick when mid-turn (not idle) — does not spend cooldown budget", () => {
+    const state = new Map<number, McpRecoveryState>();
+    process_mcp_health_tick(1, false, true, MCP_GRACE_PERIOD_MS, 0, state);
+    const result = process_mcp_health_tick(1, false, false, MCP_GRACE_PERIOD_MS, 1000, state);
+    expect(result).toEqual({ action: "none" });
+    expect(state.get(1)!.last_action_ms).toBeNull();
+
+    // Becomes idle on the next tick — should now fire recover immediately
+    // (consecutive fails already satisfied the threshold).
+    const next = process_mcp_health_tick(1, false, true, MCP_GRACE_PERIOD_MS, 2000, state);
+    expect(next).toEqual({ action: "recover" });
+  });
+
+  it("honors the per-bot cooldown between recovery cycles", () => {
+    const state = new Map<number, McpRecoveryState>();
+    process_mcp_health_tick(1, false, true, MCP_GRACE_PERIOD_MS, 0, state);
+    const first = process_mcp_health_tick(1, false, true, MCP_GRACE_PERIOD_MS, 1000, state);
+    expect(first).toEqual({ action: "recover" });
+
+    // Immediately after — still within cooldown, must not act again.
+    const second = process_mcp_health_tick(1, false, true, MCP_GRACE_PERIOD_MS, 2000, state);
+    expect(second).toEqual({ action: "none" });
+
+    // After the cooldown elapses, the next cycle fires.
+    const third = process_mcp_health_tick(
+      1,
+      false,
+      true,
+      MCP_GRACE_PERIOD_MS,
+      1000 + MCP_RECOVERY_COOLDOWN_MS + 1,
+      state,
+    );
+    expect(third).toEqual({ action: "recover" });
+  });
+
+  it("3 cycles at the 10-minute cooldown pace fit inside the 30-minute give-up window", () => {
+    // This is the core anti-thrash compatibility the design depends on:
+    // MCP_GIVEUP_THRESHOLD cycles x MCP_RECOVERY_COOLDOWN_MS must fit within
+    // MCP_GIVEUP_WINDOW_MS, since each cycle only consumes one cooldown slot
+    // (not one slot per Reconnect sub-attempt).
+    expect(MCP_GIVEUP_THRESHOLD * MCP_RECOVERY_COOLDOWN_MS).toBeLessThanOrEqual(30 * 60 * 1000);
+  });
+});
+
+// ── record_cycle_outcome (give-up bookkeeping after a cycle completes) ──
+
+describe("record_cycle_outcome", () => {
+  it("returns null and records nothing for a reconnected outcome", () => {
+    const state = new Map<number, McpRecoveryState>();
+    const result = record_cycle_outcome(1, "reconnected", 1000, state);
+    expect(result).toBeNull();
+    expect(state.has(1)).toBe(false);
+  });
+
+  it("gives up after MCP_GIVEUP_THRESHOLD failed cycles within the window", () => {
+    const state = new Map<number, McpRecoveryState>();
+    let now = 0;
+    let last: ReturnType<typeof record_cycle_outcome> = null;
+    for (let i = 0; i < MCP_GIVEUP_THRESHOLD; i++) {
+      now += MCP_RECOVERY_COOLDOWN_MS;
+      last = record_cycle_outcome(1, "fell_back", now, state);
+    }
+    expect(last).toEqual({ cycle_fail_count: MCP_GIVEUP_THRESHOLD });
+    expect(state.get(1)?.given_up).toBe(true);
+  });
+
+  it("does not give up before the threshold is reached", () => {
+    const state = new Map<number, McpRecoveryState>();
+    const result = record_cycle_outcome(1, "fell_back", 1000, state);
+    expect(result).toBeNull();
+    expect(state.get(1)?.given_up).toBe(false);
+  });
+
+  it("only counts failed cycles within the give-up window", () => {
+    const state = new Map<number, McpRecoveryState>();
+    record_cycle_outcome(1, "fell_back", 0, state);
+    // Far outside the window — should be pruned, not counted.
+    const now = 1_000_000 * 60 * 60; // 1000 hours later
+    const result = record_cycle_outcome(1, "fell_back", now, state);
+    expect(result).toBeNull();
+    expect(state.get(1)?.cycle_fail_timestamps).toEqual([now]);
+  });
+
+  it("propagates through process_mcp_health_tick: given_up silences further recover actions", () => {
+    const state = new Map<number, McpRecoveryState>();
+    let now = 0;
+    process_mcp_health_tick(1, false, true, MCP_GRACE_PERIOD_MS, now, state); // 1st fail
+    for (let i = 0; i < MCP_GIVEUP_THRESHOLD; i++) {
+      now += MCP_RECOVERY_COOLDOWN_MS + 1;
+      const tick = process_mcp_health_tick(1, false, true, MCP_GRACE_PERIOD_MS, now, state);
+      expect(tick).toEqual({ action: "recover" });
+      record_cycle_outcome(1, "fell_back", now, state);
+    }
+
+    now += MCP_RECOVERY_COOLDOWN_MS + 1;
+    const after_giveup = process_mcp_health_tick(1, false, true, MCP_GRACE_PERIOD_MS, now, state);
+    expect(after_giveup).toEqual({ action: "none" });
+  });
+
+  it("resets given_up once the bot is observed healthy again", () => {
+    const state = new Map<number, McpRecoveryState>();
+    state.set(1, {
+      consecutive_fails: 5,
+      last_action_ms: 1000,
+      cycle_fail_timestamps: [100, 200, 300],
+      given_up: true,
+    });
+    const result = process_mcp_health_tick(1, true, true, MCP_GRACE_PERIOD_MS, 2000, state);
+    expect(result).toEqual({ action: "none" });
+    expect(state.get(1)?.given_up).toBe(false);
+  });
+});
+
+describe("prune_mcp_state", () => {
+  it("removes state entries for bots no longer assigned", () => {
+    const state = new Map<number, McpRecoveryState>();
+    const blank: McpRecoveryState = {
+      consecutive_fails: 1,
+      last_action_ms: null,
+      cycle_fail_timestamps: [],
+      given_up: false,
+    };
+    state.set(1, { ...blank });
+    state.set(2, { ...blank });
+    prune_mcp_state(state, new Set([1]));
+    expect(state.has(1)).toBe(true);
+    expect(state.has(2)).toBe(false);
+  });
+});
+
+// ── run_mcp_recovery_cycle (Step 1 x N, then Step 2 fallback) ──
+
+describe("run_mcp_recovery_cycle", () => {
+  it("returns reconnected as soon as one attempt succeeds, without falling back", async () => {
+    const kill_fn = vi.fn();
+    const scripted_driver = make_scripted_success_driver();
+
+    const outcome = await run_mcp_recovery_cycle("pool-1", kill_fn, scripted_driver);
+
+    expect(outcome).toBe("reconnected");
+    expect(kill_fn).not.toHaveBeenCalled();
+  });
+
+  it("falls back (kills tmux) after MCP_MAX_RECONNECT_ATTEMPTS failed attempts", async () => {
+    const driver = make_driver({ capture: vi.fn().mockReturnValue("unrelated pane text") });
+    const kill_fn = vi.fn();
+
+    const outcome = await run_mcp_recovery_cycle("pool-1", kill_fn, driver);
+
+    expect(outcome).toBe("fell_back");
+    expect(kill_fn).toHaveBeenCalledTimes(1);
+    // One attempt_mcp_reconnect call per MCP_MAX_RECONNECT_ATTEMPTS — each
+    // sends /mcp once, so count the /mcp sends as a proxy for attempt count.
+    const mcp_sends = (driver.send as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c) => c[1] === "/mcp",
+    );
+    expect(mcp_sends).toHaveLength(MCP_MAX_RECONNECT_ATTEMPTS);
+  });
+});
+
+function make_scripted_success_driver(): McpDriver {
+  const panel = "Manage MCP servers";
+  const captures = [
+    panel,
+    `${panel}\n❯ plugin:discord`,
+    `${panel}\n❯ plugin:discord`,
+    "❯ 1. Reconnect",
+  ];
+  return {
+    capture: vi.fn(() => captures.shift() ?? null),
+    send: vi.fn(),
+    sleep: vi.fn().mockResolvedValue(undefined),
+    is_healthy: vi.fn().mockReturnValue(true),
+  };
+}
+
+// ── attempt_mcp_reconnect (scripted /mcp Reconnect driver) ──
+
+function make_driver(overrides: Partial<McpDriver> = {}): McpDriver {
+  return {
+    capture: vi.fn().mockReturnValue(""),
+    send: vi.fn(),
+    sleep: vi.fn().mockResolvedValue(undefined),
+    is_healthy: vi.fn().mockReturnValue(true),
+    ...overrides,
+  };
+}
+
+describe("attempt_mcp_reconnect", () => {
+  it("aborts with Escape when the Manage MCP servers panel never opens", async () => {
+    const driver = make_driver({ capture: vi.fn().mockReturnValue("some unrelated pane text") });
+
+    const result = await attempt_mcp_reconnect("pool-1", driver);
+
+    expect(result).toEqual({ ok: false, reason: "panel_not_open" });
+    expect(driver.send).toHaveBeenCalledWith("pool-1", "Escape");
+    // Never pressed Down/Enter beyond the initial /mcp — no blind navigation.
+    expect(driver.send).not.toHaveBeenCalledWith("pool-1", "Down");
+  });
+
+  it("hunts with Down until the selection line contains plugin:discord, never counting keystrokes", async () => {
+    const panel = "Manage MCP servers";
+    const captures = [
+      panel, // after /mcp
+      `${panel}\n❯ computer-use`, // 1st nav check — wrong server first (per spec)
+      `${panel}\n  computer-use\n❯ plugin:discord`, // 2nd nav check — found it
+      `${panel}\n  computer-use\n❯ plugin:discord`, // re-confirm before Enter
+      "Manage MCP servers\n❯ 1. Reconnect", // detail menu
+    ];
+    const capture = vi.fn(() => captures.shift() ?? null);
+    const driver = make_driver({ capture, is_healthy: vi.fn().mockReturnValue(true) });
+
+    const result = await attempt_mcp_reconnect("pool-1", driver);
+
+    expect(result).toEqual({ ok: true });
+    // One Down press to skip past "computer-use" before landing on plugin:discord.
+    expect(driver.send).toHaveBeenCalledWith("pool-1", "Down");
+    expect(driver.send).toHaveBeenCalledWith("pool-1", "Enter");
+    // Final step returns to the prompt.
+    expect(driver.send).toHaveBeenLastCalledWith("pool-1", "Escape");
+  });
+
+  it("aborts without pressing Enter when the selection line is wrong right before select", async () => {
+    const panel = "Manage MCP servers";
+    const captures = [
+      panel, // after /mcp
+      `${panel}\n❯ plugin:discord`, // nav check — found immediately
+      `${panel}\n❯ something-else`, // re-confirm — selection moved (stray key)
+    ];
+    const capture = vi.fn(() => captures.shift() ?? null);
+    const send = vi.fn();
+    const driver = make_driver({ capture, send });
+
+    const result = await attempt_mcp_reconnect("pool-1", driver);
+
+    expect(result).toEqual({ ok: false, reason: "wrong_selection" });
+    // Enter must never be sent when the pre-Enter guard fails.
+    expect(send).not.toHaveBeenCalledWith("pool-1", "Enter");
+    expect(send).toHaveBeenCalledWith("pool-1", "Escape");
+  });
+
+  it("aborts when the detail menu doesn't show Reconnect selected", async () => {
+    const panel = "Manage MCP servers";
+    const captures = [
+      panel,
+      `${panel}\n❯ plugin:discord`,
+      `${panel}\n❯ plugin:discord`,
+      "some other detail menu\n❯ 2. Disable", // wrong item selected
+    ];
+    const capture = vi.fn(() => captures.shift() ?? null);
+    const send = vi.fn();
+    const driver = make_driver({ capture, send });
+
+    const result = await attempt_mcp_reconnect("pool-1", driver);
+
+    expect(result).toEqual({ ok: false, reason: "detail_menu_not_shown" });
+    // The failing capture was after the plugin:discord Enter — that Enter did fire...
+    expect(send).toHaveBeenCalledWith("pool-1", "Enter");
+    // ...but the final Reconnect-confirming Enter must never fire.
+    expect(send.mock.calls.filter((c) => c[1] === "Enter")).toHaveLength(1);
+    expect(send).toHaveBeenCalledWith("pool-1", "Escape");
+  });
+
+  it("reports child_still_missing when the process signal doesn't recover after Reconnect", async () => {
+    const panel = "Manage MCP servers";
+    const captures = [
+      panel,
+      `${panel}\n❯ plugin:discord`,
+      `${panel}\n❯ plugin:discord`,
+      "❯ 1. Reconnect",
+    ];
+    const capture = vi.fn(() => captures.shift() ?? null);
+    const driver = make_driver({ capture, is_healthy: vi.fn().mockReturnValue(false) });
+
+    const result = await attempt_mcp_reconnect("pool-1", driver);
+
+    expect(result).toEqual({ ok: false, reason: "child_still_missing" });
+  });
+
+  it("happy path: full sequence confirms reconnect and re-verifies the process signal", async () => {
+    const panel = "Manage MCP servers";
+    const captures = [
+      panel,
+      `${panel}\n❯ plugin:discord`,
+      `${panel}\n❯ plugin:discord`,
+      "❯ 1. Reconnect",
+    ];
+    const capture = vi.fn(() => captures.shift() ?? null);
+    const is_healthy = vi.fn().mockReturnValue(true);
+    const driver = make_driver({ capture, is_healthy });
+
+    const result = await attempt_mcp_reconnect("pool-1", driver);
+
+    expect(result).toEqual({ ok: true });
+    expect(is_healthy).toHaveBeenCalledWith("pool-1");
+  });
+});
+
+// ── wait_for_mcp_child (post-spawn grace poll) ──
+
+describe("wait_for_mcp_child", () => {
+  it("resolves immediately when the child is already present", async () => {
+    const has_child_fn = vi.fn().mockReturnValue(true);
+    const result = await wait_for_mcp_child(
+      "pool-1",
+      { timeout_ms: 1000, poll_ms: 10 },
+      has_child_fn,
+    );
+    expect(result).toBe(true);
+    expect(has_child_fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("polls until the child appears within the timeout", async () => {
+    let calls = 0;
+    const has_child_fn = vi.fn(() => {
+      calls++;
+      return calls >= 3;
+    });
+    const result = await wait_for_mcp_child(
+      "pool-1",
+      { timeout_ms: 1000, poll_ms: 5 },
+      has_child_fn,
+    );
+    expect(result).toBe(true);
+    expect(calls).toBeGreaterThanOrEqual(3);
+  });
+
+  it("gives up after the timeout when the child never appears", async () => {
+    const has_child_fn = vi.fn().mockReturnValue(false);
+    const result = await wait_for_mcp_child(
+      "pool-1",
+      { timeout_ms: 30, poll_ms: 10 },
+      has_child_fn,
+    );
+    expect(result).toBe(false);
+  });
+});

--- a/packages/daemon/src/__tests__/pool-mcp-health.test.ts
+++ b/packages/daemon/src/__tests__/pool-mcp-health.test.ts
@@ -1,0 +1,558 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LobsterFarmConfigSchema } from "@lobster-farm/shared";
+import type { EntityConfig, LobsterFarmConfig } from "@lobster-farm/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  MCP_GIVEUP_THRESHOLD,
+  MCP_GRACE_PERIOD_MS,
+  MCP_RECOVERY_COOLDOWN_MS,
+} from "../mcp-health.js";
+import { BotPool } from "../pool.js";
+import type { PoolBot } from "../pool.js";
+import type { EntityRegistry } from "../registry.js";
+
+// Mock actions.ts — notify is imported by pool.ts for alerting
+vi.mock("../actions.js", () => ({
+  notify: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock persistence to avoid filesystem side effects
+vi.mock("../persistence.js", () => ({
+  save_pool_state: vi.fn().mockResolvedValue(undefined),
+  load_pool_state: vi.fn().mockResolvedValue({
+    bots: [],
+    session_history: {},
+    avatar_state: {},
+  }),
+}));
+
+// Mock sentry
+vi.mock("../sentry.js", () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  addBreadcrumb: vi.fn(),
+}));
+
+// Partially mock mcp-health.js: keep the pure state-machine functions real
+// (already covered by mcp-health.test.ts) but replace the tmux/pgrep-driving
+// functions with controllable mocks so these integration tests never touch
+// real tmux sessions or real wall-clock waits.
+vi.mock("../mcp-health.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../mcp-health.js")>();
+  return {
+    ...original,
+    has_mcp_child: vi.fn().mockReturnValue(true),
+    run_mcp_recovery_cycle: vi.fn().mockResolvedValue("reconnected"),
+    wait_for_mcp_child: vi.fn().mockResolvedValue(true),
+  };
+});
+
+// ── Test helpers ──
+
+let temp_dir: string;
+
+function make_config(): LobsterFarmConfig {
+  return LobsterFarmConfigSchema.parse({
+    user: { name: "Test" },
+    paths: { lobsterfarm_dir: temp_dir },
+  });
+}
+
+function make_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
+  return {
+    state: "free",
+    channel_id: null,
+    entity_id: null,
+    archetype: null,
+    channel_type: null,
+    session_id: null,
+    session_confirmed: true,
+    tmux_session: `pool-${String(overrides.id)}`,
+    last_active: null,
+    assigned_at: null,
+    state_dir: `/tmp/test-pool-${String(overrides.id)}`,
+    model: null,
+    effort: null,
+    last_avatar_archetype: null,
+    last_avatar_set_at: null,
+    ...overrides,
+  };
+}
+
+function make_entity_config(entity_id: string, channel_ids: string[]): EntityConfig {
+  return {
+    entity: {
+      id: entity_id,
+      name: `Test ${entity_id}`,
+      description: "",
+      status: "active",
+      repos: [],
+      accounts: {},
+      channels: {
+        category_id: "",
+        list: channel_ids.map((id) => ({ type: "general" as const, id })),
+      },
+      memory: { path: "/tmp/memory", auto_extract: true },
+      secrets: { vault: "1password", vault_name: `entity-${entity_id}` },
+    },
+  };
+}
+
+function make_registry(entities: EntityConfig[]): EntityRegistry {
+  const map = new Map<string, EntityConfig>();
+  for (const e of entities) map.set(e.entity.id, e);
+  return {
+    get: (id: string) => map.get(id),
+    get_all: () => [...map.values()],
+    get_active: () => [...map.values()].filter((e) => e.entity.status === "active"),
+    count: () => map.size,
+  } as unknown as EntityRegistry;
+}
+
+/** Test subclass exposing internals; keeps JSONL/idle/confirmation stubbed
+ * to their happy-path defaults (mirrors BotPoolTestBase) but leaves
+ * check_mcp_health / verify_mcp_post_spawn wired to the real implementation
+ * under test, driven by the mocked mcp-health.js functions above. */
+class TestBotPool extends BotPool {
+  private idle_overrides = new Map<number, boolean>();
+
+  protected override check_session_jsonl_exists_anywhere(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  protected override check_session_jsonl_exists(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  protected override watch_session_confirmation(bot: PoolBot): void {
+    bot.session_confirmed = true;
+  }
+  set_bot_idle(bot_id: number, idle: boolean): void {
+    this.idle_overrides.set(bot_id, idle);
+  }
+  protected override is_bot_idle(bot: PoolBot): boolean {
+    return this.idle_overrides.get(bot.id) ?? true;
+  }
+
+  inject_bots(bots: PoolBot[]): void {
+    (this as unknown as { bots: PoolBot[] }).bots = bots;
+  }
+  get_bots(): PoolBot[] {
+    return (this as unknown as { bots: PoolBot[] }).bots;
+  }
+  get_mcp_state(): Map<number, unknown> {
+    return (this as unknown as { mcp_state: Map<number, unknown> }).mcp_state;
+  }
+  async run_check_mcp_health(bot: PoolBot): Promise<void> {
+    await (this as unknown as { check_mcp_health(b: PoolBot): Promise<void> }).check_mcp_health(
+      bot,
+    );
+  }
+  async run_verify_mcp_post_spawn(bot: PoolBot): Promise<boolean> {
+    return (
+      this as unknown as { verify_mcp_post_spawn(b: PoolBot): Promise<boolean> }
+    ).verify_mcp_post_spawn(bot);
+  }
+}
+
+describe("check_mcp_health integration", () => {
+  let config: LobsterFarmConfig;
+  let pool: TestBotPool;
+  let mock_notify: ReturnType<typeof vi.fn>;
+  let mock_has_mcp_child: ReturnType<typeof vi.fn>;
+  let mock_run_cycle: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    temp_dir = await mkdtemp(join(tmpdir(), "mcp-health-pool-test-"));
+    config = make_config();
+    pool = new TestBotPool(config);
+
+    const actions = await import("../actions.js");
+    mock_notify = actions.notify as unknown as ReturnType<typeof vi.fn>;
+    mock_notify.mockClear();
+
+    const mcp_health = await import("../mcp-health.js");
+    mock_has_mcp_child = mcp_health.has_mcp_child as unknown as ReturnType<typeof vi.fn>;
+    mock_run_cycle = mcp_health.run_mcp_recovery_cycle as unknown as ReturnType<typeof vi.fn>;
+    mock_has_mcp_child.mockReturnValue(true);
+    mock_run_cycle.mockReset().mockResolvedValue("reconnected");
+
+    vi.spyOn(pool as unknown as Record<string, unknown>, "kill_tmux" as never).mockImplementation(
+      () => {},
+    );
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(temp_dir, { recursive: true, force: true });
+  });
+
+  function old_bot(overrides: Partial<PoolBot> & { id: number }): PoolBot {
+    return make_bot({
+      state: "assigned",
+      assigned_at: new Date(Date.now() - MCP_GRACE_PERIOD_MS - 1000),
+      ...overrides,
+    });
+  }
+
+  it("does nothing when the MCP child is present", async () => {
+    mock_has_mcp_child.mockReturnValue(true);
+    const bot = old_bot({ id: 1, entity_id: "e1", channel_id: "ch-1" });
+    pool.inject_bots([bot]);
+
+    await pool.run_check_mcp_health(bot);
+    await pool.run_check_mcp_health(bot);
+
+    expect(mock_run_cycle).not.toHaveBeenCalled();
+  });
+
+  it("does not act on a session younger than the grace period even if unhealthy", async () => {
+    mock_has_mcp_child.mockReturnValue(false);
+    const bot = make_bot({ id: 1, state: "assigned", assigned_at: new Date(), entity_id: "e1" });
+    pool.inject_bots([bot]);
+
+    await pool.run_check_mcp_health(bot);
+
+    expect(mock_run_cycle).not.toHaveBeenCalled();
+  });
+
+  it("does not act on a single failed tick — requires consecutive fails", async () => {
+    mock_has_mcp_child.mockReturnValue(false);
+    const bot = old_bot({ id: 1, entity_id: "e1" });
+    pool.inject_bots([bot]);
+
+    await pool.run_check_mcp_health(bot);
+
+    expect(mock_run_cycle).not.toHaveBeenCalled();
+  });
+
+  it("runs a recovery cycle once consecutive fails cross the threshold, while idle", async () => {
+    mock_has_mcp_child.mockReturnValue(false);
+    const bot = old_bot({ id: 1, entity_id: "e1", channel_id: "ch-1" });
+    pool.inject_bots([bot]);
+    pool.set_bot_idle(1, true);
+
+    await pool.run_check_mcp_health(bot); // 1st fail — no action
+    await pool.run_check_mcp_health(bot); // 2nd fail — fires
+
+    expect(mock_run_cycle).toHaveBeenCalledTimes(1);
+    expect(mock_run_cycle.mock.calls[0][0]).toBe("pool-1");
+  });
+
+  it("defers the recovery cycle while the bot is mid-turn (not idle)", async () => {
+    mock_has_mcp_child.mockReturnValue(false);
+    const bot = old_bot({ id: 1, entity_id: "e1" });
+    pool.inject_bots([bot]);
+    pool.set_bot_idle(1, false);
+
+    await pool.run_check_mcp_health(bot);
+    await pool.run_check_mcp_health(bot);
+    await pool.run_check_mcp_health(bot);
+
+    expect(mock_run_cycle).not.toHaveBeenCalled();
+  });
+
+  it("stays silent (no #alerts) on a routine reconnected outcome", async () => {
+    mock_has_mcp_child.mockReturnValue(false);
+    mock_run_cycle.mockResolvedValue("reconnected");
+    const bot = old_bot({ id: 1, entity_id: "e1" });
+    pool.inject_bots([bot]);
+
+    await pool.run_check_mcp_health(bot);
+    await pool.run_check_mcp_health(bot);
+
+    expect(mock_notify).not.toHaveBeenCalled();
+  });
+
+  it("stays silent on a single fell_back outcome (below give-up threshold)", async () => {
+    mock_has_mcp_child.mockReturnValue(false);
+    mock_run_cycle.mockResolvedValue("fell_back");
+    const bot = old_bot({ id: 1, entity_id: "e1" });
+    pool.inject_bots([bot]);
+
+    await pool.run_check_mcp_health(bot);
+    await pool.run_check_mcp_health(bot);
+
+    expect(mock_notify).not.toHaveBeenCalled();
+    expect(bot.state).toBe("assigned"); // never released
+  });
+
+  it("gives up and alerts #alerts after MCP_GIVEUP_THRESHOLD failed cycles, without releasing the bot", async () => {
+    mock_has_mcp_child.mockReturnValue(false);
+    mock_run_cycle.mockResolvedValue("fell_back");
+    const bot = old_bot({
+      id: 1,
+      entity_id: "test-entity",
+      channel_id: "ch-1",
+      archetype: "builder",
+    });
+    pool.inject_bots([bot]);
+    const registry = make_registry([make_entity_config("test-entity", ["ch-1"])]);
+    (pool as unknown as { registry: EntityRegistry }).registry = registry;
+
+    let now = Date.now();
+    const real_now = Date.now;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+
+    await pool.run_check_mcp_health(bot); // 1st fail
+    for (let i = 0; i < MCP_GIVEUP_THRESHOLD; i++) {
+      now += MCP_RECOVERY_COOLDOWN_MS + 1000;
+      await pool.run_check_mcp_health(bot);
+    }
+
+    vi.spyOn(Date, "now").mockImplementation(real_now);
+
+    expect(mock_run_cycle).toHaveBeenCalledTimes(MCP_GIVEUP_THRESHOLD);
+    expect(mock_notify).toHaveBeenCalledTimes(1);
+    const [channel_type, message] = mock_notify.mock.calls[0] as [string, string];
+    expect(channel_type).toBe("alerts");
+    expect(message).toContain("Pool bot 1");
+    expect(message).toContain("NOT released");
+    expect(bot.state).toBe("assigned"); // still never released
+  });
+
+  it("resets to a fresh anti-thrash slate once the bot is observed healthy again", async () => {
+    mock_has_mcp_child.mockReturnValue(false);
+    mock_run_cycle.mockResolvedValue("fell_back");
+    const bot = old_bot({ id: 1, entity_id: "e1" });
+    pool.inject_bots([bot]);
+
+    await pool.run_check_mcp_health(bot);
+    await pool.run_check_mcp_health(bot); // triggers a cycle, records a failure
+
+    mock_has_mcp_child.mockReturnValue(true);
+    await pool.run_check_mcp_health(bot); // healthy now
+
+    // process_mcp_health_tick resets to a zeroed state object on a healthy
+    // reading (not a deleted map entry — the entry only disappears once
+    // prune_mcp_state removes it for a no-longer-assigned bot).
+    const state = pool.get_mcp_state() as Map<
+      number,
+      { given_up: boolean; consecutive_fails: number }
+    >;
+    expect(state.get(1)).toMatchObject({ given_up: false, consecutive_fails: 0 });
+  });
+});
+
+describe("verify_mcp_post_spawn integration", () => {
+  let config: LobsterFarmConfig;
+  let pool: TestBotPool;
+  let mock_wait: ReturnType<typeof vi.fn>;
+  let mock_run_cycle: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    temp_dir = await mkdtemp(join(tmpdir(), "mcp-postspawn-test-"));
+    config = make_config();
+    pool = new TestBotPool(config);
+
+    const mcp_health = await import("../mcp-health.js");
+    mock_wait = mcp_health.wait_for_mcp_child as unknown as ReturnType<typeof vi.fn>;
+    mock_run_cycle = mcp_health.run_mcp_recovery_cycle as unknown as ReturnType<typeof vi.fn>;
+    mock_wait.mockReset();
+    mock_run_cycle.mockReset();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(temp_dir, { recursive: true, force: true });
+  });
+
+  it("returns true immediately when the MCP child appears within the grace wait", async () => {
+    mock_wait.mockResolvedValue(true);
+    const bot = make_bot({ id: 1 });
+
+    const result = await pool.run_verify_mcp_post_spawn(bot);
+
+    expect(result).toBe(true);
+    expect(mock_run_cycle).not.toHaveBeenCalled();
+  });
+
+  it("falls through to a scripted reconnect when the grace wait times out, and succeeds", async () => {
+    mock_wait.mockResolvedValue(false);
+    mock_run_cycle.mockResolvedValue("reconnected");
+    const bot = make_bot({ id: 1 });
+
+    const result = await pool.run_verify_mcp_post_spawn(bot);
+
+    expect(result).toBe(true);
+    expect(mock_run_cycle).toHaveBeenCalledTimes(1);
+    expect(mock_run_cycle.mock.calls[0][0]).toBe("pool-1");
+  });
+
+  it("returns false when both the grace wait and the reconnect attempt fail", async () => {
+    mock_wait.mockResolvedValue(false);
+    mock_run_cycle.mockResolvedValue("fell_back");
+    const bot = make_bot({ id: 1 });
+
+    const result = await pool.run_verify_mcp_post_spawn(bot);
+
+    expect(result).toBe(false);
+  });
+
+  it("does not kill the bot's tmux as part of the post-spawn reconnect fallback", async () => {
+    mock_wait.mockResolvedValue(false);
+    // Simulate run_mcp_recovery_cycle's real contract: it invokes kill_fn on
+    // exhaustion. verify_mcp_post_spawn must pass a no-op kill_fn (a bot that
+    // was *just* spawned shouldn't be killed again by its own readiness check).
+    mock_run_cycle.mockImplementation(async (_session: string, kill_fn: () => void) => {
+      kill_fn();
+      return "fell_back";
+    });
+    const kill_spy = vi
+      .spyOn(pool as unknown as Record<string, unknown>, "kill_tmux" as never)
+      .mockImplementation(() => {});
+    const bot = make_bot({ id: 1 });
+
+    await pool.run_verify_mcp_post_spawn(bot);
+
+    expect(kill_spy).not.toHaveBeenCalled();
+  });
+});
+
+describe("resume_parked_bots() boot stagger (issue #345)", () => {
+  let config: LobsterFarmConfig;
+
+  beforeEach(async () => {
+    temp_dir = await mkdtemp(join(tmpdir(), "mcp-boot-stagger-test-"));
+    config = make_config();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(temp_dir, { recursive: true, force: true });
+  });
+
+  class StaggerTestPool extends BotPool {
+    protected override check_session_jsonl_exists_anywhere(): Promise<boolean> {
+      return Promise.resolve(true);
+    }
+    protected override check_session_jsonl_exists(): Promise<boolean> {
+      return Promise.resolve(true);
+    }
+    protected override watch_session_confirmation(): void {
+      /* no-op */
+    }
+
+    /** Records the interleaving of start_tmux vs verify_mcp_post_spawn calls
+     * so tests can assert strict serialization (each verify completes before
+     * the next start_tmux begins). */
+    call_log: string[] = [];
+    /** bot_id → simulated verification delay in ms. Bots with no entry
+     * resolve immediately. */
+    verify_delay_ms = new Map<number, number>();
+
+    protected override async start_tmux(bot: PoolBot): Promise<void> {
+      this.call_log.push(`start_tmux:${String(bot.id)}`);
+    }
+
+    protected override async verify_mcp_post_spawn(bot: PoolBot): Promise<boolean> {
+      this.call_log.push(`verify_start:${String(bot.id)}`);
+      const delay = this.verify_delay_ms.get(bot.id) ?? 0;
+      if (delay > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+      this.call_log.push(`verify_end:${String(bot.id)}`);
+      return true;
+    }
+
+    set_resume_candidates(
+      candidates: Array<{
+        id: number;
+        channel_id: string;
+        entity_id: string;
+        archetype: "builder" | "planner";
+        session_id: string;
+      }>,
+    ): void {
+      (
+        this as unknown as {
+          resume_candidates: Array<Record<string, unknown>>;
+        }
+      ).resume_candidates = candidates.map((c) => ({
+        ...c,
+        state: "assigned",
+        channel_type: null,
+        last_active: null,
+      }));
+    }
+
+    inject_bot(bot: PoolBot): void {
+      (this as unknown as { bots: PoolBot[] }).bots.push(bot);
+    }
+
+    /** Shrunk to a few ms so the cap test doesn't need real 45s waits or the
+     * fake-timers/real-fs-IO interleaving hazard that comes with mixing
+     * vi.useFakeTimers() and resume_parked_bots()'s real filesystem writes. */
+    protected override boot_stagger_cap_ms(): number {
+      return 20;
+    }
+  }
+
+  async function setup(bot_ids: number[]): Promise<StaggerTestPool> {
+    const p = new StaggerTestPool(config);
+    for (const id of bot_ids) {
+      // channel_id must match the corresponding resume candidate — the real
+      // resume_parked_bots() only matches a candidate to a bot with the same
+      // id AND channel_id (see pool.ts's `this.bots.find(...)`).
+      p.inject_bot(make_bot({ id, state: "parked", channel_id: `ch-${String(id)}` }));
+    }
+    vi.spyOn(
+      p as unknown as Record<string, unknown>,
+      "write_access_json" as never,
+    ).mockResolvedValue(undefined);
+    vi.spyOn(
+      p as unknown as Record<string, unknown>,
+      "set_bot_nickname" as never,
+    ).mockResolvedValue(undefined);
+    vi.spyOn(p as unknown as Record<string, unknown>, "set_bot_avatar" as never).mockResolvedValue(
+      undefined,
+    );
+    vi.spyOn(p as unknown as Record<string, unknown>, "kill_tmux" as never).mockImplementation(
+      () => {},
+    );
+    vi.spyOn(p as unknown as Record<string, unknown>, "persist" as never).mockResolvedValue(
+      undefined,
+    );
+    return p;
+  }
+
+  it("gates each resume's start_tmux on the previous candidate's MCP verification completing first", async () => {
+    const p = await setup([1, 2, 3]);
+    p.set_resume_candidates([
+      { id: 1, channel_id: "ch-1", entity_id: "e1", archetype: "builder", session_id: "s1" },
+      { id: 2, channel_id: "ch-2", entity_id: "e2", archetype: "builder", session_id: "s2" },
+      { id: 3, channel_id: "ch-3", entity_id: "e3", archetype: "builder", session_id: "s3" },
+    ]);
+
+    await p.resume_parked_bots();
+
+    // Each candidate's verify must fully complete (verify_end) before the
+    // next candidate's start_tmux begins — this is what "serializes cold
+    // starts" means structurally.
+    const start_indices = [1, 2, 3].map((id) => p.call_log.indexOf(`start_tmux:${String(id)}`));
+    const verify_end_indices = [1, 2, 3].map((id) =>
+      p.call_log.indexOf(`verify_end:${String(id)}`),
+    );
+
+    expect(start_indices[1]).toBeGreaterThan(verify_end_indices[0]!);
+    expect(start_indices[2]).toBeGreaterThan(verify_end_indices[1]!);
+  });
+
+  it("caps a stuck candidate's verification so it doesn't stall the whole queue", async () => {
+    const p = await setup([1, 2]);
+    p.set_resume_candidates([
+      { id: 1, channel_id: "ch-1", entity_id: "e1", archetype: "builder", session_id: "s1" },
+      { id: 2, channel_id: "ch-2", entity_id: "e2", archetype: "builder", session_id: "s2" },
+    ]);
+    // Bot 1's verification never resolves within the (shrunk) cap — only
+    // the cap inside resume_parked_bots() can unblock the queue. Bot 2
+    // resolves immediately, so it's the queue-progress signal.
+    p.verify_delay_ms.set(1, 10_000);
+
+    await p.resume_parked_bots();
+
+    expect(p.call_log).toContain("start_tmux:2");
+    const bots = (p as unknown as { bots: PoolBot[] }).bots;
+    expect(bots.find((b) => b.id === 2)!.state).toBe("assigned");
+  });
+});

--- a/packages/daemon/src/__tests__/pool-mcp-health.test.ts
+++ b/packages/daemon/src/__tests__/pool-mcp-health.test.ts
@@ -311,6 +311,54 @@ describe("check_mcp_health integration", () => {
     expect(bot.state).toBe("assigned"); // still never released
   });
 
+  it("alerts #alerts when the bot recovers after a kill+resume fallback", async () => {
+    mock_has_mcp_child.mockReturnValue(false);
+    mock_run_cycle.mockResolvedValue("fell_back");
+    const bot = old_bot({
+      id: 1,
+      entity_id: "test-entity",
+      channel_id: "ch-1",
+      archetype: "builder",
+    });
+    pool.inject_bots([bot]);
+    (pool as unknown as { registry: EntityRegistry }).registry = make_registry([
+      make_entity_config("test-entity", ["ch-1"]),
+    ]);
+
+    await pool.run_check_mcp_health(bot);
+    await pool.run_check_mcp_health(bot); // cycle runs, falls back to kill+resume
+    expect(mock_notify).not.toHaveBeenCalled(); // below give-up threshold — silent so far
+
+    // Crash-recovery respawned the session and the MCP child is back.
+    mock_has_mcp_child.mockReturnValue(true);
+    await pool.run_check_mcp_health(bot);
+
+    expect(mock_notify).toHaveBeenCalledTimes(1);
+    const [channel_type, message] = mock_notify.mock.calls[0] as [string, string];
+    expect(channel_type).toBe("alerts");
+    expect(message).toContain("Pool bot 1");
+    expect(message).toContain("recovered");
+
+    // Recovery is reported once, not on every subsequent healthy tick.
+    await pool.run_check_mcp_health(bot);
+    expect(mock_notify).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays silent when the bot recovers after a routine Step 1 reconnect", async () => {
+    mock_has_mcp_child.mockReturnValue(false);
+    mock_run_cycle.mockResolvedValue("reconnected");
+    const bot = old_bot({ id: 1, entity_id: "e1", channel_id: "ch-1" });
+    pool.inject_bots([bot]);
+
+    await pool.run_check_mcp_health(bot);
+    await pool.run_check_mcp_health(bot);
+
+    mock_has_mcp_child.mockReturnValue(true);
+    await pool.run_check_mcp_health(bot);
+
+    expect(mock_notify).not.toHaveBeenCalled();
+  });
+
   it("resets to a fresh anti-thrash slate once the bot is observed healthy again", async () => {
     mock_has_mcp_child.mockReturnValue(false);
     mock_run_cycle.mockResolvedValue("fell_back");

--- a/packages/daemon/src/commander-process.ts
+++ b/packages/daemon/src/commander-process.ts
@@ -6,7 +6,16 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import type { LobsterFarmConfig } from "@lobster-farm/shared";
 import { lobsterfarm_dir } from "@lobster-farm/shared";
+import {
+  has_mcp_child,
+  process_mcp_health_tick,
+  record_cycle_outcome,
+  run_mcp_recovery_cycle,
+  wait_for_mcp_child,
+} from "./mcp-health.js";
+import type { McpRecoveryState } from "./mcp-health.js";
 import { resolve_model_id } from "./models.js";
+import { is_tmux_session_idle } from "./pool.js";
 import * as sentry from "./sentry.js";
 import { sq } from "./shell.js";
 
@@ -25,6 +34,10 @@ const BACKOFF_RESET_MS = 10 * 60 * 1000; // 10 min stable → reset counter
 const MAX_RESTARTS = 5;
 const HEALTH_INTERVAL_MS = 10_000; // check every 10s
 
+/** Single-instance key into the mcp_state map — Pat has exactly one session,
+ * unlike the pool bots (indexed by numeric bot id in pool.ts). */
+const PAT_MCP_STATE_KEY = 0;
+
 /**
  * Manages a persistent Claude Code session connected to Discord via the
  * channel plugin, running inside a tmux session for proper TTY support.
@@ -37,6 +50,12 @@ export class CommanderProcess extends EventEmitter {
   private restart_timer: ReturnType<typeof setTimeout> | null = null;
   private backoff_reset_timer: ReturnType<typeof setTimeout> | null = null;
   private health_timer: ReturnType<typeof setInterval> | null = null;
+  /** MCP connection health state for Pat's session (issue #345). Keyed by
+   * PAT_MCP_STATE_KEY since there's only ever one Commander session. */
+  private mcp_state = new Map<number, McpRecoveryState>();
+  /** True while a check_mcp_health() cycle is in flight — prevents two
+   * overlapping recovery cycles if a health tick fires mid-cycle. */
+  private mcp_check_running = false;
 
   constructor(private config: LobsterFarmConfig) {
     super();
@@ -241,6 +260,12 @@ export class CommanderProcess extends EventEmitter {
         console.log(`[commander] ${agent_name} running in tmux (pane pid: ${String(pid)})`);
         this.emit("started", pid);
 
+        // Post-spawn MCP verification gate (issue #345), fire-and-forget —
+        // mirrors pool.ts's verify_mcp_post_spawn: wait for the MCP child,
+        // fall back to one scripted /mcp Reconnect attempt if it doesn't
+        // appear. Not awaited — start() shouldn't block server startup.
+        void this.verify_mcp_post_spawn();
+
         // Persist session_id so future restarts can resume the conversation
         void this.write_session_id(session_id).catch((err) => {
           console.error(`[commander] Failed to persist session_id: ${String(err)}`);
@@ -290,9 +315,15 @@ export class CommanderProcess extends EventEmitter {
           clearTimeout(this.backoff_reset_timer);
           this.backoff_reset_timer = null;
         }
+        this.mcp_state.delete(PAT_MCP_STATE_KEY);
         this.emit("crashed", 1);
         this.schedule_restart();
+        return;
       }
+
+      // Tmux alive — verify the Discord plugin MCP server is actually
+      // connected (issue #345). Pane text alone doesn't prove it.
+      void this.check_mcp_health();
     }, HEALTH_INTERVAL_MS);
   }
 
@@ -301,6 +332,103 @@ export class CommanderProcess extends EventEmitter {
       clearInterval(this.health_timer);
       this.health_timer = null;
     }
+  }
+
+  /** Check if Pat's tmux pane is idle at the prompt (reuses pool.ts's
+   * detector — same signal, no need for a second implementation). */
+  private is_idle(): boolean {
+    return is_tmux_session_idle(PAT_TMUX_SESSION);
+  }
+
+  /**
+   * Verify Pat's Discord plugin MCP connection and drive recovery if it's
+   * confirmed dead (issue #345). Mirrors pool.ts's check_mcp_health() —
+   * same detection/anti-thrash state machine, single-session key. Kill +
+   * resume fallback reuses the existing crash-restart path: killing the
+   * tmux session here is picked up by this same interval's next tick via
+   * the dead-tmux branch, which already calls schedule_restart() with its
+   * own backoff — Pat has no separate "crash-loop guard" to preserve.
+   */
+  private async check_mcp_health(): Promise<void> {
+    if (this.mcp_check_running) return;
+    this.mcp_check_running = true;
+
+    try {
+      const healthy = has_mcp_child(PAT_TMUX_SESSION);
+      const age_ms = this.last_started_at ? Date.now() - this.last_started_at.getTime() : 0;
+      const idle = this.is_idle();
+      const now = Date.now();
+
+      const tick = process_mcp_health_tick(
+        PAT_MCP_STATE_KEY,
+        healthy,
+        idle,
+        age_ms,
+        now,
+        this.mcp_state,
+      );
+      if (tick.action === "none") return;
+
+      console.warn("[commander] MCP connection dead — running recovery cycle");
+      sentry.addBreadcrumb({
+        category: "daemon.commander",
+        message: "Commander MCP recovery cycle starting",
+      });
+
+      const outcome = await run_mcp_recovery_cycle(PAT_TMUX_SESSION, () => {
+        console.warn(
+          "[commander] MCP Reconnect exhausted — killing tmux for crash-restart to pick up",
+        );
+        try {
+          execFileSync("tmux", ["kill-session", "-t", PAT_TMUX_SESSION], { stdio: "ignore" });
+        } catch {
+          /* already dead */
+        }
+      });
+
+      if (outcome === "reconnected") {
+        console.log("[commander] MCP reconnected via scripted /mcp Reconnect");
+        return;
+      }
+
+      const escalation = record_cycle_outcome(PAT_MCP_STATE_KEY, outcome, now, this.mcp_state);
+      if (!escalation) return;
+
+      console.error(
+        `[commander] MCP recovery gave up after ${String(escalation.cycle_fail_count)} failed cycles`,
+      );
+      sentry.captureMessage("Commander MCP recovery gave up", "error", {
+        tags: { module: "commander", action: "mcp_recovery_giveup" },
+        contexts: { mcp_recovery: { cycle_fail_count: escalation.cycle_fail_count } },
+      });
+    } finally {
+      this.mcp_check_running = false;
+    }
+  }
+
+  /**
+   * Post-spawn MCP verification gate (issue #345). Waits for the MCP child
+   * to appear after a fresh spawn/resume; if still absent, runs the
+   * scripted `/mcp` Reconnect inline. Does not kill on failure here — that
+   * escalation is owned by check_mcp_health() on the next health tick, same
+   * division of responsibility as pool.ts's verify_mcp_post_spawn().
+   */
+  private async verify_mcp_post_spawn(): Promise<boolean> {
+    if (await wait_for_mcp_child(PAT_TMUX_SESSION)) return true;
+
+    console.warn(
+      "[commander] Spawned but MCP child not detected within grace window — attempting scripted reconnect",
+    );
+    const result = await run_mcp_recovery_cycle(PAT_TMUX_SESSION, () => {
+      /* post-spawn recovery is reconnect-only; see check_mcp_health() for the kill+resume escalation */
+    });
+
+    if (result === "reconnected") {
+      console.log("[commander] MCP reconnected post-spawn via scripted /mcp Reconnect");
+      return true;
+    }
+    console.warn("[commander] MCP still unconfirmed post-spawn — health monitor will retry");
+    return false;
   }
 
   private schedule_restart(): void {
@@ -343,6 +471,7 @@ export class CommanderProcess extends EventEmitter {
       this.backoff_reset_timer = null;
     }
     this.stop_health_polling();
+    this.mcp_state.delete(PAT_MCP_STATE_KEY);
 
     this.state = "stopped";
 

--- a/packages/daemon/src/commander-process.ts
+++ b/packages/daemon/src/commander-process.ts
@@ -367,6 +367,18 @@ export class CommanderProcess extends EventEmitter {
         now,
         this.mcp_state,
       );
+      if (tick.action === "notify_recovered") {
+        // One-shot recovery notice after a Step 2 fallback (spec: alert on
+        // give-up and on successful recovery after a fallback; silent for
+        // routine Step 1 reconnects). Pat is platform-level with no entity
+        // config, so this reports through sentry + console — the same
+        // channel its give-up escalation uses.
+        console.log("[commander] MCP recovered after kill+resume fallback");
+        sentry.captureMessage("Commander MCP recovered after kill+resume fallback", "info", {
+          tags: { module: "commander", action: "mcp_recovery_recovered" },
+        });
+        return;
+      }
       if (tick.action === "none") return;
 
       console.warn("[commander] MCP connection dead — running recovery cycle");

--- a/packages/daemon/src/mcp-health.ts
+++ b/packages/daemon/src/mcp-health.ts
@@ -291,12 +291,14 @@ export async function attempt_mcp_reconnect(
   driver.send(tmux_session, "Enter");
 
   await driver.sleep(MCP_RECONNECT_VERIFY_WAIT_MS);
+  // The panel stays open after the Reconnect action, so dismiss it back to the
+  // prompt regardless of outcome. On failure the caller retries immediately,
+  // and a leftover panel would swallow the next attempt's `/mcp` keystrokes —
+  // firing whatever menu item happened to be selected instead.
+  driver.send(tmux_session, "Escape");
   if (!driver.is_healthy(tmux_session)) {
     return { ok: false, reason: "child_still_missing" };
   }
-
-  // Back to the prompt.
-  driver.send(tmux_session, "Escape");
   return { ok: true };
 }
 

--- a/packages/daemon/src/mcp-health.ts
+++ b/packages/daemon/src/mcp-health.ts
@@ -1,0 +1,503 @@
+/**
+ * MCP connection verification and auto-reconnect recovery for pool bots and
+ * the Commander (Pat).
+ *
+ * 2026-07-18 outage: after a machine reboot, sessions came up "alive but
+ * deaf" — tmux alive, Claude at the prompt, but the Discord plugin's MCP
+ * server process was never spawned (or died) inside the session, and
+ * nothing retried. Pane text is NOT a trustworthy proxy for a live MCP
+ * connection — `wait_for_bot_ready` already requires "Listening for channel
+ * messages" in the pane, and deaf sessions passed that check anyway.
+ *
+ * Detection is process-level: a healthy session has a `bun` child process
+ * (the plugin MCP server) under the pane PID.
+ *
+ * Recovery is ordered:
+ *   1. Scripted in-session `/mcp` Reconnect (primary) — driven via tmux
+ *      send-keys with a pane-state guard before every keystroke. Preserves
+ *      full conversation context, measured 19/19 during the incident.
+ *   2. Kill + resume (fallback) — after 2 failed Reconnect attempts, kill
+ *      the tmux session and let the existing crash-recovery path
+ *      (`restart_crashed_session`) respawn it with `--resume`. Recycling
+ *      alone (no MCP verification) was measured at ~25% success in bad
+ *      windows — Reconnect is tried first because it's far more reliable
+ *      and doesn't touch the crash-loop counter.
+ *
+ * Anti-thrash: at most one recovery action (a Reconnect attempt or the
+ * fallback) per bot per 10 minutes. After 3 failed full recovery cycles
+ * (Reconnect x2 + fallback, still unhealthy) within 30 minutes, give up —
+ * stop attempting and let the caller alert. The bot is never released.
+ *
+ * References: issue #345. Template for pane-driving with guards:
+ * `rate-limit-recovery.ts` (#270) and `econnreset-recovery.ts` (#337, sibling
+ * — a different failure mode, deliberately not merged with this detector).
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// ── Thresholds ──
+
+/** Don't flag a session younger than this — the MCP server takes a few
+ * seconds to appear after spawn. */
+export const MCP_GRACE_PERIOD_MS = 60_000;
+
+/** Require the process-level check to fail this many consecutive ticks
+ * before acting — avoids racing a slow spawn. */
+export const MCP_MIN_CONSECUTIVE_FAILS = 2;
+
+/** At most one recovery action (Reconnect attempt or fallback) per bot in
+ * this window. */
+export const MCP_RECOVERY_COOLDOWN_MS = 10 * 60 * 1000;
+
+/** Number of scripted Reconnect attempts tried before falling back to
+ * kill + resume. Spec: "If Reconnect fails twice, kill the tmux session." */
+export const MCP_MAX_RECONNECT_ATTEMPTS = 2;
+
+/** Give up (stop attempting, escalate) after this many failed full recovery
+ * cycles within MCP_GIVEUP_WINDOW_MS. */
+export const MCP_GIVEUP_THRESHOLD = 3;
+export const MCP_GIVEUP_WINDOW_MS = 30 * 60 * 1000;
+
+/** Wait between each guarded keystroke of the reconnect driver, giving the
+ * TUI time to render before the next pane capture. */
+export const MCP_RECONNECT_STEP_WAIT_MS = 1_500;
+
+/** After sending the final Reconnect keystroke, wait this long before
+ * re-verifying the process-level signal (spec: "wait ~6s"). */
+export const MCP_RECONNECT_VERIFY_WAIT_MS = 6_000;
+
+/** Safety cap on Down-presses while hunting for the plugin:discord row —
+ * the server count varies per session; this just bounds a runaway loop. */
+export const MCP_MAX_DOWN_PRESSES = 20;
+
+// ── Process-level detection ──
+
+/** Get the pane PID of a tmux session's active pane. Returns null if the
+ * session doesn't exist or the pane PID can't be parsed. */
+export function get_pane_pid(tmux_session: string): number | null {
+  try {
+    const out = execFileSync("tmux", ["list-panes", "-t", tmux_session, "-F", "#{pane_pid}"], {
+      encoding: "utf-8",
+      timeout: 2000,
+    })
+      .trim()
+      .split("\n")[0];
+    const pid = Number.parseInt(out ?? "", 10);
+    return Number.isNaN(pid) ? null : pid;
+  } catch {
+    return null;
+  }
+}
+
+/** Check whether the pane PID has any child processes (pgrep -P). Returns
+ * false on any error — `pgrep` exits non-zero with no output when there are
+ * no matching children, which is a legitimate "no MCP server" result, not a
+ * tool failure worth distinguishing. */
+export function has_children(pane_pid: number): boolean {
+  try {
+    const out = execFileSync("pgrep", ["-P", String(pane_pid)], {
+      encoding: "utf-8",
+      timeout: 2000,
+    });
+    return out.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Primary detection signal (spec: process-level, reliable, scriptable).
+ * A healthy session has a `bun` child process (the plugin MCP server) under
+ * the pane PID. Returns false if the pane can't be read or has no children
+ * — both mean "can't confirm a live MCP connection."
+ */
+export function has_mcp_child(
+  tmux_session: string,
+  pane_pid_fn: (session: string) => number | null = get_pane_pid,
+  has_children_fn: (pid: number) => boolean = has_children,
+): boolean {
+  const pane_pid = pane_pid_fn(tmux_session);
+  if (pane_pid === null) return false;
+  return has_children_fn(pane_pid);
+}
+
+// ── Corroborating signal (log-dir, diagnosis only — never gates recovery) ──
+
+/** Encode an absolute path into the claude-cli-nodejs cache slug format
+ * (replaces every `/` and `.` with `-`). Mirrors `encode_project_slug` in
+ * pool.ts — duplicated here rather than imported to avoid a pool.ts <->
+ * mcp-health.ts import cycle; both are one-line pure functions. */
+export function encode_cache_slug(abs_path: string): string {
+  return abs_path.replace(/[/.]/g, "-");
+}
+
+/** Absolute path to this session's Discord plugin MCP log directory. */
+export function mcp_log_dir(working_dir: string): string {
+  return join(
+    homedir(),
+    "Library",
+    "Caches",
+    "claude-cli-nodejs",
+    encode_cache_slug(working_dir),
+    "mcp-logs-plugin-discord-discord",
+  );
+}
+
+export type McpFailureMode = "never-spawned" | "died" | "unknown";
+
+/**
+ * Classify a detected MCP failure using the log-dir corroborating signal,
+ * for logging/diagnosis only — this NEVER gates detection or recovery
+ * (spec: "Do NOT rely on pane text" applies equally to log presence, which
+ * can be stale or missing for reasons unrelated to the current failure).
+ */
+export function classify_mcp_failure(
+  working_dir: string,
+  exists_fn: (path: string) => boolean = existsSync,
+): McpFailureMode {
+  const dir = mcp_log_dir(working_dir);
+  if (!exists_fn(dir)) return "never-spawned";
+  return "died";
+}
+
+// ── Tmux pane interaction (reconnect driver primitives) ──
+
+/** Capture the full content of a tmux pane. Returns null if unreadable. */
+export function capture_pane(tmux_session: string): string | null {
+  try {
+    return execFileSync("tmux", ["capture-pane", "-t", tmux_session, "-p"], {
+      encoding: "utf-8",
+      timeout: 2000,
+    });
+  } catch {
+    return null;
+  }
+}
+
+/** Send one or more keys/literal strings to a tmux session via send-keys.
+ * Best-effort — a dead/unreadable session throws from tmux itself; swallow
+ * it the same way `capture_pane` fails closed to null, so a stray failed
+ * keystroke can't crash the driver mid-sequence (the next pane capture will
+ * naturally see the unexpected state and abort). */
+export function send_keys(tmux_session: string, ...keys: string[]): void {
+  try {
+    execFileSync("tmux", ["send-keys", "-t", tmux_session, ...keys], {
+      stdio: "ignore",
+      timeout: 2000,
+    });
+  } catch {
+    /* best-effort — see doc comment above */
+  }
+}
+
+/** Find the line containing the `❯` selection cursor in a TUI list/panel. */
+export function selection_line(pane_output: string): string | null {
+  return pane_output.split("\n").find((line) => line.includes("❯")) ?? null;
+}
+
+// ── Reconnect driver (Step 1) ──
+
+export interface McpDriver {
+  capture: (session: string) => string | null;
+  send: (session: string, ...keys: string[]) => void;
+  sleep: (ms: number) => Promise<void>;
+  is_healthy: (session: string) => boolean;
+}
+
+export const default_mcp_driver: McpDriver = {
+  capture: capture_pane,
+  send: send_keys,
+  sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+  is_healthy: (session: string) => has_mcp_child(session),
+};
+
+export type ReconnectFailureReason =
+  | "panel_not_open"
+  | "server_not_found"
+  | "wrong_selection"
+  | "detail_menu_not_shown"
+  | "child_still_missing"
+  | "pane_unreadable";
+
+export type ReconnectResult = { ok: true } | { ok: false; reason: ReconnectFailureReason };
+
+/**
+ * Drive Claude Code's `/mcp` TUI to reconnect the Discord plugin server.
+ * Guards at every step (spec): stray keys go into the prompt if we don't
+ * verify pane state before each Enter — this fired an accidental `/compact`
+ * during manual recovery in the incident. Aborts with Escape on any
+ * unexpected pane state instead of pressing on blind.
+ *
+ * Sequence (measured 19/19 during the incident):
+ *   1. Send `/mcp` + Enter.
+ *   2. Confirm "Manage MCP servers" panel visible, else abort.
+ *   3. Press Down until the `❯` selection line contains "plugin:discord" —
+ *      never count keystrokes, the server list varies per session (e.g. a
+ *      "computer-use" built-in may appear first).
+ *   4. Re-confirm the selection line before Enter (guards against a stray
+ *      keystroke moving the cursor between capture and send).
+ *   5. Confirm the detail menu shows "❯ 1. Reconnect" selected, else abort.
+ *   6. Enter, wait ~6s, then re-verify the process-level signal.
+ */
+export async function attempt_mcp_reconnect(
+  tmux_session: string,
+  driver: McpDriver = default_mcp_driver,
+): Promise<ReconnectResult> {
+  driver.send(tmux_session, "/mcp", "Enter");
+  await driver.sleep(MCP_RECONNECT_STEP_WAIT_MS);
+
+  let pane = driver.capture(tmux_session);
+  if (pane === null) return { ok: false, reason: "pane_unreadable" };
+  if (!pane.includes("Manage MCP servers")) {
+    driver.send(tmux_session, "Escape");
+    return { ok: false, reason: "panel_not_open" };
+  }
+
+  let found = false;
+  for (let i = 0; i < MCP_MAX_DOWN_PRESSES; i++) {
+    pane = driver.capture(tmux_session);
+    if (pane === null) return { ok: false, reason: "pane_unreadable" };
+    if (selection_line(pane)?.includes("plugin:discord")) {
+      found = true;
+      break;
+    }
+    driver.send(tmux_session, "Down");
+    await driver.sleep(MCP_RECONNECT_STEP_WAIT_MS);
+  }
+  if (!found) {
+    driver.send(tmux_session, "Escape");
+    return { ok: false, reason: "server_not_found" };
+  }
+
+  // Re-confirm immediately before Enter — guards against a stray keystroke
+  // moving the selection between the last capture and now.
+  pane = driver.capture(tmux_session);
+  if (pane === null) return { ok: false, reason: "pane_unreadable" };
+  if (!selection_line(pane)?.includes("plugin:discord")) {
+    driver.send(tmux_session, "Escape");
+    return { ok: false, reason: "wrong_selection" };
+  }
+  driver.send(tmux_session, "Enter");
+  await driver.sleep(MCP_RECONNECT_STEP_WAIT_MS);
+
+  pane = driver.capture(tmux_session);
+  if (pane === null) return { ok: false, reason: "pane_unreadable" };
+  if (!selection_line(pane)?.includes("1. Reconnect")) {
+    driver.send(tmux_session, "Escape");
+    return { ok: false, reason: "detail_menu_not_shown" };
+  }
+  driver.send(tmux_session, "Enter");
+
+  await driver.sleep(MCP_RECONNECT_VERIFY_WAIT_MS);
+  if (!driver.is_healthy(tmux_session)) {
+    return { ok: false, reason: "child_still_missing" };
+  }
+
+  // Back to the prompt.
+  driver.send(tmux_session, "Escape");
+  return { ok: true };
+}
+
+// ── Recovery cycle orchestration (Step 1 x N, then Step 2 fallback) ──
+
+export type RecoveryCycleOutcome = "reconnected" | "fell_back";
+
+/**
+ * Run one full recovery cycle for a bot: up to MCP_MAX_RECONNECT_ATTEMPTS
+ * scripted `/mcp` Reconnect attempts (Step 1), falling back to `kill_fn()`
+ * (Step 2 — kills the tmux session; the caller's existing crash-recovery
+ * path picks up the respawn with `--resume` on its next tick) if all of
+ * them fail.
+ *
+ * Runs end-to-end inside a single health-tick invocation (each Reconnect
+ * attempt takes only a few seconds) so the caller's per-bot cooldown
+ * throttles whole cycles, not individual keystroke-level attempts — this is
+ * what makes "≤1 action/10min" and "≤3 failed cycles/30min" compatible
+ * (3 cycles x 10min cooldown = 30min, not 3 cycles x 2 attempts x 10min).
+ */
+export async function run_mcp_recovery_cycle(
+  tmux_session: string,
+  kill_fn: () => void,
+  driver: McpDriver = default_mcp_driver,
+): Promise<RecoveryCycleOutcome> {
+  for (let attempt = 0; attempt < MCP_MAX_RECONNECT_ATTEMPTS; attempt++) {
+    const result = await attempt_mcp_reconnect(tmux_session, driver);
+    if (result.ok) return "reconnected";
+  }
+  kill_fn();
+  return "fell_back";
+}
+
+// ── Continuous-monitoring state machine (grace + consecutive-fail gate,
+//    per-bot cooldown, give-up) ──
+
+export interface McpRecoveryState {
+  /** Consecutive health-tick failures since the last healthy reading. */
+  consecutive_fails: number;
+  /** epoch ms of the last recovery cycle — drives the 10-minute per-bot
+   * cooldown between cycles. */
+  last_action_ms: number | null;
+  /** epoch ms timestamps of failed cycles (recorded via
+   * `record_cycle_outcome` when a cycle ends in "fell_back") — drives the
+   * give-up count. */
+  cycle_fail_timestamps: number[];
+  /** Once true, stop acting entirely until the bot is observed healthy
+   * again (external recovery or manual intervention resets state). */
+  given_up: boolean;
+}
+
+function initial_state(): McpRecoveryState {
+  return {
+    consecutive_fails: 0,
+    last_action_ms: null,
+    cycle_fail_timestamps: [],
+    given_up: false,
+  };
+}
+
+export type McpHealthAction = { action: "none" } | { action: "recover" };
+
+/**
+ * Decide what (if anything) to do for one bot on one health tick.
+ *
+ * Mutates `state` in place — the caller owns the map and persists it across
+ * ticks. Pure w.r.t. its inputs otherwise (no I/O), so it's a plain unit to
+ * test against synthetic tick sequences.
+ *
+ * When this returns `{action: "recover"}`, the caller should run
+ * `run_mcp_recovery_cycle` and report the outcome back via
+ * `record_cycle_outcome` — this function only decides *whether* to act.
+ *
+ * @param bot_id - identifies the bot's entry in `state`
+ * @param is_healthy - result of has_mcp_child() this tick
+ * @param is_idle - whether the bot is idle at the prompt right now. Gates
+ *   "recover" — Step 1 drives the TUI, so it must not run mid-turn (spec:
+ *   "reuse the existing idle-detection used for injection draining... if
+ *   mid-turn, defer to the next health tick"). Deferring does NOT consume
+ *   the cooldown budget.
+ * @param age_ms - how long the current session has been assigned/spawned
+ * @param now_ms - current epoch ms (injectable for testing)
+ * @param state - mutable map: bot_id → McpRecoveryState (owned by caller)
+ */
+export function process_mcp_health_tick(
+  bot_id: number,
+  is_healthy: boolean,
+  is_idle: boolean,
+  age_ms: number,
+  now_ms: number,
+  state: Map<number, McpRecoveryState>,
+): McpHealthAction {
+  const s = state.get(bot_id) ?? initial_state();
+
+  if (age_ms < MCP_GRACE_PERIOD_MS) {
+    state.set(bot_id, { ...s, consecutive_fails: 0 });
+    return { action: "none" };
+  }
+
+  if (is_healthy) {
+    // Healthy — clear everything, including give-up. A bot that recovers
+    // (on its own or via our recovery) gets a fresh slate.
+    state.set(bot_id, initial_state());
+    return { action: "none" };
+  }
+
+  const fails = s.consecutive_fails + 1;
+
+  if (fails < MCP_MIN_CONSECUTIVE_FAILS) {
+    state.set(bot_id, { ...s, consecutive_fails: fails });
+    return { action: "none" };
+  }
+
+  if (s.given_up) {
+    state.set(bot_id, { ...s, consecutive_fails: fails });
+    return { action: "none" };
+  }
+
+  if (s.last_action_ms !== null && now_ms - s.last_action_ms < MCP_RECOVERY_COOLDOWN_MS) {
+    state.set(bot_id, { ...s, consecutive_fails: fails });
+    return { action: "none" };
+  }
+
+  if (!is_idle) {
+    // Mid-turn — defer to the next tick without spending cooldown budget.
+    state.set(bot_id, { ...s, consecutive_fails: fails });
+    return { action: "none" };
+  }
+
+  state.set(bot_id, { ...s, consecutive_fails: fails, last_action_ms: now_ms });
+  return { action: "recover" };
+}
+
+/**
+ * Report the outcome of a recovery cycle back into `state`. Call this after
+ * `run_mcp_recovery_cycle` resolves, following a `{action: "recover"}` tick.
+ *
+ * A "reconnected" outcome needs no bookkeeping here — the next health tick
+ * will observe `is_healthy: true` and clear the state naturally.
+ *
+ * A "fell_back" outcome records a failed-cycle timestamp and, once
+ * MCP_GIVEUP_THRESHOLD failed cycles land within MCP_GIVEUP_WINDOW_MS, sets
+ * `given_up` so future ticks stay silent instead of spamming recovery
+ * attempts (and #alerts) for a bot that isn't responding to any of them.
+ *
+ * Returns escalation info when this outcome crosses the give-up threshold,
+ * or null otherwise.
+ */
+export function record_cycle_outcome(
+  bot_id: number,
+  outcome: RecoveryCycleOutcome,
+  now_ms: number,
+  state: Map<number, McpRecoveryState>,
+): { cycle_fail_count: number } | null {
+  if (outcome === "reconnected") return null;
+
+  const s = state.get(bot_id) ?? initial_state();
+  const window_start = now_ms - MCP_GIVEUP_WINDOW_MS;
+  const recent_cycle_fails = [...s.cycle_fail_timestamps.filter((t) => t > window_start), now_ms];
+  const given_up = recent_cycle_fails.length >= MCP_GIVEUP_THRESHOLD;
+
+  state.set(bot_id, { ...s, cycle_fail_timestamps: recent_cycle_fails, given_up });
+
+  return given_up ? { cycle_fail_count: recent_cycle_fails.length } : null;
+}
+
+/** Remove state entries for bots no longer assigned (released, parked) so
+ * the map doesn't grow unbounded. Call periodically from the health loop. */
+export function prune_mcp_state(
+  state: Map<number, McpRecoveryState>,
+  assigned_bot_ids: Set<number>,
+): void {
+  for (const id of state.keys()) {
+    if (!assigned_bot_ids.has(id)) {
+      state.delete(id);
+    }
+  }
+}
+
+// ── Post-spawn verification (grace-period poll, no state machine) ──
+
+/**
+ * Poll for the MCP child to appear after a fresh spawn. Distinct from the
+ * continuous-monitoring tick machinery above — this is a one-shot wait used
+ * right after `start_tmux` + `wait_for_bot_ready`, mirroring the shape of
+ * `wait_for_bot_ready` itself (poll loop with a bounded timeout).
+ */
+export async function wait_for_mcp_child(
+  tmux_session: string,
+  opts?: { timeout_ms?: number; poll_ms?: number },
+  has_child_fn: (session: string) => boolean = has_mcp_child,
+): Promise<boolean> {
+  const timeout = opts?.timeout_ms ?? 15_000;
+  const poll = opts?.poll_ms ?? 1_000;
+  const start = Date.now();
+
+  if (has_child_fn(tmux_session)) return true;
+
+  while (Date.now() - start < timeout) {
+    await new Promise((resolve) => setTimeout(resolve, poll));
+    if (has_child_fn(tmux_session)) return true;
+  }
+  return false;
+}

--- a/packages/daemon/src/mcp-health.ts
+++ b/packages/daemon/src/mcp-health.ts
@@ -345,6 +345,12 @@ export interface McpRecoveryState {
    * `record_cycle_outcome` when a cycle ends in "fell_back") — drives the
    * give-up count. */
   cycle_fail_timestamps: number[];
+  /** epoch ms of the most recent Step 2 (kill+resume) fallback, or null if
+   * the last cycle didn't fall back. Set by `record_cycle_outcome`, consumed
+   * and cleared by the first healthy tick afterwards — that transition is
+   * the "recovered after a fallback" signal the spec wants on #alerts.
+   * Routine Step 1 reconnects never set it, so they stay silent. */
+  last_fell_back_at: number | null;
   /** Once true, stop acting entirely until the bot is observed healthy
    * again (external recovery or manual intervention resets state). */
   given_up: boolean;
@@ -355,11 +361,19 @@ function initial_state(): McpRecoveryState {
     consecutive_fails: 0,
     last_action_ms: null,
     cycle_fail_timestamps: [],
+    last_fell_back_at: null,
     given_up: false,
   };
 }
 
-export type McpHealthAction = { action: "none" } | { action: "recover" };
+export type McpHealthAction =
+  | { action: "none" }
+  | { action: "recover" }
+  /** The bot is healthy again after a Step 2 kill+resume fallback — the
+   * caller should post the one-shot recovery notice (spec: #alerts on
+   * successful recovery after a fallback). Distinct from "recover", which
+   * asks the caller to *start* a recovery cycle. */
+  | { action: "notify_recovered" };
 
 /**
  * Decide what (if anything) to do for one bot on one health tick.
@@ -371,6 +385,10 @@ export type McpHealthAction = { action: "none" } | { action: "recover" };
  * When this returns `{action: "recover"}`, the caller should run
  * `run_mcp_recovery_cycle` and report the outcome back via
  * `record_cycle_outcome` — this function only decides *whether* to act.
+ *
+ * When it returns `{action: "notify_recovered"}`, the bot came back healthy
+ * after a Step 2 fallback and the caller should post the one-shot recovery
+ * notice; no recovery cycle is needed.
  *
  * @param bot_id - identifies the bot's entry in `state`
  * @param is_healthy - result of has_mcp_child() this tick
@@ -400,9 +418,12 @@ export function process_mcp_health_tick(
 
   if (is_healthy) {
     // Healthy — clear everything, including give-up. A bot that recovers
-    // (on its own or via our recovery) gets a fresh slate.
+    // (on its own or via our recovery) gets a fresh slate. Clearing also
+    // consumes `last_fell_back_at`, so the recovery notice fires exactly
+    // once rather than on every healthy tick that follows.
+    const recovered_after_fallback = s.last_fell_back_at !== null;
     state.set(bot_id, initial_state());
-    return { action: "none" };
+    return recovered_after_fallback ? { action: "notify_recovered" } : { action: "none" };
   }
 
   const fails = s.consecutive_fails + 1;
@@ -437,7 +458,12 @@ export function process_mcp_health_tick(
  * `run_mcp_recovery_cycle` resolves, following a `{action: "recover"}` tick.
  *
  * A "reconnected" outcome needs no bookkeeping here — the next health tick
- * will observe `is_healthy: true` and clear the state naturally.
+ * will observe `is_healthy: true` and clear the state naturally, silently
+ * (spec: routine Step 1 reconnects don't page anyone).
+ *
+ * A "fell_back" outcome additionally stamps `last_fell_back_at`, so the first
+ * healthy tick afterwards returns `{action: "notify_recovered"}` and the
+ * caller can post the "recovered after kill+resume" notice.
  *
  * A "fell_back" outcome records a failed-cycle timestamp and, once
  * MCP_GIVEUP_THRESHOLD failed cycles land within MCP_GIVEUP_WINDOW_MS, sets
@@ -460,7 +486,12 @@ export function record_cycle_outcome(
   const recent_cycle_fails = [...s.cycle_fail_timestamps.filter((t) => t > window_start), now_ms];
   const given_up = recent_cycle_fails.length >= MCP_GIVEUP_THRESHOLD;
 
-  state.set(bot_id, { ...s, cycle_fail_timestamps: recent_cycle_fails, given_up });
+  state.set(bot_id, {
+    ...s,
+    cycle_fail_timestamps: recent_cycle_fails,
+    last_fell_back_at: now_ms,
+    given_up,
+  });
 
   return given_up ? { cycle_fail_count: recent_cycle_fails.length } : null;
 }

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -13,6 +13,16 @@ import {
   session_jsonl_exists_anywhere_in,
 } from "./claude-config-migration.js";
 import { resolve_binary } from "./env.js";
+import {
+  classify_mcp_failure,
+  has_mcp_child,
+  process_mcp_health_tick,
+  prune_mcp_state,
+  record_cycle_outcome,
+  run_mcp_recovery_cycle,
+  wait_for_mcp_child,
+} from "./mcp-health.js";
+import type { McpRecoveryState } from "./mcp-health.js";
 import { resolve_effort, resolve_model_id } from "./models.js";
 import { load_pool_state, save_pool_state } from "./persistence.js";
 import type { PersistedBotAvatarState, PersistedPoolBot } from "./persistence.js";
@@ -415,6 +425,10 @@ export class BotPool extends EventEmitter {
   private session_watchers = new Map<number, ReturnType<typeof setTimeout>>();
   /** Timer for the rate-limit modal recovery scan (60s interval, issue #270). */
   private rate_limit_timer: ReturnType<typeof setInterval> | null = null;
+  /** Per-bot MCP connection health state (issue #345). bot_id →
+   * McpRecoveryState. Cleared on release/park so a future assignment starts
+   * with a clean slate. */
+  private mcp_state = new Map<number, McpRecoveryState>();
 
   constructor(config: LobsterFarmConfig) {
     super();
@@ -903,6 +917,24 @@ export class BotPool extends EventEmitter {
           extra_env,
         );
 
+        // Boot-stagger gate (issue #345): the 2026-07-18 outage was caused by
+        // ~9 simultaneous cold starts racing the CLI's plugin-MCP startup.
+        // Gate this candidate's resume on its own post-spawn MCP
+        // verification before the loop moves to the next candidate — this
+        // serializes cold starts instead of firing them back-to-back. Capped
+        // (default 45s) so one stuck bot can't stall the whole resume queue.
+        const cap_ms = this.boot_stagger_cap_ms();
+        const mcp_verified = await Promise.race([
+          this.verify_mcp_post_spawn(bot),
+          new Promise<boolean>((resolve) => setTimeout(() => resolve(false), cap_ms)),
+        ]);
+        if (!mcp_verified) {
+          console.warn(
+            `[pool] pool-${String(bot.id)} MCP unconfirmed after boot-stagger cap ` +
+              `(${String(cap_ms)}ms) — moving to next candidate; continuous health monitor will retry`,
+          );
+        }
+
         // Update bot state to assigned. The resumed session is known to have
         // a JSONL on disk (pre-flight checked in initialize()), so mark it
         // confirmed — persist() will now write the session_id.
@@ -1186,6 +1218,13 @@ export class BotPool extends EventEmitter {
         extra_env,
       );
 
+      // Post-spawn MCP verification gate (issue #345), fire-and-forget —
+      // assign() is on the live-message path (a Discord user is waiting),
+      // so this runs in the background rather than blocking the response.
+      // No stagger needed here (spec: assign() spawns are naturally spread
+      // out already, unlike the boot-time resume_parked_bots() burst).
+      void this.verify_mcp_post_spawn(bot);
+
       // Update bot state
       const assigned_defaults = DEFAULT_ARCHETYPES[archetype];
       bot.state = "assigned";
@@ -1264,6 +1303,9 @@ export class BotPool extends EventEmitter {
       const bot_id = bot.id;
       this.kill_tmux(bot.tmux_session);
       this.cancel_session_watcher(bot_id);
+      // Clear MCP health state so a future assignment on this bot doesn't
+      // inherit a stale observation window or give-up flag (issue #345).
+      this.mcp_state.delete(bot_id);
 
       // Clear any orphaned pending file when releasing a bot — prevents stale
       // message content from a previous assignment leaking into a future one.
@@ -1303,6 +1345,9 @@ export class BotPool extends EventEmitter {
   /** Park a bot — preserve session ID for later resume, free the bot. */
   private async park_bot(bot: PoolBot): Promise<void> {
     this.kill_tmux(bot.tmux_session);
+    // The tmux session is being killed — any in-progress MCP observation
+    // window is moot (issue #345).
+    this.mcp_state.delete(bot.id);
     bot.state = "parked";
     // session_id, channel_id, entity_id, archetype preserved for resume in memory.
     // Clear access.json on disk so no stale channel config survives if the bot's
@@ -1622,6 +1667,10 @@ export class BotPool extends EventEmitter {
       // Clean up old crash history entries (>1 hour) to prevent memory growth
       this.cleanup_crash_history();
       this.cleanup_session_history();
+      prune_mcp_state(
+        this.mcp_state,
+        new Set(this.bots.filter((b) => b.state === "assigned").map((b) => b.id)),
+      );
 
       // Deliver any queued messages to bots that are now at the prompt
       this.drain_pending_injections();
@@ -1639,6 +1688,9 @@ export class BotPool extends EventEmitter {
         if (this.is_tmux_alive(bot.tmux_session)) {
           // Session alive — check for orphaned cwd (directory deleted out from under it)
           await this.check_cwd_health(bot);
+          // Verify the Discord plugin MCP server is actually connected —
+          // pane text alone doesn't prove it (issue #345).
+          await this.check_mcp_health(bot);
           continue;
         }
 
@@ -1801,6 +1853,13 @@ export class BotPool extends EventEmitter {
         is_resume,
         extra_env,
       );
+
+      // Post-spawn MCP verification gate (issue #345): spawn success in bad
+      // windows has been measured as low as ~25% — verify before declaring
+      // this crash-restart successful. Awaited (unlike assign()'s
+      // fire-and-forget) because this is a background health-monitor
+      // operation, not a live user-facing call.
+      await this.verify_mcp_post_spawn(bot);
 
       // Update state — bot stays assigned with refreshed timestamps.
       // `is_resume` is only true when we pre-flighted the JSONL on disk, so
@@ -2717,6 +2776,149 @@ export class BotPool extends EventEmitter {
       // Best-effort — tmux display-message or send-keys failed.
       // The existing liveness check handles truly dead sessions separately.
     }
+  }
+
+  // ── MCP connection verification & auto-reconnect (issue #345) ──
+
+  /** Per-candidate cap (ms) for the resume_parked_bots() boot-stagger gate —
+   * see the call site. A protected getter (rather than a bare literal) so
+   * tests can shrink it and exercise the cap path without real 45-second
+   * waits. */
+  protected boot_stagger_cap_ms(): number {
+    return 45_000;
+  }
+
+  /**
+   * Verify a single assigned bot's Discord plugin MCP connection and drive
+   * recovery if it's confirmed dead. Called from check_assigned_health() for
+   * every assigned bot whose tmux is alive — pane text is NOT a trustworthy
+   * proxy for a live MCP connection (deaf sessions still show the prompt).
+   *
+   * Detection: a `bun` child process under the pane PID. Confirmed dead
+   * after MCP_MIN_CONSECUTIVE_FAILS consecutive ticks past a grace period
+   * (`process_mcp_health_tick` in mcp-health.ts owns the anti-thrash state
+   * machine). When it fires:
+   *   1. Scripted `/mcp` Reconnect, up to MCP_MAX_RECONNECT_ATTEMPTS times —
+   *      silent on success (routine, no #alerts noise).
+   *   2. Fallback: kill the tmux session. The next tick's dead-tmux branch
+   *      picks it up via the existing restart_crashed_session() path (which
+   *      now carries its own post-spawn MCP verification, see
+   *      verify_mcp_post_spawn()) — this also means a fallback DOES count
+   *      toward the crash-loop guard, as specified.
+   *   3. After MCP_GIVEUP_THRESHOLD failed cycles in the give-up window,
+   *      stop and alert #alerts. The bot is never released.
+   */
+  protected async check_mcp_health(bot: PoolBot): Promise<void> {
+    const healthy = has_mcp_child(bot.tmux_session);
+    const age_ms = bot.assigned_at ? Date.now() - bot.assigned_at.getTime() : 0;
+    const idle = this.is_bot_idle(bot);
+    const now = Date.now();
+
+    const tick = process_mcp_health_tick(bot.id, healthy, idle, age_ms, now, this.mcp_state);
+    if (tick.action === "none") return;
+
+    const working_dir = bot.entity_id ? entity_dir(this.config.paths, bot.entity_id) : null;
+    const failure_mode = working_dir ? classify_mcp_failure(working_dir) : "unknown";
+    console.warn(
+      `[pool] pool-${String(bot.id)} MCP connection dead (${failure_mode}) — running recovery cycle ` +
+        `(entity: ${bot.entity_id ?? "unknown"}, channel: ${bot.channel_id ?? "none"})`,
+    );
+    sentry.addBreadcrumb({
+      category: "daemon.pool",
+      message: `pool-${String(bot.id)} MCP recovery cycle starting`,
+      data: { bot_id: bot.id, entity_id: bot.entity_id, channel_id: bot.channel_id, failure_mode },
+    });
+
+    const outcome = await run_mcp_recovery_cycle(bot.tmux_session, () =>
+      this.kill_tmux(bot.tmux_session),
+    );
+
+    if (outcome === "reconnected") {
+      // Silent per spec — routine Step 1 success shouldn't page anyone.
+      console.log(`[pool] pool-${String(bot.id)} MCP reconnected via scripted /mcp Reconnect`);
+      return;
+    }
+
+    console.warn(
+      `[pool] pool-${String(bot.id)} MCP Reconnect exhausted — fell back to kill+resume ` +
+        `(channel: ${bot.channel_id ?? "none"})`,
+    );
+
+    const escalation = record_cycle_outcome(bot.id, outcome, now, this.mcp_state);
+    if (!escalation) return;
+
+    const entity_config = bot.entity_id ? this.registry?.get(bot.entity_id) : undefined;
+    const channel_label =
+      entity_config?.entity.channels.list.find((ch) => ch.id === bot.channel_id)?.purpose ??
+      bot.channel_id ??
+      bot.entity_id ??
+      "unknown";
+
+    console.error(
+      `[pool] pool-${String(bot.id)} MCP recovery gave up after ${String(escalation.cycle_fail_count)} failed cycles — bot left assigned, needs manual attention`,
+    );
+    sentry.captureMessage(`MCP recovery gave up for pool-${String(bot.id)}`, "error", {
+      tags: { module: "pool", bot_id: String(bot.id), action: "mcp_recovery_giveup" },
+      contexts: {
+        mcp_recovery: {
+          entity_id: bot.entity_id,
+          channel_id: bot.channel_id,
+          cycle_fail_count: escalation.cycle_fail_count,
+        },
+      },
+    });
+    try {
+      await notify(
+        "alerts",
+        `🔴 Pool bot ${String(bot.id)} (${bot.archetype ?? "unknown"}) MCP connection dead — ${String(escalation.cycle_fail_count)} recovery cycles failed in 30 min for ${bot.entity_id ?? "unknown"}/${channel_label}. Reconnect script and kill+resume both exhausted. Bot NOT released — needs manual intervention.`,
+        entity_config,
+      );
+    } catch (err) {
+      console.warn(`[pool] Failed to alert MCP give-up for pool-${String(bot.id)}: ${String(err)}`);
+    }
+  }
+
+  /**
+   * Post-spawn MCP verification gate (issue #345). Waits for the MCP child
+   * to appear after a fresh spawn/respawn/resume; if it's still absent,
+   * runs the scripted `/mcp` Reconnect (up to MCP_MAX_RECONNECT_ATTEMPTS
+   * tries) inline.
+   *
+   * Deliberately does NOT loop into a kill+resume fallback here — that
+   * escalation path is owned by the continuous health-tick monitor
+   * (check_mcp_health), which check_assigned_health() will pick up on its
+   * next tick using this bot's fresh `assigned_at` timestamp. Looping a
+   * full respawn cycle synchronously inside assign()/restart/resume would
+   * risk long blocking calls and duplicate the anti-thrash bookkeeping that
+   * already lives in the continuous monitor.
+   *
+   * Returns whether the MCP connection was confirmed by the time this call
+   * returns — callers use this only for logging; they still declare the
+   * bot assigned either way, matching the codebase's existing pattern of
+   * never blocking bot readiness on best-effort verification.
+   */
+  protected async verify_mcp_post_spawn(bot: PoolBot): Promise<boolean> {
+    if (await wait_for_mcp_child(bot.tmux_session)) return true;
+
+    console.warn(
+      `[pool] pool-${String(bot.id)} spawned but MCP child not detected within grace window — attempting scripted reconnect`,
+    );
+    const result = await run_mcp_recovery_cycle(bot.tmux_session, () => {
+      // No kill here — the bot was *just* spawned; killing it again would
+      // just repeat the spawn we already attempted. Post-spawn recovery is
+      // reconnect-only; the continuous monitor owns the kill+resume escalation.
+    });
+
+    if (result === "reconnected") {
+      console.log(
+        `[pool] pool-${String(bot.id)} MCP reconnected post-spawn via scripted /mcp Reconnect`,
+      );
+      return true;
+    }
+    console.warn(
+      `[pool] pool-${String(bot.id)} MCP still unconfirmed post-spawn — continuous health monitor will retry`,
+    );
+    return false;
   }
 
   private is_tmux_alive(session_name: string): boolean {

--- a/packages/daemon/src/pool.ts
+++ b/packages/daemon/src/pool.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from "node:events";
 import { access, readFile, readdir, stat, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import type { ArchetypeRole, LobsterFarmConfig } from "@lobster-farm/shared";
+import type { ArchetypeRole, EntityConfig, LobsterFarmConfig } from "@lobster-farm/shared";
 import { DEFAULT_ARCHETYPES, entity_dir, expand_home, lobsterfarm_dir } from "@lobster-farm/shared";
 import type { ChannelType } from "@lobster-farm/shared";
 import { notify } from "./actions.js";
@@ -2807,6 +2807,10 @@ export class BotPool extends EventEmitter {
    *      toward the crash-loop guard, as specified.
    *   3. After MCP_GIVEUP_THRESHOLD failed cycles in the give-up window,
    *      stop and alert #alerts. The bot is never released.
+   *
+   * Also posts a one-shot #alerts notice when a bot comes back healthy after
+   * a Step 2 fallback (spec: alert on give-up and on successful recovery
+   * after a fallback; silent for routine Step 1 reconnects).
    */
   protected async check_mcp_health(bot: PoolBot): Promise<void> {
     const healthy = has_mcp_child(bot.tmux_session);
@@ -2815,6 +2819,10 @@ export class BotPool extends EventEmitter {
     const now = Date.now();
 
     const tick = process_mcp_health_tick(bot.id, healthy, idle, age_ms, now, this.mcp_state);
+    if (tick.action === "notify_recovered") {
+      await this.alert_mcp_recovered(bot);
+      return;
+    }
     if (tick.action === "none") return;
 
     const working_dir = bot.entity_id ? entity_dir(this.config.paths, bot.entity_id) : null;
@@ -2847,12 +2855,7 @@ export class BotPool extends EventEmitter {
     const escalation = record_cycle_outcome(bot.id, outcome, now, this.mcp_state);
     if (!escalation) return;
 
-    const entity_config = bot.entity_id ? this.registry?.get(bot.entity_id) : undefined;
-    const channel_label =
-      entity_config?.entity.channels.list.find((ch) => ch.id === bot.channel_id)?.purpose ??
-      bot.channel_id ??
-      bot.entity_id ??
-      "unknown";
+    const { entity_config, channel_label } = this.mcp_alert_context(bot);
 
     console.error(
       `[pool] pool-${String(bot.id)} MCP recovery gave up after ${String(escalation.cycle_fail_count)} failed cycles — bot left assigned, needs manual attention`,
@@ -2875,6 +2878,55 @@ export class BotPool extends EventEmitter {
       );
     } catch (err) {
       console.warn(`[pool] Failed to alert MCP give-up for pool-${String(bot.id)}: ${String(err)}`);
+    }
+  }
+
+  /** Resolve the entity config and human-readable channel label used in MCP
+   * #alerts messages. Falls back through channel purpose → channel id →
+   * entity id so the alert always names *something* identifiable. */
+  private mcp_alert_context(bot: PoolBot): {
+    entity_config: EntityConfig | undefined;
+    channel_label: string;
+  } {
+    const entity_config = bot.entity_id ? this.registry?.get(bot.entity_id) : undefined;
+    const channel_label =
+      entity_config?.entity.channels.list.find((ch) => ch.id === bot.channel_id)?.purpose ??
+      bot.channel_id ??
+      bot.entity_id ??
+      "unknown";
+    return { entity_config, channel_label };
+  }
+
+  /**
+   * Post the one-shot "recovered after kill+resume" notice (issue #345).
+   * Fired when a bot reads healthy again after a Step 2 fallback — the
+   * fallback itself is silent, so without this the operator would see a
+   * bot go quiet and never learn it came back. Routine Step 1 reconnects
+   * never reach here (they don't stamp `last_fell_back_at`).
+   */
+  private async alert_mcp_recovered(bot: PoolBot): Promise<void> {
+    const { entity_config, channel_label } = this.mcp_alert_context(bot);
+
+    console.log(
+      `[pool] pool-${String(bot.id)} MCP recovered after kill+resume fallback ` +
+        `(entity: ${bot.entity_id ?? "unknown"}, channel: ${channel_label})`,
+    );
+    sentry.addBreadcrumb({
+      category: "daemon.pool",
+      message: `pool-${String(bot.id)} MCP recovered after fallback`,
+      data: { bot_id: bot.id, entity_id: bot.entity_id, channel_id: bot.channel_id },
+    });
+
+    try {
+      await notify(
+        "alerts",
+        `🟢 Pool bot ${String(bot.id)} (${bot.archetype ?? "unknown"}) MCP connection recovered after kill+resume fallback — ${bot.entity_id ?? "unknown"}/${channel_label}. Back online, no action needed.`,
+        entity_config,
+      );
+    } catch (err) {
+      console.warn(
+        `[pool] Failed to alert MCP recovery for pool-${String(bot.id)}: ${String(err)}`,
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

Detects pool bots and Pat (Commander) whose Discord plugin MCP server never spawned or died — process-level check (a `bun` child process under the pane PID), since pane text alone (the existing `wait_for_bot_ready` gate) already passed on deaf sessions during the 2026-07-18 outage.

- **Detection**: `has_mcp_child()` in `mcp-health.ts` — `tmux list-panes` for the pane PID, `pgrep -P` for children. Wired into `check_assigned_health()` for every assigned pool bot and into Pat's 10s health poll in `commander-process.ts`.
- **Recovery, ordered**:
  1. Scripted `/mcp` Reconnect (`attempt_mcp_reconnect()`), guarded at every step — confirms the "Manage MCP servers" panel, hunts for the `plugin:discord` selection line (never counts keystrokes), re-confirms before each `Enter`, and re-verifies the process signal ~6s after selecting Reconnect. Aborts with Escape on any unexpected pane state. Only runs while the bot is idle at the prompt; defers to the next tick mid-turn.
  2. After 2 failed Reconnect attempts, falls back to kill+resume — the existing `restart_crashed_session()` path, which now also carries its own post-spawn MCP verification.
- **Anti-thrash**: at most one recovery cycle per bot per 10 minutes; after 3 failed cycles in 30 minutes, gives up and alerts `#alerts` — the bot is never released.
- **Post-spawn gate**: `assign()`, `restart_crashed_session()`, and `resume_parked_bots()` all verify the MCP child before declaring a spawn/respawn/resume ready. `resume_parked_bots()` gates each candidate's resume on the previous one's verification (capped, default 45s) — this serializes boot-time cold starts instead of firing them back-to-back, which is what created the ~9-simultaneous-spawn window in the incident.

## Design notes / deviations from the spec text

- **"1 recovery action per 10 min" vs "3 failed cycles per 30 min"**: read literally, if each Reconnect sub-attempt burned its own 10-minute cooldown slot, 3 full cycles (2 reconnects + fallback each) couldn't mathematically fit inside a 30-minute window. Resolved by treating one *full cycle* (both Reconnect attempts, then fallback if needed) as a single "recovery action" that runs synchronously within one health tick and consumes one cooldown slot — this is what makes the two anti-thrash numbers compatible (verified by a dedicated unit test asserting `MCP_GIVEUP_THRESHOLD * MCP_RECOVERY_COOLDOWN_MS <= 30min`).
- **Post-spawn gate is reconnect-only, not a full kill+resume loop**: `verify_mcp_post_spawn()` waits for the MCP child, then tries the scripted Reconnect if it's missing — it does **not** recursively kill+respawn on failure. That escalation is left to the continuous monitor (`check_mcp_health`), which already owns the anti-thrash bookkeeping. Duplicating a bounded respawn loop inside the synchronous spawn path risked long blocking calls and split-brain state between two recovery owners.
- **`assign()`'s post-spawn verification is fire-and-forget**, unlike `restart_crashed_session()`/`resume_parked_bots()` (awaited). `assign()` is on the live Discord-message path; blocking a user's first reply for up to ~20s to verify MCP would be a regression. This mirrors the existing fire-and-forget pattern for `watch_session_confirmation()`.
- **Corroborating log-dir signal** (`classify_mcp_failure`) is diagnosis-only, logged alongside every recovery cycle (`never-spawned` vs `died`) — it never gates detection or recovery, per spec.

## Files

- `packages/daemon/src/mcp-health.ts` (new) — detection, reconnect driver, anti-thrash state machine. Mirrors the `rate-limit-recovery.ts` (#270) / `econnreset-recovery.ts` (#337) pane-driving template.
- `packages/daemon/src/pool.ts` — wires `check_mcp_health()` into `check_assigned_health()`, `verify_mcp_post_spawn()` into `assign()` / `restart_crashed_session()` / `resume_parked_bots()` (with boot-stagger gating), MCP state cleanup on release/park.
- `packages/daemon/src/commander-process.ts` — same detection/recovery for Pat's single session, reusing `pool.ts`'s `is_tmux_session_idle()`.
- `packages/daemon/src/__tests__/mcp-health.test.ts`, `pool-mcp-health.test.ts`, `commander-mcp-health.test.ts` (new) — unit + integration coverage per the issue's Tests section.
- `packages/daemon/src/__tests__/helpers/test-bot-pool-base.ts` — default MCP checks to a no-op/healthy happy path so the ~60 pre-existing pool tests that don't exercise MCP behavior aren't slowed down by real tmux/pgrep calls.

## Test plan

- [x] `pnpm -C packages/daemon test` — 69 files, 1217 tests pass (includes 3 new files covering detection, the reconnect driver, anti-thrash cooldown/give-up math, post-spawn gate, and boot-stagger serialization + cap)
- [x] `pnpm typecheck` — clean across all packages
- [x] `pnpm lint` (biome) — clean
- [x] `pnpm -C packages/daemon build` — bundles successfully

## Non-goals (per issue)

- The ECONNRESET wedge (#337) — separate detector, deliberately not merged with this one.
- Fixing the CLI's plugin-spawn race upstream.
- Failsafe session — interactive, user-attended, excluded same as rate-limit recovery.

## Deployment

Per the issue and CLAUDE.md: **not deploying this myself** — coordinating the daemon restart with Jax, never hot-restarting the live daemon mid-incident.

Closes #345