### PR TITLE
fix(daemon): walk full descendant tree for MCP child detection

### DIFF
--- a/packages/daemon/src/__tests__/mcp-health.test.ts
+++ b/packages/daemon/src/__tests__/mcp-health.test.ts
@@ -7,41 +7,185 @@ import {
   attempt_mcp_reconnect,
   classify_mcp_failure,
   encode_cache_slug,
+  has_bun_descendant,
   has_mcp_child,
+  is_discord_mcp_bun_process,
   process_mcp_health_tick,
   prune_mcp_state,
   record_cycle_outcome,
   run_mcp_recovery_cycle,
   selection_line,
+  snapshot_processes,
   wait_for_mcp_child,
 } from "../mcp-health.js";
-import type { McpDriver, McpRecoveryState } from "../mcp-health.js";
+import type { McpDriver, McpRecoveryState, ProcessNode } from "../mcp-health.js";
 
-// ── has_mcp_child (process-level detection) ──
+// ── has_mcp_child (process-level detection, delegates to has_bun_descendant) ──
 
 describe("has_mcp_child", () => {
-  it("returns true when the pane PID has a bun child process", () => {
+  it("returns true when a discord-plugin bun descendant is found under the pane PID", () => {
     const pane_pid_fn = vi.fn().mockReturnValue(4242);
-    const has_children_fn = vi.fn().mockReturnValue(true);
+    const has_bun_descendant_fn = vi.fn().mockReturnValue(true);
 
-    expect(has_mcp_child("pool-1", pane_pid_fn, has_children_fn)).toBe(true);
+    expect(has_mcp_child("pool-1", pane_pid_fn, has_bun_descendant_fn)).toBe(true);
     expect(pane_pid_fn).toHaveBeenCalledWith("pool-1");
-    expect(has_children_fn).toHaveBeenCalledWith(4242);
+    expect(has_bun_descendant_fn).toHaveBeenCalledWith(4242);
   });
 
-  it("returns false when the pane has no children", () => {
+  it("returns false when no bun descendant is found", () => {
     const pane_pid_fn = vi.fn().mockReturnValue(4242);
-    const has_children_fn = vi.fn().mockReturnValue(false);
+    const has_bun_descendant_fn = vi.fn().mockReturnValue(false);
 
-    expect(has_mcp_child("pool-1", pane_pid_fn, has_children_fn)).toBe(false);
+    expect(has_mcp_child("pool-1", pane_pid_fn, has_bun_descendant_fn)).toBe(false);
   });
 
   it("returns false when the pane PID can't be resolved (dead/unreadable session)", () => {
     const pane_pid_fn = vi.fn().mockReturnValue(null);
-    const has_children_fn = vi.fn();
+    const has_bun_descendant_fn = vi.fn();
 
-    expect(has_mcp_child("pool-1", pane_pid_fn, has_children_fn)).toBe(false);
-    expect(has_children_fn).not.toHaveBeenCalled();
+    expect(has_mcp_child("pool-1", pane_pid_fn, has_bun_descendant_fn)).toBe(false);
+    expect(has_bun_descendant_fn).not.toHaveBeenCalled();
+  });
+});
+
+// ── is_discord_mcp_bun_process (comm + plugin-path disambiguation) ──
+
+describe("is_discord_mcp_bun_process", () => {
+  it("matches the real discord plugin launch command", () => {
+    expect(
+      is_discord_mcp_bun_process(
+        "bun run --cwd /Users/farm/.claude/plugins/cache/claude-plugins-official/discord/0.0.4 --shell=bun --silent start",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches a full-path bun executable, not just a bare argv0", () => {
+    expect(
+      is_discord_mcp_bun_process(
+        "/opt/homebrew/bin/bun run --cwd /Users/farm/.claude/plugins/cache/claude-plugins-official/discord/0.0.4 start",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a non-discord bun MCP server (the inverse hazard)", () => {
+    expect(
+      is_discord_mcp_bun_process(
+        "bun run --cwd /Users/beacon/.claude/plugins/cache/claude-plugins-official/imessage/0.1.0 --shell=bun --silent start",
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects a non-bun process even if its args mention discord", () => {
+    expect(is_discord_mcp_bun_process("node /some/discord/script.js")).toBe(false);
+  });
+
+  it("rejects an empty command", () => {
+    expect(is_discord_mcp_bun_process("")).toBe(false);
+  });
+});
+
+// ── snapshot_processes (real `ps` call — smoke test only, OS-dependent) ──
+
+describe("snapshot_processes", () => {
+  it("returns a non-empty list of well-formed process nodes for the current machine", () => {
+    const processes = snapshot_processes();
+    expect(processes.length).toBeGreaterThan(0);
+    for (const p of processes.slice(0, 20)) {
+      expect(Number.isInteger(p.pid)).toBe(true);
+      expect(Number.isInteger(p.ppid)).toBe(true);
+      expect(typeof p.command).toBe("string");
+    }
+    // pid 1 (init/launchd) should always be present.
+    expect(processes.some((p) => p.pid === 1)).toBe(true);
+  });
+});
+
+// ── has_bun_descendant (full descendant-tree walk — the #347 fix) ──
+
+describe("has_bun_descendant", () => {
+  const DISCORD_BUN_CMD =
+    "bun run --cwd /Users/farm/.claude/plugins/cache/claude-plugins-official/discord/0.0.4 --shell=bun --silent start";
+
+  function node(pid: number, ppid: number, command: string): ProcessNode {
+    return { pid, ppid, command };
+  }
+
+  it("regression: pane -> shell -> claude, no bun anywhere -> unhealthy", () => {
+    // This is the exact shape that produced the #347 false positive: pane_pid
+    // is the resumed session's original login shell, claude is its direct
+    // child, and no MCP server ever spawned. The pre-#347 direct-children-only
+    // check (`pgrep -P pane_pid` non-empty) would have reported this healthy
+    // because `claude` itself counts as "a child."
+    const pane_pid = 100;
+    const processes = [node(200, pane_pid, "/bin/zsh"), node(300, 200, "claude --resume")];
+
+    expect(has_bun_descendant(pane_pid, () => processes)).toBe(false);
+  });
+
+  it("pane -> shell -> claude -> bun (discord) -> healthy", () => {
+    const pane_pid = 100;
+    const processes = [
+      node(200, pane_pid, "/bin/zsh"),
+      node(300, 200, "claude --resume"),
+      node(400, 300, DISCORD_BUN_CMD),
+    ];
+
+    expect(has_bun_descendant(pane_pid, () => processes)).toBe(true);
+  });
+
+  it("fresh spawn: pane PID is claude itself (exec'd shell), bun as direct child -> healthy", () => {
+    const pane_pid = 300;
+    const processes = [node(300, 1, "claude"), node(400, 300, DISCORD_BUN_CMD)];
+
+    expect(has_bun_descendant(pane_pid, () => processes)).toBe(true);
+  });
+
+  it("fresh spawn with no MCP server at all -> unhealthy", () => {
+    const pane_pid = 300;
+    const processes = [node(300, 1, "claude")];
+
+    expect(has_bun_descendant(pane_pid, () => processes)).toBe(false);
+  });
+
+  it("inverse hazard: a live sibling non-discord bun MCP server does not mask a dead discord one", () => {
+    const pane_pid = 100;
+    const processes = [
+      node(200, pane_pid, "/bin/zsh"),
+      node(300, 200, "claude --resume"),
+      node(
+        500,
+        300,
+        "bun run --cwd /Users/beacon/.claude/plugins/cache/claude-plugins-official/imessage/0.1.0 --shell=bun --silent start",
+      ),
+    ];
+
+    expect(has_bun_descendant(pane_pid, () => processes)).toBe(false);
+  });
+
+  it("finds the discord bun descendant regardless of tree traversal order (siblings, multi-level)", () => {
+    const pane_pid = 100;
+    const processes = [
+      node(999, pane_pid, "some-unrelated-sibling"),
+      node(200, pane_pid, "/bin/zsh"),
+      node(250, 200, "some-other-child"),
+      node(300, 200, "claude --resume"),
+      node(400, 300, DISCORD_BUN_CMD),
+    ];
+
+    expect(has_bun_descendant(pane_pid, () => processes)).toBe(true);
+  });
+
+  it("returns false when the process snapshot is empty (ps failed)", () => {
+    expect(has_bun_descendant(100, () => [])).toBe(false);
+  });
+
+  it("does not infinite-loop on cyclical/duplicate ppid data", () => {
+    const pane_pid = 100;
+    // Pathological input: 200's ppid points back to itself.
+    const processes = [node(200, pane_pid, "/bin/zsh"), node(200, 200, "/bin/zsh")];
+
+    expect(() => has_bun_descendant(pane_pid, () => processes)).not.toThrow();
+    expect(has_bun_descendant(pane_pid, () => processes)).toBe(false);
   });
 });
 

--- a/packages/daemon/src/mcp-health.ts
+++ b/packages/daemon/src/mcp-health.ts
@@ -9,8 +9,20 @@
  * connection — `wait_for_bot_ready` already requires "Listening for channel
  * messages" in the pane, and deaf sessions passed that check anyway.
  *
- * Detection is process-level: a healthy session has a `bun` child process
- * (the plugin MCP server) under the pane PID.
+ * Detection is process-level: a healthy session has a `bun` process (the
+ * plugin MCP server) somewhere in the pane PID's descendant tree.
+ *
+ * 2026-07-22 false-positive (#347): the original detector only checked
+ * whether the pane PID had ANY direct child (`pgrep -P`), not specifically a
+ * `bun` descendant. That's correct when the pane PID is `claude` itself
+ * (fresh spawn, the login shell execs into `claude` in place), but when a bot
+ * is respawned inside an EXISTING tmux pane (the resume path after a daemon
+ * restart), the pane PID is the original login shell, `claude` is its child,
+ * and `bun` — if it spawned at all — is a grandchild. A deaf `claude` with no
+ * MCP server still has a child ("claude" itself), so it read healthy. Fix:
+ * `has_bun_descendant` walks the full descendant tree from one `ps` snapshot
+ * and requires finding a `bun` process specifically (further disambiguated
+ * to the discord plugin's `bun`, see `is_discord_mcp_bun_process`).
  *
  * Recovery is ordered:
  *   1. Scripted in-session `/mcp` Reconnect (primary) — driven via tmux
@@ -28,7 +40,7 @@
  * (Reconnect x2 + fallback, still unhealthy) within 30 minutes, give up —
  * stop attempting and let the caller alert. The bot is never released.
  *
- * References: issue #345. Template for pane-driving with guards:
+ * References: issue #345, #347. Template for pane-driving with guards:
  * `rate-limit-recovery.ts` (#270) and `econnreset-recovery.ts` (#337, sibling
  * — a different failure mode, deliberately not merged with this detector).
  */
@@ -91,36 +103,119 @@ export function get_pane_pid(tmux_session: string): number | null {
   }
 }
 
-/** Check whether the pane PID has any child processes (pgrep -P). Returns
- * false on any error — `pgrep` exits non-zero with no output when there are
- * no matching children, which is a legitimate "no MCP server" result, not a
- * tool failure worth distinguishing. */
-export function has_children(pane_pid: number): boolean {
+export interface ProcessNode {
+  pid: number;
+  ppid: number;
+  /** Full command line (argv0 + args), not just the truncated `comm` name —
+   * needed to disambiguate the discord plugin's `bun` process from any other
+   * bun-based MCP server a session might also be running (see
+   * `is_discord_mcp_bun_process`). */
+  command: string;
+}
+
+/**
+ * Snapshot every process on the system as {pid, ppid, command} via a single
+ * `ps` call (spec: "one `ps` snapshot per check, no per-process spawning in
+ * a loop" — `has_bun_descendant` below builds a full parent→children map
+ * from one of these and walks it in memory, rather than shelling out per
+ * process). Returns `[]` on any error — fails closed, same posture as
+ * `get_pane_pid` / `capture_pane`: no process data means "can't confirm a
+ * live MCP connection."
+ */
+export function snapshot_processes(): ProcessNode[] {
   try {
-    const out = execFileSync("pgrep", ["-P", String(pane_pid)], {
+    const out = execFileSync("ps", ["-axo", "pid=,ppid=,command="], {
       encoding: "utf-8",
       timeout: 2000,
     });
-    return out.trim().length > 0;
+    const nodes: ProcessNode[] = [];
+    for (const line of out.split("\n")) {
+      // pid/ppid are whitespace-padded fixed columns; command is the
+      // remainder of the line and may itself contain arbitrary whitespace,
+      // so it's captured greedily rather than split on whitespace.
+      const match = line.match(/^\s*(\d+)\s+(\d+)\s+(.*)$/);
+      if (!match) continue;
+      nodes.push({ pid: Number(match[1]), ppid: Number(match[2]), command: match[3] ?? "" });
+    }
+    return nodes;
   } catch {
-    return false;
+    return [];
   }
 }
 
 /**
+ * True when `command` is the discord plugin's bun MCP server, launched per
+ * the plugin's `.mcp.json` as `bun run --cwd <plugin_root> --shell=bun
+ * --silent start`. Two checks:
+ *   1. The executable's basename is `bun` — matches whether argv0 is a bare
+ *      `bun` (the common case; ps resolves it via PATH lookup at spawn time)
+ *      or a full path.
+ *   2. The command line references a `discord` plugin path — cheap
+ *      disambiguation against other bun-based MCP servers a session might
+ *      also be running (e.g. an imessage plugin) so a live sibling can't
+ *      mask a dead discord server (the "inverse hazard" noted in #347).
+ *      This is a substring match on the plugin install path, not a strict
+ *      argument parse; acceptable here because every known install layout
+ *      (`.claude/plugins/cache/.../discord/...`,
+ *      `shared/claude-config-rengen/plugins/.../discord/...`) contains
+ *      "discord" in the path, confirmed against live process snapshots.
+ */
+export function is_discord_mcp_bun_process(command: string): boolean {
+  const exe = command.trim().split(/\s+/)[0] ?? "";
+  const basename = exe.split("/").pop() ?? "";
+  if (basename !== "bun") return false;
+  return /discord/i.test(command);
+}
+
+/**
+ * Walk the FULL descendant tree of `pane_pid` and return true iff a discord
+ * plugin `bun` process (see `is_discord_mcp_bun_process`) is found anywhere
+ * in it — not just among direct children. This is the fix for #347: when a
+ * bot is respawned inside an existing tmux pane (the resume path), the pane
+ * PID is the original login shell, `claude` is its direct child, and `bun`
+ * is a grandchild — a direct-children-only check (the pre-#347 bug) sees
+ * `claude` and reports healthy even when `claude` is deaf with no MCP server
+ * spawned at all.
+ */
+export function has_bun_descendant(
+  pane_pid: number,
+  processes_fn: () => ProcessNode[] = snapshot_processes,
+): boolean {
+  const processes = processes_fn();
+  const children_of = new Map<number, ProcessNode[]>();
+  for (const p of processes) {
+    const siblings = children_of.get(p.ppid);
+    if (siblings) siblings.push(p);
+    else children_of.set(p.ppid, [p]);
+  }
+
+  const stack = [...(children_of.get(pane_pid) ?? [])];
+  const visited = new Set<number>();
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (!node || visited.has(node.pid)) continue; // guard against cyclical/duplicate ppid data
+    visited.add(node.pid);
+    if (is_discord_mcp_bun_process(node.command)) return true;
+    for (const child of children_of.get(node.pid) ?? []) stack.push(child);
+  }
+  return false;
+}
+
+/**
  * Primary detection signal (spec: process-level, reliable, scriptable).
- * A healthy session has a `bun` child process (the plugin MCP server) under
- * the pane PID. Returns false if the pane can't be read or has no children
- * — both mean "can't confirm a live MCP connection."
+ * A healthy session has a discord-plugin `bun` process (the MCP server)
+ * anywhere in the pane PID's descendant tree — see `has_bun_descendant`.
+ * Returns false if the pane can't be read or no such descendant is found —
+ * both mean "can't confirm a live MCP connection."
  */
 export function has_mcp_child(
   tmux_session: string,
   pane_pid_fn: (session: string) => number | null = get_pane_pid,
-  has_children_fn: (pid: number) => boolean = has_children,
+  has_bun_descendant_fn: (pid: number) => boolean = has_bun_descendant,
 ): boolean {
   const pane_pid = pane_pid_fn(tmux_session);
   if (pane_pid === null) return false;
-  return has_children_fn(pane_pid);
+  return has_bun_descendant_fn(pane_pid);
 }
 
 // ── Corroborating signal (log-dir, diagnosis only — never gates recovery) ──


### PR DESCRIPTION
## Summary

`has_mcp_child()` was the primary MCP-health signal from #345/#346, documented as "a healthy session has a `bun` child process (the plugin MCP server) under the pane PID" — but the implementation only checked whether the pane PID had *any* direct child (`pgrep -P` non-empty), not specifically a `bun` process.

That's harmless for a fresh spawn: the login shell `exec`s into `claude` in place, so the pane PID *is* `claude`'s PID, and a direct child really does mean the MCP server spawned. But on the **resume path** — a bot respawned inside an existing tmux pane after a daemon restart — the pane PID is the original login shell, `claude` is a *forked* child of it, and `bun` (if it spawned at all) is a *grandchild*. A deaf `claude` with no MCP server still counts as "a child" under the old check, so it read healthy. Confirmed live on 2026-07-22: 4 of 5 boot-resumed bots (pool-4, 5, 11, 13) were deaf while both `verify_mcp_post_spawn()` and the periodic `check_mcp_health()` reported them healthy for 15+ minutes.

## Fix

- `snapshot_processes()` — one `ps -axo pid=,ppid=,command=` call, parsed into `{pid, ppid, command}` nodes. Fails closed (`[]`) on any error, same posture as the existing `get_pane_pid`/`capture_pane`.
- `has_bun_descendant(pane_pid, processes_fn)` — builds a parent→children map from a single snapshot and DFS's from the pane PID, returning true only if a matching `bun` process is found anywhere in the descendant tree (any depth, not just direct children). Includes a cycle guard (`visited` set) against pathological/duplicate ppid data.
- `is_discord_mcp_bun_process(command)` — matches on (1) executable basename `bun` and (2) the command line containing `discord`. The discord plugin's `.mcp.json` launches it as `bun run --cwd <plugin_root> --shell=bun --silent start`, and every known install layout (`.claude/plugins/cache/.../discord/...`, `shared/claude-config-rengen/plugins/.../discord/...`) has "discord" in the path — confirmed against live process snapshots on the machine. This also closes the *inverse* hazard: a session running another bun-based MCP server (e.g. an imessage plugin) alongside a dead discord one would otherwise read healthy under plain `bun`-comm matching.
- `has_mcp_child()`, `wait_for_mcp_child()` (default param), and the reconnect driver's `is_healthy` wiring all delegate to `has_bun_descendant()` by default — every caller gets the fix with no call-site changes.
- Removed `has_children()` (the old pgrep-based direct-child check) — it encoded the bug and had no other callers.

**Trade-off called out per the issue:** disambiguating on "discord" in the command line is a substring match, not a strict argument parse. This is acceptable for this codebase (single shared plugin install, path always contains "discord") but would need revisiting if the plugin's launch path convention ever changes.

## Tests

- Regenerated `has_mcp_child` tests around the renamed injectable (`has_bun_descendant_fn`) — same shape, updated semantics.
- New `is_discord_mcp_bun_process` unit tests (real launch command, full-path bun executable, non-discord bun rejection, non-bun rejection, empty input).
- New `has_bun_descendant` tests, including the two regression cases requested in the issue:
  - `pane -> shell -> claude` (no bun) ⇒ unhealthy
  - `pane -> shell -> claude -> bun` (discord) ⇒ healthy
  - plus: fresh-spawn shape (pane PID == claude), the "inverse hazard" (non-discord sibling bun doesn't mask a dead discord one), traversal-order independence, empty snapshot, and cyclical ppid data (no infinite loop).
- Smoke test for `snapshot_processes()` against the real `ps` on the test machine.
- Verified red→green: stashed the source fix, confirmed the 14 new/changed tests fail against the pre-fix code (`has_bun_descendant is not a function` / assertion failures), then restored the fix and confirmed all 54 tests in the file pass.

## Test results

- `pnpm test` (daemon): **69 files / 1242 tests passed**
- `pnpm typecheck` (all 3 workspace packages: shared, daemon, cli): clean
- `npx biome check` on changed files: clean, no fixes needed

Closes #347