### PR TITLE
feat: default opus tier to Claude Opus 5

### DIFF
--- a/packages/daemon/src/__tests__/session.test.ts
+++ b/packages/daemon/src/__tests__/session.test.ts
@@ -31,7 +31,7 @@ describe("build_model_flags", () => {
   it("maps opus/high to correct flags", () => {
     const flags = build_model_flags({ model: "opus", think: "high" });
     expect(flags).toContain("--model");
-    expect(flags).toContain("claude-opus-4-8");
+    expect(flags).toContain("claude-opus-5");
     expect(flags).toContain("--effort");
     expect(flags).toContain("high");
   });
@@ -52,7 +52,7 @@ describe("build_model_flags", () => {
   it("maps opus/xhigh to correct flags", () => {
     const flags = build_model_flags({ model: "opus", think: "xhigh" });
     expect(flags).toContain("--model");
-    expect(flags).toContain("claude-opus-4-8");
+    expect(flags).toContain("claude-opus-5");
     expect(flags).toContain("--effort");
     expect(flags).toContain("xhigh");
   });
@@ -60,7 +60,7 @@ describe("build_model_flags", () => {
   it("maps opus/max to correct flags", () => {
     const flags = build_model_flags({ model: "opus", think: "max" });
     expect(flags).toContain("--model");
-    expect(flags).toContain("claude-opus-4-8");
+    expect(flags).toContain("claude-opus-5");
     expect(flags).toContain("--effort");
     expect(flags).toContain("max");
   });
@@ -100,7 +100,7 @@ describe("ClaudeSessionManager", () => {
       expect(args).toContain("--agent");
       expect(args).toContain("bob"); // default builder name
       expect(args).toContain("--model");
-      expect(args).toContain("claude-opus-4-8");
+      expect(args).toContain("claude-opus-5");
       expect(args).toContain("--permission-mode");
       expect(args).toContain("bypassPermissions");
       expect(args).toContain("--session-id");

--- a/packages/daemon/src/models.ts
+++ b/packages/daemon/src/models.ts
@@ -2,7 +2,7 @@ import type { ModelName, ModelTier, ThinkLevel } from "@lobster-farm/shared";
 
 /** Map abstract model names to Claude CLI model identifiers. */
 const MODEL_IDS: Record<ModelName, string> = {
-  opus: "claude-opus-4-8",
+  opus: "claude-opus-5",
   sonnet: "claude-sonnet-4-6",
   haiku: "claude-haiku-4-5-20251001",
 };


### PR DESCRIPTION
Swaps the `opus` model alias in `packages/daemon/src/models.ts` from `claude-opus-4-8` → `claude-opus-5`.

Opus 5 launched and is enabled on our subscriptions — verified live via a headless `claude --model claude-opus-5 -p` probe on the default account (returned successfully). This flows to **every** agent that resolves the `opus` tier: planner (Gary), designer (Pearl), builder (Bob), operator (Ray), and all pool sessions.

- `sonnet` / `haiku` aliases unchanged.
- Test assertions in `session.test.ts` updated; `build_model_flags` suite passes.
- **Not** in scope: the sonar paper-trade agents pin their model independently and are intentionally left on their current model (mid controlled experiment, rate-limited subscription).

Applying to the running daemon requires a rebuild + restart after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)