### PR TITLE
fix(daemon): never sweep away worktrees holding unpushed or uncommitted work

### DIFF
--- a/packages/daemon/src/__tests__/worktree-cleanup.integration.test.ts
+++ b/packages/daemon/src/__tests__/worktree-cleanup.integration.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Integration coverage for the worktree sweep guard (issue #351).
+ *
+ * Unlike worktree-cleanup.test.ts, nothing here is mocked: these tests drive
+ * real `git` against real temporary repositories. The bug they guard against
+ * was a wrong assumption about what git reports for a never-pushed branch, so
+ * the only test that can actually prove the fix is one that asks git.
+ */
+
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup_after_merge, sweep_stale_worktrees } from "../worktree-cleanup.js";
+
+const exec = promisify(execFile);
+
+async function git(cwd: string, args: string[]): Promise<string> {
+  const { stdout } = await exec("git", args, { cwd, timeout: 30_000 });
+  return stdout;
+}
+
+/** Registry stub exposing a single repo, matching what the sweep consumes. */
+function registry_for(repo_path: string) {
+  return {
+    get_active: () => [
+      {
+        entity: { id: "integration", repos: [{ path: repo_path, url: "file://origin" }] },
+      },
+    ],
+  };
+}
+
+describe("sweep_stale_worktrees (real git)", () => {
+  let root: string;
+  let repo: string;
+  let origin: string;
+
+  beforeEach(async () => {
+    // realpath matters on macOS, where tmpdir() is a symlink into /private and
+    // git always reports the resolved path.
+    root = await realpath(await mkdtemp(join(tmpdir(), "wt-guard-")));
+    origin = join(root, "origin.git");
+    repo = join(root, "repo");
+
+    await git(root, ["init", "--quiet", "--bare", "--initial-branch=main", origin]);
+    await git(root, ["clone", "--quiet", origin, repo]);
+    await git(repo, ["config", "user.email", "test@example.com"]);
+    await git(repo, ["config", "user.name", "Integration Test"]);
+    await writeFile(join(repo, "README.md"), "base\n");
+    await git(repo, ["add", "-A"]);
+    await git(repo, ["commit", "--quiet", "-m", "base"]);
+    await git(repo, ["push", "--quiet", "-u", "origin", "main"]);
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("does not remove a worktree that has commits but was never pushed", async () => {
+    // The exact reported scenario: a builder creates a worktree, commits, and
+    // has not pushed — so refs/remotes/origin/<branch> does not exist and the
+    // pre-fix sweep classified it as "remote gone".
+    const wt = join(root, "wt-unpushed");
+    await git(repo, ["worktree", "add", "--quiet", "-b", "feature/unpushed", wt]);
+    await writeFile(join(wt, "work.ts"), "export const answer = 42;\n");
+    await git(wt, ["add", "-A"]);
+    await git(wt, ["commit", "--quiet", "-m", "20 minutes of work"]);
+
+    // Precondition: this is genuinely the state the old code deleted on.
+    await expect(
+      git(repo, ["rev-parse", "--verify", "refs/remotes/origin/feature/unpushed"]),
+    ).rejects.toThrow();
+
+    await sweep_stale_worktrees(registry_for(repo) as never);
+
+    expect(existsSync(wt)).toBe(true);
+    expect(existsSync(join(wt, "work.ts"))).toBe(true);
+    // The branch must survive too — remove_worktree also deletes the branch.
+    await expect(
+      git(repo, ["rev-parse", "--verify", "refs/heads/feature/unpushed"]),
+    ).resolves.toBeTruthy();
+  });
+
+  it("does not remove a worktree with uncommitted changes", async () => {
+    const wt = join(root, "wt-dirty");
+    // Branch tip is main, so `git branch --merged main` lists it: this
+    // exercises the Case 1 path rather than Case 2.
+    await git(repo, ["worktree", "add", "--quiet", "-b", "feature/dirty", wt]);
+    await writeFile(join(wt, "scratch.md"), "unsaved thinking\n");
+
+    await sweep_stale_worktrees(registry_for(repo) as never);
+
+    expect(existsSync(wt)).toBe(true);
+    expect(existsSync(join(wt, "scratch.md"))).toBe(true);
+  });
+
+  it("does not remove a locked worktree, and does not fail trying", async () => {
+    const wt = join(root, "wt-locked");
+    await git(repo, ["worktree", "add", "--quiet", "-b", "feature/locked", wt]);
+    await git(repo, ["worktree", "lock", wt, "--reason", "agent session running"]);
+
+    const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await sweep_stale_worktrees(registry_for(repo) as never);
+      expect(existsSync(wt)).toBe(true);
+      // The old behaviour was a `Failed to remove worktree` error line.
+      const failures = errors.mock.calls
+        .map((c) => String(c[0]))
+        .filter((line) => line.includes("Failed to remove worktree"));
+      expect(failures).toEqual([]);
+    } finally {
+      errors.mockRestore();
+      await git(repo, ["worktree", "unlock", wt]);
+    }
+  });
+
+  it("still removes a genuinely stale worktree: merged, clean, nothing unpushed", async () => {
+    const wt = join(root, "wt-stale");
+    await git(repo, ["worktree", "add", "--quiet", "-b", "feature/stale", wt]);
+
+    await sweep_stale_worktrees(registry_for(repo) as never);
+
+    expect(existsSync(wt)).toBe(false);
+  });
+
+  it("still removes a worktree whose work was merged into main and remote branch deleted", async () => {
+    const wt = join(root, "wt-merged");
+    await git(repo, ["worktree", "add", "--quiet", "-b", "feature/shipped", wt]);
+    await writeFile(join(wt, "shipped.ts"), "export const shipped = true;\n");
+    await git(wt, ["add", "-A"]);
+    await git(wt, ["commit", "--quiet", "-m", "shipped work"]);
+    await git(wt, ["push", "--quiet", "-u", "origin", "feature/shipped"]);
+
+    // A real merge keeps the branch commits reachable from main.
+    await git(repo, ["merge", "--quiet", "--no-ff", "-m", "merge", "feature/shipped"]);
+    await git(repo, ["push", "--quiet", "origin", "main"]);
+    await git(repo, ["push", "--quiet", "origin", "--delete", "feature/shipped"]);
+
+    await sweep_stale_worktrees(registry_for(repo) as never);
+
+    expect(existsSync(wt)).toBe(false);
+  });
+
+  it("conservatively keeps a squash-merged worktree, whose commits are not in main", async () => {
+    // A squash merge rewrites the work into a new commit, so the branch's own
+    // commits are reachable from nothing on the remote. Offline, that is
+    // indistinguishable from work that was never pushed, and this guard
+    // resolves the ambiguity in favour of keeping the directory.
+    //
+    // The cost is bounded: a leftover directory, cleaned on the next merge
+    // webhook via the unguarded cleanup_after_merge path. The alternative —
+    // guessing "already merged" and being wrong — is the data loss in #351.
+    const wt = join(root, "wt-squashed");
+    await git(repo, ["worktree", "add", "--quiet", "-b", "feature/squashed", wt]);
+    await writeFile(join(wt, "squashed.ts"), "export const squashed = true;\n");
+    await git(wt, ["add", "-A"]);
+    await git(wt, ["commit", "--quiet", "-m", "work"]);
+    await git(wt, ["push", "--quiet", "-u", "origin", "feature/squashed"]);
+
+    await git(repo, ["merge", "--quiet", "--squash", "feature/squashed"]);
+    await git(repo, ["commit", "--quiet", "-m", "squashed work (#1)"]);
+    await git(repo, ["push", "--quiet", "origin", "main"]);
+    await git(repo, ["push", "--quiet", "origin", "--delete", "feature/squashed"]);
+
+    await sweep_stale_worktrees(registry_for(repo) as never);
+
+    expect(existsSync(wt)).toBe(true);
+  });
+
+  it("removes a squash-merged worktree via the unguarded post-merge path", async () => {
+    // The counterpart to the test above: the merge webhook has positive
+    // evidence the PR landed, so it cleans up what the sweep declines to.
+    const wt = join(root, "wt-squashed-merged");
+    await git(repo, ["worktree", "add", "--quiet", "-b", "feature/landed", wt]);
+    await writeFile(join(wt, "landed.ts"), "export const landed = true;\n");
+    await git(wt, ["add", "-A"]);
+    await git(wt, ["commit", "--quiet", "-m", "work"]);
+    await git(wt, ["push", "--quiet", "-u", "origin", "feature/landed"]);
+
+    await git(repo, ["merge", "--quiet", "--squash", "feature/landed"]);
+    await git(repo, ["commit", "--quiet", "-m", "landed work (#2)"]);
+
+    await cleanup_after_merge(repo, "feature/landed");
+
+    expect(existsSync(wt)).toBe(false);
+  });
+});

--- a/packages/daemon/src/__tests__/worktree-cleanup.test.ts
+++ b/packages/daemon/src/__tests__/worktree-cleanup.test.ts
@@ -58,6 +58,8 @@ function make_porcelain(
     head?: string;
     branch?: string;
     bare?: boolean;
+    locked?: boolean;
+    locked_reason?: string;
   }>
 ): string {
   return entries
@@ -66,14 +68,38 @@ function make_porcelain(
       lines.push(`HEAD ${e.head ?? "abc1234567890"}`);
       if (e.branch) lines.push(`branch ${e.branch}`);
       if (e.bare) lines.push("bare");
+      if (e.locked_reason) lines.push(`locked ${e.locked_reason}`);
+      else if (e.locked) lines.push("locked");
       return lines.join("\n");
     })
     .join("\n\n");
 }
 
 /**
+ * State of an individual worktree directory, keyed by path in `trees`.
+ * Drives the git commands the protection guard runs with `cwd: <worktree>`.
+ */
+interface TreeState {
+  /** `git status --porcelain` output. Non-empty means a dirty working tree. */
+  status?: string;
+  /** Upstream ref name, or undefined for "no upstream configured". */
+  upstream?: string;
+  /** Count returned by `git rev-list --count <base>..HEAD`. */
+  unpushed?: number;
+  /** `git rev-parse --show-prefix` output. Non-empty means not a worktree root. */
+  prefix?: string;
+  /** If set, every git command run inside this worktree throws it. */
+  error?: Error;
+  /** If set, only `git status --porcelain` throws it. */
+  status_error?: Error;
+}
+
+/**
  * Configure mock_exec_file to handle specific git commands.
- * Returns a chainable builder for easy test setup.
+ *
+ * Commands are dispatched on the subcommand plus `opts.cwd` — the guard runs
+ * its checks inside the worktree directory, so per-worktree state comes from
+ * `trees[cwd]`. Defaults describe a clean, fully-pushed worktree.
  */
 function setup_git_mocks(
   opts: {
@@ -83,11 +109,19 @@ function setup_git_mocks(
     merged_branches?: string;
     fetch_error?: Error;
     rev_parse_missing?: string[]; // branches whose remote ref is gone
+    /** Refs that resolve for the `origin/main` / `main` base-ref probe. */
+    existing_refs?: string[];
+    /** Per-worktree state, keyed by absolute worktree path. */
+    trees?: Record<string, TreeState>;
   } = {},
 ): void {
-  mock_exec_file.mockImplementation((cmd: string, args: string[], _opts: unknown) => {
+  const existing_refs = opts.existing_refs ?? ["origin/main", "main"];
+
+  mock_exec_file.mockImplementation((cmd: string, args: string[], exec_opts: unknown) => {
     if (cmd !== "git") return "";
 
+    const cwd = (exec_opts as { cwd?: string } | undefined)?.cwd ?? "";
+    const tree = opts.trees?.[cwd];
     const subcmd = args[0];
 
     if (subcmd === "worktree") {
@@ -118,8 +152,40 @@ function setup_git_mocks(
       return "";
     }
 
+    // ── Guard checks: always run with cwd set to the worktree directory ──
+
+    if (subcmd === "status") {
+      if (tree?.error) throw tree.error;
+      if (tree?.status_error) throw tree.status_error;
+      return tree?.status ?? "";
+    }
+
+    if (subcmd === "rev-list") {
+      if (tree?.error) throw tree.error;
+      return `${String(tree?.unpushed ?? 0)}\n`;
+    }
+
     if (subcmd === "rev-parse") {
-      // args: ["rev-parse", "--verify", "refs/remotes/origin/<branch>"]
+      if (args.includes("--show-prefix")) {
+        if (tree?.error) throw tree.error;
+        return tree?.prefix ?? "";
+      }
+
+      if (args.includes("@{u}")) {
+        if (tree?.error) throw tree.error;
+        if (!tree?.upstream) throw new Error("fatal: no upstream configured for branch");
+        return `${tree.upstream}\n`;
+      }
+
+      // Base-ref probe: ["rev-parse", "--verify", "--quiet", "<ref>^{commit}"]
+      if (args[1] === "--verify" && args[2] === "--quiet") {
+        if (tree?.error) throw tree.error;
+        const ref = (args[3] ?? "").replace("^{commit}", "");
+        if (!existing_refs.includes(ref)) throw new Error("exit code 1");
+        return "abc123";
+      }
+
+      // Remote-branch probe: ["rev-parse", "--verify", "refs/remotes/origin/<branch>"]
       const ref = args[2] ?? "";
       const branch = ref.replace("refs/remotes/origin/", "");
       if (opts.rev_parse_missing?.includes(branch)) {
@@ -130,6 +196,32 @@ function setup_git_mocks(
 
     return "";
   });
+}
+
+/** Paths passed to `git worktree remove` across all mock calls. */
+function removed_worktree_paths(): string[] {
+  return mock_exec_file.mock.calls
+    .filter(
+      (c: unknown[]) =>
+        (c[0] as string) === "git" &&
+        (c[1] as string[])[0] === "worktree" &&
+        (c[1] as string[])[1] === "remove",
+    )
+    .map((c: unknown[]) => (c[1] as string[])[2] as string);
+}
+
+/** A registry stub exposing a single repo at `/repo`. */
+function single_repo_registry() {
+  return {
+    get_active: vi.fn().mockReturnValue([
+      {
+        entity: {
+          id: "test-entity",
+          repos: [{ path: "/repo", url: "https://github.com/test/repo.git" }],
+        },
+      },
+    ]),
+  };
 }
 
 // ── Tests ──
@@ -263,7 +355,35 @@ describe("parse_worktree_list", () => {
       head: "abc123",
       branch: "refs/heads/main",
       bare: false,
+      locked: false,
+      locked_reason: null,
     });
+  });
+
+  it("parses a bare `locked` line with no reason", () => {
+    const output = [
+      "worktree /repo/worktrees/held",
+      "HEAD abc123",
+      "branch refs/heads/feature/held",
+      "locked",
+    ].join("\n");
+
+    const entries = parse_worktree_list(output);
+    expect(entries[0]!.locked).toBe(true);
+    expect(entries[0]!.locked_reason).toBeNull();
+  });
+
+  it("parses a `locked <reason>` line and keeps the reason", () => {
+    const output = [
+      "worktree /repo/worktrees/held",
+      "HEAD abc123",
+      "branch refs/heads/feature/held",
+      "locked agent session running",
+    ].join("\n");
+
+    const entries = parse_worktree_list(output);
+    expect(entries[0]!.locked).toBe(true);
+    expect(entries[0]!.locked_reason).toBe("agent session running");
   });
 
   it("parses multiple worktrees including a detached head", () => {
@@ -641,5 +761,341 @@ describe("sweep_stale_worktrees", () => {
     };
 
     await expect(sweep_stale_worktrees(registry as any)).resolves.toBeUndefined();
+  });
+});
+
+// ── Issue #351: the sweep must never delete a worktree that still holds work ──
+
+describe("sweep_stale_worktrees — unpushed/dirty guard", () => {
+  const WT = "/repo/worktrees/active";
+  let log_spy: ReturnType<typeof vi.spyOn>;
+
+  /** Porcelain listing with main plus one feature worktree at `WT`. */
+  function listing(extra?: { locked?: boolean; locked_reason?: string }): string {
+    return make_porcelain(
+      { path: "/repo", branch: "refs/heads/main" },
+      { path: WT, branch: "refs/heads/feature/active", ...extra },
+    );
+  }
+
+  /** All `[worktree-cleanup] Skipping ...` lines emitted during the test. */
+  function skip_logs(): string[] {
+    return log_spy.mock.calls.map((c) => String(c[0])).filter((line) => line.includes("Skipping"));
+  }
+
+  beforeEach(() => {
+    log_spy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  it("does not remove a worktree with uncommitted changes", async () => {
+    setup_git_mocks({
+      worktree_list: listing(),
+      merged_branches: "",
+      rev_parse_missing: ["feature/active"], // remote gone → old code would delete
+      trees: { [WT]: { status: "?? new-file.ts\n M src/index.ts" } },
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(removed_worktree_paths()).not.toContain(WT);
+    expect(skip_logs().join("\n")).toContain("uncommitted changes");
+  });
+
+  it("does not remove a never-pushed worktree holding commits not in main", async () => {
+    // The exact reported bug: builder creates a worktree, commits, has not
+    // pushed yet, so there is no refs/remotes/origin/<branch>.
+    setup_git_mocks({
+      worktree_list: listing(),
+      merged_branches: "",
+      rev_parse_missing: ["feature/active"],
+      trees: { [WT]: { status: "", upstream: undefined, unpushed: 3 } },
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(removed_worktree_paths()).not.toContain(WT);
+    expect(skip_logs().join("\n")).toContain("3 unpushed commit(s)");
+  });
+
+  it("does not remove a merged branch carrying newer unpushed commits", async () => {
+    // Case 1 needs the guard too — `git branch --merged` is a snapshot, and a
+    // commit can land on top of a merged branch at any time.
+    setup_git_mocks({
+      worktree_list: listing(),
+      merged_branches: "  feature/active\n",
+      rev_parse_missing: [],
+      trees: { [WT]: { status: "", upstream: "origin/feature/active", unpushed: 1 } },
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(removed_worktree_paths()).not.toContain(WT);
+    expect(skip_logs().join("\n")).toContain("1 unpushed commit(s)");
+  });
+
+  it("skips a locked worktree without ever attempting removal", async () => {
+    // Previously this produced a `Failed to remove worktree` error line.
+    setup_git_mocks({
+      worktree_list: listing({ locked_reason: "agent session running" }),
+      merged_branches: "  feature/active\n",
+      rev_parse_missing: [],
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(removed_worktree_paths()).toHaveLength(0);
+    expect(skip_logs().join("\n")).toContain("agent session running");
+  });
+
+  it("still removes a genuinely stale worktree: merged, clean, nothing unpushed", async () => {
+    setup_git_mocks({
+      worktree_list: listing(),
+      merged_branches: "  feature/active\n",
+      rev_parse_missing: [],
+      trees: { [WT]: { status: "", upstream: "origin/feature/active", unpushed: 0 } },
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(removed_worktree_paths()).toContain(WT);
+  });
+
+  it("still removes a stale worktree whose remote branch is gone and work is pushed", async () => {
+    setup_git_mocks({
+      worktree_list: listing(),
+      merged_branches: "",
+      rev_parse_missing: ["feature/active"],
+      trees: { [WT]: { status: "", upstream: undefined, unpushed: 0 } },
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(removed_worktree_paths()).toContain(WT);
+  });
+
+  it("prefers the branch upstream over main, so a pushed branch ahead of main is still cleaned", async () => {
+    // Without upstream preference every feature branch looks "ahead of main"
+    // and the sweep would never clean anything again.
+    setup_git_mocks({
+      worktree_list: listing(),
+      merged_branches: "  feature/active\n",
+      rev_parse_missing: [],
+      // Ahead of main, but fully pushed to its own upstream.
+      trees: { [WT]: { status: "", upstream: "origin/feature/active", unpushed: 0 } },
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(removed_worktree_paths()).toContain(WT);
+    // The count must have been taken against the upstream, not main.
+    const rev_list = mock_exec_file.mock.calls.find(
+      (c: unknown[]) => (c[1] as string[])[0] === "rev-list",
+    );
+    expect((rev_list?.[1] as string[])[2]).toBe("origin/feature/active..HEAD");
+  });
+
+  it("skips the worktree when a git check errors (fail-safe)", async () => {
+    setup_git_mocks({
+      worktree_list: listing(),
+      merged_branches: "  feature/active\n",
+      trees: { [WT]: { error: new Error("fatal: unable to read tree") } },
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(removed_worktree_paths()).not.toContain(WT);
+    expect(skip_logs().join("\n")).toContain("check failed");
+  });
+
+  it("skips the worktree when the dirty-tree check times out (fail-safe)", async () => {
+    setup_git_mocks({
+      worktree_list: listing(),
+      merged_branches: "  feature/active\n",
+      trees: { [WT]: { status_error: new Error("Command failed: ETIMEDOUT") } },
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(removed_worktree_paths()).not.toContain(WT);
+    expect(skip_logs().join("\n")).toContain("ETIMEDOUT");
+  });
+
+  it("skips when there is no upstream and no base ref to compare against (fail-safe)", async () => {
+    setup_git_mocks({
+      worktree_list: listing(),
+      merged_branches: "  feature/active\n",
+      existing_refs: [], // neither origin/main nor main resolves
+      trees: { [WT]: { status: "", upstream: undefined } },
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(removed_worktree_paths()).not.toContain(WT);
+    expect(skip_logs().join("\n")).toContain("no upstream");
+  });
+
+  it("skips a path git does not resolve as a worktree root (fail-safe)", async () => {
+    setup_git_mocks({
+      worktree_list: listing(),
+      merged_branches: "  feature/active\n",
+      trees: { [WT]: { prefix: "worktrees/active/\n" } },
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(removed_worktree_paths()).not.toContain(WT);
+    expect(skip_logs().join("\n")).toContain("not a worktree root");
+  });
+
+  it("logs the skip with the worktree path and branch so the sweep is auditable", async () => {
+    setup_git_mocks({
+      worktree_list: listing(),
+      merged_branches: "",
+      rev_parse_missing: ["feature/active"],
+      trees: { [WT]: { status: "?? scratch.md" } },
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    const line = skip_logs()[0] ?? "";
+    expect(line).toContain(WT);
+    expect(line).toContain("feature/active");
+    expect(line).toContain("uncommitted changes");
+  });
+
+  it("still removes a worktree whose directory no longer exists on disk", async () => {
+    // Nothing to lose, and leaving it registered leaks a stale entry forever.
+    setup_git_mocks({
+      worktree_list: listing(),
+      merged_branches: "  feature/active\n",
+    });
+    mock_stat.mockImplementation(async (path: string) => {
+      if (path === WT) throw new Error("ENOENT");
+      return { isDirectory: () => true };
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(removed_worktree_paths()).toContain(WT);
+  });
+
+  it("does not emit a stale-worktree removal log line for a protected worktree", async () => {
+    setup_git_mocks({
+      worktree_list: listing(),
+      merged_branches: "",
+      rev_parse_missing: ["feature/active"],
+      trees: { [WT]: { status: "?? scratch.md" } },
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    const stale_lines = log_spy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((line) => line.includes("Stale worktree"));
+    expect(stale_lines).toHaveLength(0);
+  });
+});
+
+describe("sweep_stale_worktrees — .claude/worktrees/ guard", () => {
+  const CLAUDE_WT = "/repo/.claude/worktrees/agent-done";
+  let log_spy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    log_spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    mock_readdir.mockImplementation(async (dir: string) => {
+      if (dir.includes(".claude/worktrees")) {
+        return [{ name: "agent-done", isDirectory: () => true }];
+      }
+      return [];
+    });
+  });
+
+  it("does not remove a .claude/ worktree with uncommitted changes", async () => {
+    setup_git_mocks({
+      worktree_list: make_porcelain({ path: "/repo", branch: "refs/heads/main" }),
+      merged_branches: "  feature/done\n",
+      trees: { [CLAUDE_WT]: { status: "?? in-progress.ts" } },
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(removed_worktree_paths()).not.toContain(CLAUDE_WT);
+    expect(
+      log_spy.mock.calls
+        .map((c) => String(c[0]))
+        .filter((l) => l.includes("Skipping"))
+        .join("\n"),
+    ).toContain("uncommitted changes");
+  });
+
+  it("does not remove a .claude/ worktree with unpushed commits", async () => {
+    setup_git_mocks({
+      worktree_list: make_porcelain({ path: "/repo", branch: "refs/heads/main" }),
+      merged_branches: "  feature/done\n",
+      trees: { [CLAUDE_WT]: { status: "", upstream: undefined, unpushed: 2 } },
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(removed_worktree_paths()).not.toContain(CLAUDE_WT);
+  });
+
+  it("still removes a clean, fully-pushed .claude/ worktree", async () => {
+    setup_git_mocks({
+      worktree_list: make_porcelain({ path: "/repo", branch: "refs/heads/main" }),
+      merged_branches: "  feature/done\n",
+      trees: { [CLAUDE_WT]: { status: "", upstream: "origin/feature/done", unpushed: 0 } },
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(removed_worktree_paths()).toContain(CLAUDE_WT);
+  });
+
+  it("skips a locked .claude/ worktree instead of failing to remove it", async () => {
+    setup_git_mocks({
+      worktree_list: make_porcelain(
+        { path: "/repo", branch: "refs/heads/main" },
+        {
+          path: CLAUDE_WT,
+          branch: "refs/heads/feature/done",
+          locked_reason: "builder running",
+        },
+      ),
+      // Not merged and remote still present, so the entry loop leaves it alone;
+      // the .claude/ sweep is what must respect the lock.
+      merged_branches: "  feature/done\n",
+      trees: { [CLAUDE_WT]: { status: "", upstream: "origin/feature/done", unpushed: 0 } },
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(removed_worktree_paths()).not.toContain(CLAUDE_WT);
+    expect(
+      log_spy.mock.calls
+        .map((c) => String(c[0]))
+        .filter((l) => l.includes("Skipping"))
+        .join("\n"),
+    ).toContain("builder running");
+  });
+});
+
+describe("cleanup_after_merge — guard does not apply", () => {
+  it("removes the worktree even when dirty and ahead of main", async () => {
+    // A merge event is positive evidence the work landed. Squash merges always
+    // leave the local branch ahead of main, so guarding here would disable
+    // post-merge cleanup entirely.
+    const WT = "/repo/worktrees/merged";
+    setup_git_mocks({
+      worktree_list: make_porcelain(
+        { path: "/repo", branch: "refs/heads/main" },
+        { path: WT, branch: "refs/heads/feature/merged" },
+      ),
+      trees: { [WT]: { status: "?? build-artifact.log", upstream: undefined, unpushed: 4 } },
+    });
+
+    await cleanup_after_merge("/repo", "feature/merged");
+
+    expect(removed_worktree_paths()).toContain(WT);
   });
 });

--- a/packages/daemon/src/worktree-cleanup.ts
+++ b/packages/daemon/src/worktree-cleanup.ts
@@ -6,6 +6,13 @@
  *
  * All functions are designed to fail silently — cleanup should never break
  * the merge handler, PR cron, or daemon lifecycle.
+ *
+ * The periodic sweep decides staleness from branch state alone, which cannot
+ * distinguish an abandoned branch from a live one that has not been pushed
+ * yet. Before removing anything it therefore consults
+ * `worktree_protection_reason`, which refuses to give up a worktree holding
+ * unpushed commits, uncommitted changes, or a lock — and refuses on any check
+ * that errors. See issue #351.
  */
 
 import { execFile, execFileSync } from "node:child_process";
@@ -94,6 +101,10 @@ interface WorktreeEntry {
   branch: string | null;
   /** True if this is the main working tree. */
   bare: boolean;
+  /** True if the worktree is locked (`git worktree lock`). */
+  locked: boolean;
+  /** Reason given at lock time, or null when locked without one / unlocked. */
+  locked_reason: string | null;
 }
 
 /**
@@ -103,6 +114,7 @@ interface WorktreeEntry {
  *   worktree /path/to/tree
  *   HEAD abc123
  *   branch refs/heads/main
+ *   locked optional reason
  *   <blank line>
  */
 export function parse_worktree_list(output: string): WorktreeEntry[] {
@@ -117,6 +129,8 @@ export function parse_worktree_list(output: string): WorktreeEntry[] {
     let head = "";
     let branch: string | null = null;
     let bare = false;
+    let locked = false;
+    let locked_reason: string | null = null;
 
     for (const line of lines) {
       if (line.startsWith("worktree ")) {
@@ -127,15 +141,160 @@ export function parse_worktree_list(output: string): WorktreeEntry[] {
         branch = line.slice("branch ".length);
       } else if (line === "bare") {
         bare = true;
+      } else if (line === "locked") {
+        locked = true;
+      } else if (line.startsWith("locked ")) {
+        locked = true;
+        locked_reason = line.slice("locked ".length).trim() || null;
       }
     }
 
     if (path) {
-      entries.push({ path, head, branch, bare });
+      entries.push({ path, head, branch, bare, locked, locked_reason });
     }
   }
 
   return entries;
+}
+
+// ── Work-in-progress protection (issue #351) ──
+
+/**
+ * Base refs to compare against when a branch has no upstream, in preference
+ * order. Anything on the worktree that is not already in one of these exists
+ * only on this machine.
+ */
+const FALLBACK_BASE_REFS = ["origin/main", "main", "origin/master", "master"];
+
+function err_msg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Return the first ref in `refs` that resolves to a commit, or null if none do.
+ */
+async function first_existing_ref(cwd: string, refs: string[]): Promise<string | null> {
+  for (const ref of refs) {
+    try {
+      await exec("git", ["rev-parse", "--verify", "--quiet", `${ref}^{commit}`], {
+        cwd,
+        timeout: GIT_TIMEOUT_MS,
+      });
+      return ref;
+    } catch {
+      // Ref doesn't exist in this repo — try the next candidate.
+    }
+  }
+  return null;
+}
+
+/**
+ * Describe any commits in the worktree that exist nowhere but this machine,
+ * or null if everything is safely pushed.
+ */
+async function unpushed_commits_reason(worktree_path: string): Promise<string | null> {
+  // The branch's own upstream is the only authoritative answer to "what has
+  // already been pushed?". It is absent for a branch that has never been
+  // pushed — precisely the case this guard exists for — so handle that
+  // explicitly instead of letting `@{u}` throw and be swallowed as "clean".
+  let base: string | null = null;
+  try {
+    const { stdout } = await exec(
+      "git",
+      ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+      { cwd: worktree_path, timeout: GIT_TIMEOUT_MS },
+    );
+    base = stdout.trim() || null;
+  } catch {
+    base = null; // no upstream configured
+  }
+
+  if (base === null) {
+    base = await first_existing_ref(worktree_path, FALLBACK_BASE_REFS);
+    if (base === null) {
+      return "no upstream and no main/master ref to compare against";
+    }
+  }
+
+  try {
+    const { stdout } = await exec("git", ["rev-list", "--count", `${base}..HEAD`], {
+      cwd: worktree_path,
+      timeout: GIT_TIMEOUT_MS,
+    });
+    const count = Number.parseInt(stdout.trim(), 10);
+    if (Number.isNaN(count)) {
+      return `unpushed-commit check returned unparseable output: ${JSON.stringify(stdout.trim())}`;
+    }
+    return count > 0 ? `${String(count)} unpushed commit(s) vs ${base}` : null;
+  } catch (err) {
+    return `unpushed-commit check failed: ${err_msg(err)}`;
+  }
+}
+
+/**
+ * Decide whether a worktree still holds work that must not be destroyed.
+ *
+ * Returns a human-readable reason to skip the worktree, or null when it is
+ * safe to remove.
+ *
+ * Every failure path returns a reason: if we cannot *prove* a worktree is
+ * disposable, we leave it alone. Losing an hour of agent work is far more
+ * expensive than leaking a directory until the next sweep.
+ *
+ * @param locks - Lock reason by worktree path, from `git worktree list`.
+ *                Presence of the path means the worktree is locked.
+ */
+async function worktree_protection_reason(
+  worktree_path: string,
+  locks: Map<string, string | null>,
+): Promise<string | null> {
+  // A lock is an explicit "do not touch" from whoever created the worktree.
+  // Detecting it here turns what used to be a `git worktree remove` failure
+  // into a logged skip, so genuine removal errors stay visible.
+  if (locks.has(worktree_path)) {
+    const reason = locks.get(worktree_path);
+    return reason ? `worktree is locked (${reason})` : "worktree is locked";
+  }
+
+  // A directory that is already gone holds nothing worth saving, and leaving
+  // it registered leaks a stale entry forever.
+  try {
+    await stat(worktree_path);
+  } catch {
+    return null;
+  }
+
+  // Confirm git resolves this path as a worktree root. A non-empty prefix
+  // means the checks below would read some parent repo's state and draw
+  // conclusions about the wrong tree.
+  try {
+    const { stdout } = await exec("git", ["rev-parse", "--show-prefix"], {
+      cwd: worktree_path,
+      timeout: GIT_TIMEOUT_MS,
+    });
+    const prefix = stdout.trim();
+    if (prefix !== "") {
+      return `not a worktree root (git resolves it to the subdirectory ${prefix})`;
+    }
+  } catch (err) {
+    return `worktree root check failed: ${err_msg(err)}`;
+  }
+
+  // Uncommitted changes are the most unrecoverable thing on disk.
+  try {
+    const { stdout } = await exec("git", ["status", "--porcelain"], {
+      cwd: worktree_path,
+      timeout: GIT_TIMEOUT_MS,
+    });
+    const changed = stdout.trim();
+    if (changed !== "") {
+      return `uncommitted changes (${String(changed.split("\n").length)} path(s))`;
+    }
+  } catch (err) {
+    return `dirty-tree check failed: ${err_msg(err)}`;
+  }
+
+  return await unpushed_commits_reason(worktree_path);
 }
 
 /**
@@ -291,8 +450,20 @@ export async function cleanup_after_merge(repo_path: string, branch: string): Pr
  * Scan .claude/worktrees/ in the repo for directories that reference the
  * given branch. Agent-created worktrees follow the pattern of branch slug
  * as directory name (e.g., .claude/worktrees/agent-feature-134-auto-cleanup).
+ *
+ * @param sweep_locks - Supplied only by the periodic sweep. Its presence turns
+ *   on the work-in-progress guard, using the map for worktree lock state.
+ *
+ *   The post-merge path deliberately omits it: a merge event is positive
+ *   evidence the work landed, whereas the sweep is only guessing. A squash
+ *   merge also always leaves the local branch ahead of main, so guarding the
+ *   post-merge path would disable it entirely.
  */
-async function cleanup_claude_worktrees(repo_path: string, branch: string): Promise<void> {
+async function cleanup_claude_worktrees(
+  repo_path: string,
+  branch: string,
+  sweep_locks?: Map<string, string | null>,
+): Promise<void> {
   const claude_wt_dir = join(repo_path, ".claude", "worktrees");
 
   try {
@@ -314,6 +485,15 @@ async function cleanup_claude_worktrees(repo_path: string, branch: string): Prom
       // Match directories that contain the branch slug
       if (entry.name.includes(branch_slug)) {
         const wt_path = join(claude_wt_dir, entry.name);
+
+        if (sweep_locks) {
+          const protection = await worktree_protection_reason(wt_path, sweep_locks);
+          if (protection !== null) {
+            console.log(`[worktree-cleanup] Skipping ${wt_path} [${branch}]: ${protection}`);
+            continue;
+          }
+        }
+
         console.log(`[worktree-cleanup] Found .claude/worktrees/ match: ${wt_path}`);
         // Relocate any sessions whose cwd is inside this worktree before removal
         const relocated = relocate_sessions_from_path(wt_path, repo_path);
@@ -411,6 +591,13 @@ async function sweep_repo(repo_path: string): Promise<number> {
     return 0;
   }
 
+  // Lock state by worktree path, so a locked tree becomes an explicit skip
+  // rather than a `git worktree remove --force` failure.
+  const locks = new Map<string, string | null>();
+  for (const entry of entries) {
+    if (entry.locked) locks.set(entry.path, entry.locked_reason);
+  }
+
   let cleaned = 0;
 
   for (const entry of entries) {
@@ -425,38 +612,48 @@ async function sweep_repo(repo_path: string): Promise<number> {
     // Check if this is the main working tree (same path as repo_path)
     if (entry.path === repo_path) continue;
 
-    let should_clean = false;
+    let stale_reason: string | null = null;
 
     // Case 1: Branch is merged into main
     if (merged_branches.has(branch)) {
-      console.log(`[worktree-cleanup] Stale worktree (branch merged): ${entry.path} [${branch}]`);
-      should_clean = true;
+      stale_reason = "branch merged";
     }
 
     // Case 2: Remote tracking ref is gone (branch deleted on remote)
-    if (!should_clean) {
-      should_clean = await is_remote_branch_gone(repo_path, branch);
-      if (should_clean) {
-        console.log(`[worktree-cleanup] Stale worktree (remote gone): ${entry.path} [${branch}]`);
-      }
+    if (stale_reason === null && (await is_remote_branch_gone(repo_path, branch))) {
+      stale_reason = "remote gone";
     }
 
-    if (should_clean) {
-      // Relocate any sessions whose cwd is inside this worktree before removal
-      const relocated = relocate_sessions_from_path(entry.path, repo_path);
-      if (relocated > 0) {
-        console.log(
-          `[worktree-cleanup] Relocated ${String(relocated)} session(s) from ${entry.path}`,
-        );
-      }
-      const removed = await remove_worktree(repo_path, entry.path, branch);
-      if (removed) cleaned++;
+    if (stale_reason === null) continue;
+
+    // Both cases above are heuristics about whether the *work* is finished.
+    // Neither is evidence that the *worktree* is empty: a merged branch can
+    // pick up new commits at any time, and "no remote ref" is also the normal
+    // state of a branch that has simply never been pushed. Check the disk
+    // before destroying anything.
+    const protection = await worktree_protection_reason(entry.path, locks);
+    if (protection !== null) {
+      console.log(`[worktree-cleanup] Skipping ${entry.path} [${branch}]: ${protection}`);
+      continue;
     }
+
+    console.log(`[worktree-cleanup] Stale worktree (${stale_reason}): ${entry.path} [${branch}]`);
+
+    // Relocate any sessions whose cwd is inside this worktree before removal
+    const relocated = relocate_sessions_from_path(entry.path, repo_path);
+    if (relocated > 0) {
+      console.log(
+        `[worktree-cleanup] Relocated ${String(relocated)} session(s) from ${entry.path}`,
+      );
+    }
+    const removed = await remove_worktree(repo_path, entry.path, branch);
+    if (removed) cleaned++;
   }
 
-  // Also sweep .claude/worktrees/ for agent directories referencing merged branches
+  // Also sweep .claude/worktrees/ for agent directories referencing merged
+  // branches. Guarded, for the same reason the loop above is.
   for (const branch of merged_branches) {
-    await cleanup_claude_worktrees(repo_path, branch);
+    await cleanup_claude_worktrees(repo_path, branch, locks);
   }
 
   return cleaned;


### PR DESCRIPTION
## Summary

The hourly worktree sweep treated "no `refs/remotes/origin/<branch>`" as "abandoned". That is also the normal state of a freshly created, never-pushed builder worktree, so the sweep force-removed active agent work mid-session — 3,641 removals machine-wide, four confirmed data-loss occurrences in one entity.

Both removal paths in `sweep_repo()` now consult `worktree_protection_reason()` before touching anything. It returns a reason to skip, or `null` when the worktree is provably disposable.

## What protects a worktree

| Signal | Detection |
|---|---|
| Locked | `locked` field from `git worktree list --porcelain`, parsed up-front |
| Uncommitted changes | `git status --porcelain` in the worktree dir |
| Unpushed commits | `git rev-list --count <base>..HEAD`, where `<base>` is the branch's own upstream, falling back to `origin/main` / `main` / `origin/master` / `master` when there is none |
| Any check errors or times out | Fail safe — protected, with the error in the log |

Every skip is logged with an explicit reason, so the sweep is auditable rather than trusted:

```
[worktree-cleanup] Skipping /path/wt-unpushed [feature/unpushed]: 1 unpushed commit(s) vs origin/main
[worktree-cleanup] Skipping /path/wt-dirty [feature/dirty]: uncommitted changes (1 path(s))
[worktree-cleanup] Skipping /path/wt-locked [feature/locked]: worktree is locked (agent session running)
```

The `Stale worktree (...)` line now only fires for worktrees that are actually removed, so that log line means what the issue's metrics assumed it meant.

## Notes for the reviewer

**Locked trees.** Detected from porcelain rather than by attempting removal and catching failure. The 3,846 `Failed to remove worktree` errors were the sweep repeatedly trying to delete locked active work; those become logged skips, so genuine removal errors stay visible instead of drowning.

**`@{u}` with no upstream is handled explicitly** rather than being allowed to throw and get swallowed into "clean" — that swallow is the shape of the original bug.

**Two deliberate decisions worth a look:**

1. **The post-merge path (`cleanup_after_merge`) is intentionally *not* guarded.** A merge event is positive evidence the work landed, whereas the sweep is only guessing. A squash merge also always leaves the local branch ahead of `main`, so guarding there would disable post-merge cleanup entirely. The guard is opt-in via a parameter on `cleanup_claude_worktrees`, passed only by the sweep.

2. **A squash-merged branch whose remote ref was deleted is conservatively kept by the sweep.** Its commits are reachable from nothing on the remote, which offline is indistinguishable from work that was never pushed. The cost is bounded — a leftover directory, cleaned by the merge webhook via the unguarded path above. Both halves are pinned by tests. Erring the other way is exactly the data loss in #351.

**Worktrees whose directory no longer exists are still cleaned**, so a stale registration does not leak forever.

## Verification

- `pnpm run build` — exit 0; `pnpm run typecheck` — exit 0
- `pnpm run test` — **70 files, 1270 tests passing**
- 21 new unit tests, plus 7 **real-git integration tests** (`worktree-cleanup.integration.test.ts`) that drive the sweep against real temporary repositories rather than mocks — the bug was a wrong assumption about what git reports, so a mock could not have caught it.
- **Red-green verified:** with `worktree_protection_reason` stubbed to `return null`, the 4 protection tests fail (the reported bug reproduces — the never-pushed worktree is deleted) while the 3 "still cleans" tests keep passing, confirming they are not vacuous.

Acceptance criteria from the issue, end to end: create a worktree, commit without pushing, run the sweep, confirm it survives — covered by `does not remove a worktree that has commits but was never pushed`, which also asserts the branch itself survives.

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)