### PR TITLE
feat(daemon): alert when a session's context crosses 200k/500k/800k tokens

### DIFF
--- a/packages/daemon/src/README.md
+++ b/packages/daemon/src/README.md
@@ -18,7 +18,8 @@ The LobsterFarm daemon process. Manages entities, spawns Claude Code agent sessi
 - `review-utils.ts` -- Utility functions for PR review feedback: fetch review comments from GitHub and build fix prompts for the auto-fix loop.
 - `hooks.ts` -- Post-session hooks. Extracts session learnings via Haiku and appends them to daily logs. Also manages the global learnings file.
 - `models.ts` -- Maps abstract model tiers (opus/sonnet/haiku + think level) to Claude CLI flags.
-- `persistence.ts` -- JSON file persistence for PR review state and pool state. Saves to and loads from `~/.lobsterfarm/state/`.
+- `persistence.ts` -- JSON file persistence for PR review state, pool state, PR watches, deploy triage, and context alert state. Saves to and loads from `~/.lobsterfarm/state/`.
+- `context-alerts.ts` -- Periodic context-size sweep. Every 15 min, reads each assigned pool session's context via `/context` and alerts when it crosses 200k/500k/800k tokens. Fires once per breach with hysteresis (re-arms when usage drops below a threshold, so a session that regrows after `/compact` alerts again). Dedupe state is keyed by `session_id` and persisted to `state/context-alerts.json`.
 - `pid.ts` -- PID file management. Write, read, remove, and check if the daemon is already running.
 - `pr-cron.ts` -- `PRReviewCron`. Polls entity repos for open PRs, spawns headless reviewer sessions, and routes outcomes (approve/merge, fix, escalate).
 - `auth-watchdog.ts` -- `AuthWatchdog`. Per shared Claude credential (config dir), runs a periodic fresh-process canary probe + best-effort keychain expiry check. On a logged-out/invalid-grant credential it quarantines poisoned session transcripts, generates a re-login URL, and alerts the owner in the configured channel; the owner pastes the OAuth code back (owner-only security boundary), which completes the login and recycles the affected pool bots. Network/rate failures are never treated as auth incidents.

--- a/packages/daemon/src/__tests__/context-alerts.test.ts
+++ b/packages/daemon/src/__tests__/context-alerts.test.ts
@@ -1,0 +1,534 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { LobsterFarmConfig } from "@lobster-farm/shared";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AlertPayload } from "../alert-router.js";
+import {
+  CONTEXT_ALERT_STATE_TTL_MS,
+  CONTEXT_ALERT_THRESHOLDS,
+  CONTEXT_SWEEP_INTERVAL_MS,
+  type ContextSweepBot,
+  type ContextSweepDeps,
+  context_bots_from_pool,
+  evaluate_thresholds,
+  sweep_context_thresholds,
+} from "../context-alerts.js";
+import { load_context_alerts, save_context_alerts } from "../persistence.js";
+import type { ContextAlertState } from "../persistence.js";
+import type { PoolBot } from "../pool.js";
+import type { ContextUsage } from "../tmux-query.js";
+
+// ── Helpers ──
+
+const T200 = 200_000;
+const T500 = 500_000;
+const T800 = 800_000;
+
+function make_config(lf_dir: string): LobsterFarmConfig {
+  return {
+    paths: { lobsterfarm_dir: lf_dir, projects_dir: "/tmp", claude_dir: "/tmp" },
+  } as LobsterFarmConfig;
+}
+
+/** Build a ContextUsage as `query_context_usage` would return it. */
+function usage(used_tokens: number): ContextUsage {
+  const total = 1_000_000;
+  const percent = Math.round((used_tokens / total) * 1000) / 10;
+  return {
+    summary: `${String(Math.round(used_tokens / 1000))}k / 1m (${String(percent)}%)`,
+    used_tokens,
+    total_tokens: total,
+    percent,
+  };
+}
+
+function make_bot(overrides: Partial<ContextSweepBot> = {}): ContextSweepBot {
+  return {
+    bot_id: 3,
+    session_id: "session-aaa",
+    entity_id: "acme",
+    channel_id: "chan-1",
+    tmux_session: "pool-3",
+    ...overrides,
+  };
+}
+
+/**
+ * A test harness that drives `sweep_context_thresholds` over a scripted
+ * sequence of readings, capturing every alert that was posted.
+ *
+ * `state_store` is a mutable in-memory stand-in for the on-disk state file, so
+ * a "restart" can be simulated by building a fresh harness over the same store.
+ */
+interface Harness {
+  deps: ContextSweepDeps;
+  alerts: AlertPayload[];
+  /** Set the reading that the next sweep will observe for a tmux session. */
+  set_reading(tmux_session: string, reading: ContextUsage | null | Error): void;
+  set_bots(bots: ContextSweepBot[]): void;
+  sweep(): Promise<void>;
+}
+
+function make_harness(options: {
+  bots?: ContextSweepBot[];
+  state?: { current: ContextAlertState };
+  now?: () => Date;
+}): Harness {
+  const alerts: AlertPayload[] = [];
+  const readings = new Map<string, ContextUsage | null | Error>();
+  const store = options.state ?? { current: {} };
+  let bots = options.bots ?? [make_bot()];
+
+  const deps: ContextSweepDeps = {
+    list_bots: () => bots,
+    query_usage: (tmux_session: string) => {
+      const reading = readings.get(tmux_session);
+      if (reading instanceof Error) return Promise.reject(reading);
+      return Promise.resolve(reading ?? null);
+    },
+    post_alert: (payload: AlertPayload) => {
+      alerts.push(payload);
+      return Promise.resolve({ message_id: null });
+    },
+    load_state: () => Promise.resolve(structuredClone(store.current)),
+    save_state: (next: ContextAlertState) => {
+      store.current = structuredClone(next);
+      return Promise.resolve();
+    },
+    now: options.now,
+  };
+
+  return {
+    deps,
+    alerts,
+    set_reading: (tmux_session, reading) => readings.set(tmux_session, reading),
+    set_bots: (next) => {
+      bots = next;
+    },
+    sweep: () => sweep_context_thresholds(deps),
+  };
+}
+
+/** Sweep once with a single bot reporting `used` tokens. */
+async function sweep_at(h: Harness, used: number, tmux_session = "pool-3"): Promise<void> {
+  h.set_reading(tmux_session, usage(used));
+  await h.sweep();
+}
+
+// ── Thresholds constant ──
+
+describe("CONTEXT_ALERT_THRESHOLDS", () => {
+  it("declares 200k / 500k / 800k in ascending order", () => {
+    expect(CONTEXT_ALERT_THRESHOLDS.map((t) => t.tokens)).toEqual([T200, T500, T800]);
+  });
+
+  it("gives every threshold a human label and an alert tier", () => {
+    for (const t of CONTEXT_ALERT_THRESHOLDS) {
+      expect(t.label).toBeTruthy();
+      expect(t.tier).toBeTruthy();
+    }
+  });
+
+  it("sweeps every 15 minutes", () => {
+    expect(CONTEXT_SWEEP_INTERVAL_MS).toBe(15 * 60 * 1000);
+  });
+});
+
+// ── evaluate_thresholds (pure hysteresis core) ──
+
+describe("evaluate_thresholds", () => {
+  it("reports no crossing below the lowest threshold", () => {
+    const result = evaluate_thresholds(199_999, []);
+    expect(result.crossed).toEqual([]);
+    expect(result.fired).toEqual([]);
+  });
+
+  it("fires on the upward crossing of a threshold", () => {
+    const result = evaluate_thresholds(T200, []);
+    expect(result.crossed.map((t) => t.tokens)).toEqual([T200]);
+    expect(result.fired).toEqual([T200]);
+  });
+
+  it("does not re-fire a threshold that is still breached", () => {
+    const result = evaluate_thresholds(350_000, [T200]);
+    expect(result.crossed).toEqual([]);
+    expect(result.fired).toEqual([T200]);
+  });
+
+  it("re-arms a threshold once usage drops back below it", () => {
+    const result = evaluate_thresholds(150_000, [T200]);
+    expect(result.crossed).toEqual([]);
+    expect(result.fired).toEqual([]);
+  });
+
+  it("fires again after a re-arm", () => {
+    const rearmed = evaluate_thresholds(150_000, [T200]);
+    const recrossed = evaluate_thresholds(210_000, rearmed.fired);
+    expect(recrossed.crossed.map((t) => t.tokens)).toEqual([T200]);
+  });
+
+  it("reports every threshold crossed when usage jumps past several at once", () => {
+    const result = evaluate_thresholds(600_000, []);
+    expect(result.crossed.map((t) => t.tokens)).toEqual([T200, T500]);
+    expect(result.fired).toEqual([T200, T500]);
+  });
+
+  it("re-arms only the thresholds usage actually fell below", () => {
+    const result = evaluate_thresholds(300_000, [T200, T500]);
+    expect(result.crossed).toEqual([]);
+    expect(result.fired).toEqual([T200]);
+  });
+
+  it("treats an exact threshold value as a breach", () => {
+    expect(evaluate_thresholds(T800, [T200, T500]).crossed.map((t) => t.tokens)).toEqual([T800]);
+  });
+});
+
+// ── Sweep: fire-once-per-breach ──
+
+describe("sweep_context_thresholds — once per breach", () => {
+  it("alerts exactly once for each threshold as usage climbs", async () => {
+    const h = make_harness({});
+
+    await sweep_at(h, 100_000);
+    expect(h.alerts).toHaveLength(0);
+
+    await sweep_at(h, 250_000);
+    expect(h.alerts).toHaveLength(1);
+    expect(h.alerts[0]?.body).toContain("200k");
+
+    await sweep_at(h, 550_000);
+    expect(h.alerts).toHaveLength(2);
+    expect(h.alerts[1]?.body).toContain("500k");
+
+    await sweep_at(h, 850_000);
+    expect(h.alerts).toHaveLength(3);
+    expect(h.alerts[2]?.body).toContain("800k");
+  });
+
+  it("does not re-alert while a session stays above a threshold", async () => {
+    const h = make_harness({});
+
+    await sweep_at(h, 250_000);
+    expect(h.alerts).toHaveLength(1);
+
+    // Ten more sweeps, all still above 200k but below 500k.
+    for (const used of [260_000, 300_000, 310_000, 400_000, 490_000, 499_999, 250_000, 260_000]) {
+      await sweep_at(h, used);
+    }
+    expect(h.alerts).toHaveLength(1);
+  });
+
+  it("posts a single alert naming the highest threshold when several cross at once", async () => {
+    const h = make_harness({});
+
+    await sweep_at(h, 600_000);
+    expect(h.alerts).toHaveLength(1);
+    expect(h.alerts[0]?.body).toContain("500k");
+
+    // 200k was consumed by the same jump — it must not fire later on the way up.
+    await sweep_at(h, 700_000);
+    expect(h.alerts).toHaveLength(1);
+  });
+});
+
+// ── Sweep: re-arm on the way down ──
+
+describe("sweep_context_thresholds — re-arming", () => {
+  it("re-alerts after a compaction drops usage below the threshold", async () => {
+    const h = make_harness({});
+
+    await sweep_at(h, 250_000);
+    expect(h.alerts).toHaveLength(1);
+
+    // /compact
+    await sweep_at(h, 40_000);
+    expect(h.alerts).toHaveLength(1);
+
+    // regrowth back over 200k
+    await sweep_at(h, 210_000);
+    expect(h.alerts).toHaveLength(2);
+    expect(h.alerts[1]?.body).toContain("200k");
+  });
+
+  it("re-arms higher thresholds independently", async () => {
+    const h = make_harness({});
+
+    await sweep_at(h, 850_000); // crosses all three, alerts on 800k
+    expect(h.alerts).toHaveLength(1);
+
+    await sweep_at(h, 600_000); // 800k re-armed, 500k/200k still fired
+    expect(h.alerts).toHaveLength(1);
+
+    await sweep_at(h, 810_000); // 800k crosses again
+    expect(h.alerts).toHaveLength(2);
+    expect(h.alerts[1]?.body).toContain("800k");
+  });
+});
+
+// ── Sweep: session identity ──
+
+describe("sweep_context_thresholds — session identity", () => {
+  it("starts a recycled session with every threshold armed", async () => {
+    const h = make_harness({ bots: [make_bot({ session_id: "session-old" })] });
+
+    await sweep_at(h, 850_000);
+    expect(h.alerts).toHaveLength(1);
+
+    // Same bot, same channel, brand-new session after a recycle.
+    h.set_bots([make_bot({ session_id: "session-new" })]);
+    await sweep_at(h, 250_000);
+    expect(h.alerts).toHaveLength(2);
+    expect(h.alerts[1]?.body).toContain("200k");
+
+    await sweep_at(h, 550_000);
+    expect(h.alerts).toHaveLength(3);
+    expect(h.alerts[2]?.body).toContain("500k");
+  });
+
+  it("tracks sessions independently of one another", async () => {
+    const h = make_harness({
+      bots: [
+        make_bot({ bot_id: 1, session_id: "s1", tmux_session: "pool-1", channel_id: "c1" }),
+        make_bot({ bot_id: 2, session_id: "s2", tmux_session: "pool-2", channel_id: "c2" }),
+      ],
+    });
+
+    h.set_reading("pool-1", usage(250_000));
+    h.set_reading("pool-2", usage(10_000));
+    await h.sweep();
+    expect(h.alerts).toHaveLength(1);
+    expect(h.alerts[0]?.body).toContain("c1");
+
+    h.set_reading("pool-2", usage(250_000));
+    await h.sweep();
+    expect(h.alerts).toHaveLength(2);
+    expect(h.alerts[1]?.body).toContain("c2");
+  });
+
+  it("skips bots that have no session id yet", async () => {
+    const h = make_harness({ bots: [make_bot({ session_id: null as unknown as string })] });
+    await sweep_at(h, 900_000);
+    expect(h.alerts).toHaveLength(0);
+  });
+});
+
+// ── Sweep: restart durability ──
+
+describe("sweep_context_thresholds — restart durability", () => {
+  let tmp_dir: string;
+
+  beforeEach(async () => {
+    tmp_dir = await mkdtemp(join(tmpdir(), "lf-ctx-alerts-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmp_dir, { recursive: true, force: true });
+  });
+
+  it("does not re-fire thresholds after a daemon restart", async () => {
+    const config = make_config(tmp_dir);
+    const bots = [make_bot()];
+
+    const build = (): Harness => {
+      const alerts: AlertPayload[] = [];
+      const deps: ContextSweepDeps = {
+        list_bots: () => bots,
+        query_usage: () => Promise.resolve(usage(620_000)),
+        post_alert: (payload) => {
+          alerts.push(payload);
+          return Promise.resolve({ message_id: null });
+        },
+        load_state: () => load_context_alerts(config),
+        save_state: (state) => save_context_alerts(state, config),
+      };
+      return {
+        deps,
+        alerts,
+        set_reading: () => undefined,
+        set_bots: () => undefined,
+        sweep: () => sweep_context_thresholds(deps),
+      };
+    };
+
+    const before = build();
+    await before.sweep();
+    expect(before.alerts).toHaveLength(1);
+
+    // State must be on disk, not just in memory.
+    const persisted = await load_context_alerts(config);
+    expect(persisted["session-aaa"]?.fired).toEqual([T200, T500]);
+
+    // Simulated restart: brand-new deps, same state file.
+    const after = build();
+    await after.sweep();
+    await after.sweep();
+    expect(after.alerts).toHaveLength(0);
+  });
+
+  it("forgets sessions that have not been seen for longer than the TTL", async () => {
+    const store = { current: {} as ContextAlertState };
+    const stale = new Date(Date.now() - CONTEXT_ALERT_STATE_TTL_MS - 60_000).toISOString();
+    store.current = {
+      "session-gone": { fired: [T200, T500], last_used_tokens: 600_000, last_seen_at: stale },
+      "session-aaa": { fired: [T200], last_used_tokens: 250_000, last_seen_at: stale },
+    };
+
+    const h = make_harness({ state: store });
+    await sweep_at(h, 250_000);
+
+    // The absent session is pruned; the live one is refreshed, not pruned,
+    // and its still-breached threshold does not re-fire.
+    expect(Object.keys(store.current)).toEqual(["session-aaa"]);
+    expect(h.alerts).toHaveLength(0);
+  });
+});
+
+// ── Sweep: unreadable context ──
+
+describe("sweep_context_thresholds — unreadable context", () => {
+  it("skips a session whose context cannot be read", async () => {
+    const h = make_harness({});
+    h.set_reading("pool-3", null);
+    await expect(h.sweep()).resolves.toBeUndefined();
+    expect(h.alerts).toHaveLength(0);
+  });
+
+  it("skips a session whose query throws", async () => {
+    const h = make_harness({});
+    h.set_reading("pool-3", new Error("no server running on /tmp/tmux-501/default"));
+    await expect(h.sweep()).resolves.toBeUndefined();
+    expect(h.alerts).toHaveLength(0);
+  });
+
+  it("skips a reading with an unparseable token count", async () => {
+    const h = make_harness({});
+    h.set_reading("pool-3", {
+      summary: "??",
+      used_tokens: null,
+      total_tokens: null,
+      percent: null,
+    });
+    await h.sweep();
+    expect(h.alerts).toHaveLength(0);
+  });
+
+  it("preserves dedupe state for a session that becomes unreadable", async () => {
+    const store = { current: {} as ContextAlertState };
+    const h = make_harness({ state: store });
+
+    await sweep_at(h, 250_000);
+    expect(h.alerts).toHaveLength(1);
+
+    h.set_reading("pool-3", null);
+    await h.sweep();
+    expect(store.current["session-aaa"]?.fired).toEqual([T200]);
+
+    // Still breached when readable again — must not re-alert.
+    await sweep_at(h, 260_000);
+    expect(h.alerts).toHaveLength(1);
+  });
+
+  it("keeps sweeping other bots after one of them fails", async () => {
+    const h = make_harness({
+      bots: [
+        make_bot({ bot_id: 1, session_id: "s1", tmux_session: "pool-1", channel_id: "c1" }),
+        make_bot({ bot_id: 2, session_id: "s2", tmux_session: "pool-2", channel_id: "c2" }),
+      ],
+    });
+
+    h.set_reading("pool-1", new Error("tmux gone"));
+    h.set_reading("pool-2", usage(250_000));
+    await h.sweep();
+
+    expect(h.alerts).toHaveLength(1);
+    expect(h.alerts[0]?.body).toContain("c2");
+  });
+
+  it("still persists state when posting the alert fails", async () => {
+    const store = { current: {} as ContextAlertState };
+    const h = make_harness({ state: store });
+    h.deps.post_alert = () => Promise.reject(new Error("discord down"));
+
+    await sweep_at(h, 250_000);
+    expect(store.current["session-aaa"]?.fired).toEqual([T200]);
+  });
+});
+
+// ── Alert content ──
+
+describe("context alert content", () => {
+  it("carries entity, channel, usage, session id and a suggested action", async () => {
+    const h = make_harness({});
+    await sweep_at(h, 520_000);
+
+    const alert = h.alerts[0];
+    expect(alert).toBeDefined();
+    expect(alert?.entity_id).toBe("acme");
+    expect(alert?.body).toContain("chan-1");
+    expect(alert?.body).toContain("520k / 1m");
+    expect(alert?.body).toContain("500k");
+    expect(alert?.body).toContain("session-aaa");
+    expect(alert?.body).toContain("/compact");
+  });
+
+  it("uses the tier declared on the threshold that fired", async () => {
+    const h = make_harness({});
+    const tier_of = (tokens: number) =>
+      CONTEXT_ALERT_THRESHOLDS.find((t) => t.tokens === tokens)?.tier;
+
+    await sweep_at(h, 250_000);
+    expect(h.alerts[0]?.tier).toBe(tier_of(T200));
+
+    await sweep_at(h, 850_000);
+    expect(h.alerts[1]?.tier).toBe(tier_of(T800));
+  });
+});
+
+// ── Pool adapter ──
+
+describe("context_bots_from_pool", () => {
+  function pool_bot(overrides: Partial<PoolBot> = {}): PoolBot {
+    return {
+      id: 4,
+      state: "assigned",
+      channel_id: "chan-9",
+      entity_id: "acme",
+      archetype: "builder",
+      channel_type: "work_room",
+      session_id: "sess-9",
+      session_confirmed: true,
+      tmux_session: "pool-4",
+      last_active: null,
+      assigned_at: null,
+      state_dir: "/tmp",
+      model: null,
+      effort: null,
+      last_avatar_archetype: null,
+      last_avatar_set_at: null,
+      ...overrides,
+    } as PoolBot;
+  }
+
+  it("maps assigned bots that have a session", () => {
+    expect(context_bots_from_pool([pool_bot()])).toEqual([
+      {
+        bot_id: 4,
+        session_id: "sess-9",
+        entity_id: "acme",
+        channel_id: "chan-9",
+        tmux_session: "pool-4",
+      },
+    ]);
+  });
+
+  it("drops bots with no session, entity, or channel", () => {
+    const bots = [
+      pool_bot({ session_id: null }),
+      pool_bot({ entity_id: null }),
+      pool_bot({ channel_id: null }),
+    ];
+    expect(context_bots_from_pool(bots)).toEqual([]);
+  });
+});

--- a/packages/daemon/src/context-alerts.ts
+++ b/packages/daemon/src/context-alerts.ts
@@ -1,0 +1,313 @@
+/**
+ * Context-size threshold alerts (#353).
+ *
+ * Context is the dominant driver of subscription burn — the spend is re-reading
+ * accumulated context, not generating tokens. A handful of long-lived pool
+ * sessions can consume most of a weekly allowance, and today the first signal
+ * is the allowance running out.
+ *
+ * This module sweeps the pool every 15 minutes, reads each session's context
+ * size via the existing `/context` tmux query, and posts an alert through the
+ * existing alert router when a session crosses a size threshold.
+ *
+ * Two properties matter more than anything else here:
+ *
+ *  1. **Once per breach, not once per sweep.** A threshold that has fired stays
+ *     quiet while usage remains above it.
+ *  2. **Hysteresis — re-arm on the way down.** A threshold is *armed* whenever
+ *     current usage is below it, and fires on the upward crossing. Compacting a
+ *     session re-arms its thresholds, so if the context regrows past one you get
+ *     told again. That is the whole point: you compact, and you want to know if
+ *     it comes back.
+ *
+ * Dedupe state is keyed by `session_id` (so a recycled session starts fully
+ * armed) and persisted to `state/context-alerts.json` (so a daemon restart does
+ * not re-fire every threshold for every session).
+ *
+ * This is a monitoring aid. It must never crash the sweep and must never become
+ * a noise source: any session whose context can't be read is skipped silently,
+ * with its dedupe state left untouched.
+ */
+
+import type { AlertPayload, AlertResult, AlertTier } from "./alert-router.js";
+import { ALERT_COLOR_AMBER, ALERT_COLOR_RED } from "./alert-router.js";
+import type { ContextAlertSession, ContextAlertState } from "./persistence.js";
+import type { PoolBot } from "./pool.js";
+import * as sentry from "./sentry.js";
+import type { ContextUsage } from "./tmux-query.js";
+
+// ── Thresholds ──
+
+export interface ContextThreshold {
+  /** Absolute context size, in tokens, that triggers the alert. */
+  tokens: number;
+  /** Human label used in alert copy, e.g. "500k". */
+  label: string;
+  /** Which alert tier this threshold warrants. */
+  tier: AlertTier;
+  /** Embed color for `action_required` alerts. */
+  color: number;
+  /** What to do about it, rendered into the alert body. */
+  action: string;
+}
+
+/**
+ * The thresholds, ascending. Tunable — this is the single place they live.
+ *
+ * Tiers escalate deliberately. 200k is informational and goes to the daily
+ * activity thread; a top-level embed for every session that gets moderately
+ * large would be exactly the noise this feature must not create. 500k and 800k
+ * are top-level, because by then the session is materially expensive.
+ *
+ * Against the 1M window these are ~20% / 50% / 80%, but the comparison is
+ * always against absolute tokens — `total_tokens` is only used for display.
+ */
+export const CONTEXT_ALERT_THRESHOLDS: readonly ContextThreshold[] = [
+  {
+    tokens: 200_000,
+    label: "200k",
+    tier: "routine",
+    color: ALERT_COLOR_AMBER,
+    action: "No action needed yet — worth a `/compact` at the next natural break.",
+  },
+  {
+    tokens: 500_000,
+    label: "500k",
+    tier: "action_required",
+    color: ALERT_COLOR_AMBER,
+    action: "Run `/compact` in the channel, or recycle the bot if the thread is done.",
+  },
+  {
+    tokens: 800_000,
+    label: "800k",
+    tier: "action_required",
+    color: ALERT_COLOR_RED,
+    action:
+      "Recycle the bot, or `/compact` immediately — every further turn re-reads this whole context.",
+  },
+];
+
+/** How often the sweep runs. Cheap — a local tmux query, no model call. */
+export const CONTEXT_SWEEP_INTERVAL_MS = 15 * 60 * 1000;
+
+/**
+ * Drop dedupe state for sessions the sweep hasn't seen in this long. Keyed on
+ * *seen in the pool*, not *successfully read*, so a session that is merely busy
+ * for a long stretch keeps its state and won't re-alert when it comes back.
+ */
+export const CONTEXT_ALERT_STATE_TTL_MS = 24 * 60 * 60 * 1000;
+
+// ── Threshold evaluation (pure) ──
+
+export interface ThresholdEvaluation {
+  /** Thresholds newly crossed on this reading, ascending. */
+  crossed: ContextThreshold[];
+  /** The next `fired` set: breached thresholds, ascending. */
+  fired: number[];
+}
+
+/**
+ * Evaluate a context reading against the thresholds and the previously fired
+ * set. Pure — this is the entire dedupe/hysteresis rule in one place.
+ *
+ * A threshold is breached when `used_tokens >= tokens` (an exact hit counts).
+ * Breached and previously armed → crossed. Not breached → re-armed.
+ */
+export function evaluate_thresholds(
+  used_tokens: number,
+  fired: readonly number[],
+  thresholds: readonly ContextThreshold[] = CONTEXT_ALERT_THRESHOLDS,
+): ThresholdEvaluation {
+  const previously_fired = new Set(fired);
+  const crossed: ContextThreshold[] = [];
+  const next_fired: number[] = [];
+
+  for (const threshold of thresholds) {
+    if (used_tokens < threshold.tokens) continue; // below → armed
+    next_fired.push(threshold.tokens);
+    if (!previously_fired.has(threshold.tokens)) crossed.push(threshold);
+  }
+
+  return { crossed, fired: next_fired.sort((a, b) => a - b) };
+}
+
+// ── Pool adapter ──
+
+/** The slice of a pool bot the sweep needs. */
+export interface ContextSweepBot {
+  bot_id: number;
+  session_id: string;
+  entity_id: string;
+  channel_id: string;
+  tmux_session: string;
+}
+
+/**
+ * Narrow pool bots to the ones the sweep can act on: a live session with an
+ * entity and channel to route an alert to.
+ */
+export function context_bots_from_pool(bots: readonly PoolBot[]): ContextSweepBot[] {
+  const sweepable: ContextSweepBot[] = [];
+  for (const bot of bots) {
+    if (!bot.session_id || !bot.entity_id || !bot.channel_id) continue;
+    sweepable.push({
+      bot_id: bot.id,
+      session_id: bot.session_id,
+      entity_id: bot.entity_id,
+      channel_id: bot.channel_id,
+      tmux_session: bot.tmux_session,
+    });
+  }
+  return sweepable;
+}
+
+// ── Alert formatting ──
+
+/** Render a token count the way `/context` does: 45k, 1.2m. */
+export function format_tokens(tokens: number): string {
+  if (tokens >= 1_000_000) {
+    const m = tokens / 1_000_000;
+    return `${(Math.round(m * 10) / 10).toString()}m`;
+  }
+  return `${Math.round(tokens / 1000).toString()}k`;
+}
+
+/**
+ * Build the alert for a crossed threshold. Everything needed to act is in the
+ * body: which channel, how big, which threshold, which session, what to do.
+ */
+export function format_context_alert(
+  bot: ContextSweepBot,
+  threshold: ContextThreshold,
+  usage: ContextUsage,
+): AlertPayload {
+  const size = usage.summary || format_tokens(usage.used_tokens ?? threshold.tokens);
+
+  return {
+    entity_id: bot.entity_id,
+    tier: threshold.tier,
+    title: `\u{1f9e0} Context over ${threshold.label} — pool-${bot.bot_id.toString()}`,
+    body: [
+      `<#${bot.channel_id}> (\`${bot.entity_id}\`) is at **${size}** — crossed the **${threshold.label}** threshold.`,
+      `Session \`${bot.session_id}\` on \`${bot.tmux_session}\`.`,
+      threshold.action,
+    ].join("\n"),
+    embed_color: threshold.color,
+  };
+}
+
+// ── Sweep ──
+
+export interface ContextSweepDeps {
+  /** Pool bots eligible for a context check. */
+  list_bots: () => ContextSweepBot[];
+  /** Read a session's context size. Returns null when unreadable or busy. */
+  query_usage: (tmux_session: string) => Promise<ContextUsage | null>;
+  post_alert: (payload: AlertPayload) => Promise<AlertResult | unknown>;
+  load_state: () => Promise<ContextAlertState>;
+  save_state: (state: ContextAlertState) => Promise<void>;
+  /** Injectable clock for deterministic tests. */
+  now?: () => Date;
+}
+
+/**
+ * One sweep: check every eligible pool session, alert on newly crossed
+ * thresholds, and persist the updated dedupe state.
+ *
+ * Sessions are checked serially — `query_usage` types `/context` into a live
+ * tmux pane and waits for the render, so hammering ten panes at once buys
+ * nothing on a 15-minute cycle.
+ *
+ * Never throws.
+ */
+export async function sweep_context_thresholds(deps: ContextSweepDeps): Promise<void> {
+  const now = deps.now?.() ?? new Date();
+  const now_iso = now.toISOString();
+
+  let state: ContextAlertState;
+  try {
+    state = await deps.load_state();
+  } catch (err) {
+    console.error(`[context-alerts] Could not load state: ${String(err)}`);
+    return;
+  }
+
+  const bots = deps.list_bots();
+  const next_state: ContextAlertState = {};
+  let alerted = 0;
+
+  for (const bot of bots) {
+    // Defensive: pool state is rehydrated from JSON, so the non-null type on
+    // session_id is only as strong as whoever built the list. Keying state
+    // under a missing id would merge unrelated bots into one dedupe entry.
+    if (!bot.session_id) continue;
+
+    const previous: ContextAlertSession | undefined = state[bot.session_id];
+
+    // Seen in the pool this sweep — carry state forward and refresh the TTL,
+    // whether or not the reading below succeeds.
+    const entry: ContextAlertSession = {
+      fired: previous?.fired ?? [],
+      last_used_tokens: previous?.last_used_tokens ?? null,
+      last_seen_at: now_iso,
+    };
+    next_state[bot.session_id] = entry;
+
+    let usage: ContextUsage | null;
+    try {
+      usage = await deps.query_usage(bot.tmux_session);
+    } catch {
+      // Dead session, tmux gone, injection refused — skip silently. State for
+      // this session is preserved above so nothing re-fires when it returns.
+      continue;
+    }
+
+    if (!usage || usage.used_tokens === null) continue;
+
+    const { crossed, fired } = evaluate_thresholds(usage.used_tokens, entry.fired);
+    entry.fired = fired;
+    entry.last_used_tokens = usage.used_tokens;
+
+    if (crossed.length === 0) continue;
+
+    // A single jump can clear several thresholds. Alert once, on the highest —
+    // the lower ones are marked fired above so they stay quiet on the way up.
+    const highest = crossed[crossed.length - 1]!;
+    try {
+      await deps.post_alert(format_context_alert(bot, highest, usage));
+      alerted++;
+    } catch (err) {
+      // The threshold is still recorded as fired: a Discord outage must not
+      // turn into a burst of duplicate alerts on the next sweep.
+      console.error(
+        `[context-alerts] Failed to post alert for ${bot.tmux_session}: ${String(err)}`,
+      );
+      sentry.captureException(err, {
+        tags: { module: "context-alerts", action: "post_alert", entity: bot.entity_id },
+      });
+    }
+  }
+
+  // Carry forward sessions absent from this sweep until they age out, so a
+  // transiently empty pool (mid-restart, say) can't wipe the dedupe state.
+  const ttl_cutoff = now.getTime() - CONTEXT_ALERT_STATE_TTL_MS;
+  for (const [session_id, entry] of Object.entries(state)) {
+    if (session_id in next_state) continue;
+    if (Date.parse(entry.last_seen_at) >= ttl_cutoff) next_state[session_id] = entry;
+  }
+
+  try {
+    await deps.save_state(next_state);
+  } catch (err) {
+    console.error(`[context-alerts] Could not save state: ${String(err)}`);
+    sentry.captureException(err, {
+      tags: { module: "context-alerts", action: "save_state" },
+    });
+  }
+
+  if (alerted > 0) {
+    console.log(
+      `[context-alerts] Sweep complete: ${alerted.toString()} threshold alert(s) across ${bots.length.toString()} session(s)`,
+    );
+  }
+}

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -4,11 +4,16 @@ import { AlertRouter } from "./alert-router.js";
 import { AuthWatchdog } from "./auth-watchdog.js";
 import { CommanderProcess } from "./commander-process.js";
 import { load_config } from "./config.js";
+import {
+  CONTEXT_SWEEP_INTERVAL_MS,
+  context_bots_from_pool,
+  sweep_context_thresholds,
+} from "./context-alerts.js";
 import { DiscordBot, resolve_bot_token } from "./discord.js";
 import { check_required_binaries, propagate_tmux_env } from "./env.js";
 import { init_github_app_from_env } from "./github-app.js";
 import { prune_daily_logs } from "./memory-pruning.js";
-import { append_session_log } from "./persistence.js";
+import { append_session_log, load_context_alerts, save_context_alerts } from "./persistence.js";
 import { remove_pid, write_pid } from "./pid.js";
 import { BotPool } from "./pool.js";
 import { PRReviewCron } from "./pr-cron.js";
@@ -19,6 +24,7 @@ import * as sentry from "./sentry.js";
 import { start_server } from "./server.js";
 import { ClaudeSessionManager } from "./session.js";
 import type { ActiveSession, SessionResult } from "./session.js";
+import { query_context_usage } from "./tmux-query.js";
 import { sweep_stale_worktrees } from "./worktree-cleanup.js";
 
 async function main(): Promise<void> {
@@ -313,6 +319,25 @@ async function main(): Promise<void> {
   }, WORKTREE_SWEEP_INTERVAL_MS);
   console.log("[worktree-cleanup] Stale worktree sweep scheduled (every 60 min)");
 
+  // Start periodic context-size sweep (#353) — alerts when a pool session's
+  // context crosses 200k/500k/800k tokens, so a runaway session can be
+  // compacted before it dominates the weekly subscription burn.
+  const context_sweep_timer = setInterval(() => {
+    void sweep_context_thresholds({
+      list_bots: () => context_bots_from_pool(pool.get_assigned_bots()),
+      query_usage: query_context_usage,
+      post_alert: (payload) => alert_router.post_alert(payload),
+      load_state: () => load_context_alerts(config),
+      save_state: (state) => save_context_alerts(state, config),
+    }).catch((err) => {
+      console.error(`[context-alerts] Sweep failed: ${String(err)}`);
+      sentry.captureException(err, {
+        tags: { module: "context-alerts", action: "sweep" },
+      });
+    });
+  }, CONTEXT_SWEEP_INTERVAL_MS);
+  console.log("[context-alerts] Context threshold sweep scheduled (every 15 min)");
+
   // Start weekly memory pruning — archives daily logs older than 30 days.
   // Runs once on startup (catches up if daemon was down) then weekly.
   const MEMORY_PRUNE_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000; // 1 week
@@ -387,6 +412,7 @@ async function main(): Promise<void> {
     pr_cron.stop();
     auth_watchdog.stop();
     clearInterval(worktree_sweep_timer);
+    clearInterval(context_sweep_timer);
     clearInterval(memory_prune_timer);
 
     // Check for active work

--- a/packages/daemon/src/persistence.ts
+++ b/packages/daemon/src/persistence.ts
@@ -9,6 +9,7 @@ const PR_REVIEWS_FILE = "pr-reviews.json";
 const POOL_STATE_FILE = "pool-state.json";
 const PR_WATCHES_FILE = "pr-watches.json";
 const DEPLOY_TRIAGE_FILE = "deploy-triage.json";
+const CONTEXT_ALERTS_FILE = "context-alerts.json";
 
 function state_dir(config: LobsterFarmConfig): string {
   return join(lobsterfarm_dir(config.paths), STATE_DIR);
@@ -28,6 +29,10 @@ function pr_watches_path(config: LobsterFarmConfig): string {
 
 function deploy_triage_path(config: LobsterFarmConfig): string {
   return join(state_dir(config), DEPLOY_TRIAGE_FILE);
+}
+
+function context_alerts_path(config: LobsterFarmConfig): string {
+  return join(state_dir(config), CONTEXT_ALERTS_FILE);
 }
 
 // ── PR Review State ──
@@ -368,6 +373,53 @@ export async function load_deploy_triage(config: LobsterFarmConfig): Promise<Dep
     const data: unknown = JSON.parse(content);
     if (typeof data !== "object" || data === null || Array.isArray(data)) return {};
     return data as DeployTriageState;
+  } catch {
+    return {};
+  }
+}
+
+// ── Context Threshold Alerts (#353) ──
+
+/**
+ * Dedupe state for one session's context-size alerts.
+ *
+ * `fired` holds the thresholds (in tokens) that have alerted and have *not*
+ * been re-armed — a threshold is re-armed the moment usage drops back below
+ * it, which is what lets a session alert again if it regrows after a
+ * `/compact`. Everything not in `fired` is armed.
+ */
+export interface ContextAlertSession {
+  /** Breached thresholds, in tokens, ascending. */
+  fired: number[];
+  /** Last successfully read context size. Null when never read. */
+  last_used_tokens: number | null;
+  /** ISO timestamp of the last sweep that saw this session in the pool. */
+  last_seen_at: string;
+}
+
+/** Keyed by Claude session_id — a recycled session gets a fresh, fully armed entry. */
+export type ContextAlertState = Record<string, ContextAlertSession>;
+
+/** Save context alert state to disk. Uses atomic write-to-temp-then-rename. */
+export async function save_context_alerts(
+  state: ContextAlertState,
+  config: LobsterFarmConfig,
+): Promise<void> {
+  const path = context_alerts_path(config);
+  const tmp_path = `${path}.${randomUUID().slice(0, 8)}.tmp`;
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(tmp_path, JSON.stringify(state, null, 2), "utf-8");
+  await rename(tmp_path, path);
+}
+
+/** Load context alert state from disk. Returns empty object if file doesn't exist. */
+export async function load_context_alerts(config: LobsterFarmConfig): Promise<ContextAlertState> {
+  const path = context_alerts_path(config);
+  try {
+    const content = await readFile(path, "utf-8");
+    const data: unknown = JSON.parse(content);
+    if (typeof data !== "object" || data === null || Array.isArray(data)) return {};
+    return data as ContextAlertState;
   } catch {
     return {};
   }


### PR DESCRIPTION
## Summary

Adds a 15-minute daemon sweep that reads each assigned pool session's context size and posts an alert when it crosses **200k / 500k / 800k** tokens — the missing signal before the weekly allowance is already gone.

Reuses the existing plumbing rather than building new measurement or alerting:
- `query_context_usage()` (`tmux-query.ts`) for measurement
- `alert_router.post_alert()` for delivery
- The worktree sweep's `setInterval` registration/logging/teardown shape in `index.ts`

## Behavior

**Once per breach, per threshold, per session.** A fired threshold stays quiet while usage remains above it.

**Hysteresis — re-arms on the way down.** A threshold is *armed* whenever current usage is below it and fires on the upward crossing. Compacting re-arms it, so a session that regrows past the same threshold alerts again. This is the point of the feature.

**Keyed by `session_id`,** so a recycled session starts fully armed regardless of bot or channel.

**Persisted** to `state/context-alerts.json` (same atomic write-temp-then-rename convention as the other daemon state files), so a restart doesn't re-fire everything.

**Never a noise source, never crashes the sweep.** Dead sessions, busy panes, tmux gone, unparseable output — all skipped silently, with that session's dedupe state preserved so nothing re-fires when it comes back. A failed `post_alert` still records the threshold as fired, so a Discord outage can't turn into a burst of duplicates.

## Decisions worth a look

- **Tiering.** 200k is `routine` (daily activity thread); 500k and 800k are `action_required` (top-level embed, amber then red). A top-level embed for every session that gets moderately large is exactly the noise the spec says to avoid. Both live in the same tunable constant.
- **Multiple thresholds crossed in one sweep** (e.g. 0 → 600k) post a single alert naming the highest, with the lower ones marked fired so they stay quiet on the way up. Alerting three times at once for one jump would be noise.
- **State for absent sessions is carried forward for 24h**, not dropped immediately. Pruning on absence alone would let a sweep that lands while the pool is mid-initialization wipe the state and re-fire every threshold — the exact failure this is supposed to prevent.
- **`CONTEXT_ALERT_THRESHOLDS`** is the single named constant; no scattered literals.

## Testing

31 unit tests in `packages/daemon/src/__tests__/context-alerts.test.ts`, covering every acceptance criterion — each threshold firing exactly once per breach, staying above not re-alerting, dropping below and re-crossing re-alerting, recycled `session_id` starting armed, dedupe surviving a simulated restart (real persist → reload), and unreadable/throwing/unparseable readings skipped without alerting or throwing.

Verified non-vacuous:
- Stubbing the dedupe (`previously_fired` always empty) fails **10** tests, including every core criterion.
- Stubbing `save_context_alerts` to a no-op fails the restart-durability test specifically.

`pnpm run build`, `pnpm run typecheck`, `pnpm run lint` all pass. Full suite: **1301 passed (71 files)**.

## One thing to flag

`query_context_usage` works by typing `/context` into the live tmux pane (guarded to only fire when the session is idle at the prompt). So each idle pool session will now have `/context` typed into it four times an hour. That's inherent to the measurement plumbing the spec specifies reusing, and it's local with no model call, but it is a visible side effect on live panes — worth knowing before it ships.

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)