### PR TITLE
fix(daemon): stop v1 merging past pending CI, merge on check_suite instead

### DIFF
--- a/packages/daemon/src/README.md
+++ b/packages/daemon/src/README.md
@@ -23,7 +23,8 @@ The LobsterFarm daemon process. Manages entities, spawns Claude Code agent sessi
 - `pid.ts` -- PID file management. Write, read, remove, and check if the daemon is already running.
 - `pr-cron.ts` -- `PRReviewCron`. Polls entity repos for open PRs, spawns headless reviewer sessions, and routes outcomes (approve/merge, fix, escalate).
 - `auth-watchdog.ts` -- `AuthWatchdog`. Per shared Claude credential (config dir), runs a periodic fresh-process canary probe + best-effort keychain expiry check. On a logged-out/invalid-grant credential it quarantines poisoned session transcripts, generates a re-login URL, and alerts the owner in the configured channel; the owner pastes the OAuth code back (owner-only security boundary), which completes the login and recycles the affected pool bots. Network/rate failures are never treated as auth incidents.
-- `webhook-handler.ts` -- GitHub webhook handler. Receives PR events, verifies signatures, maps repos to entities, and spawns reviewer/fixer sessions.
+- `webhook-handler.ts` -- GitHub webhook handler. Receives PR events, verifies signatures, maps repos to entities, and spawns reviewer/fixer sessions. On v1 entities an approval that lands while CI is still running is *parked* (persisted as `approved` + `v1_approved_sha`), never merged past the running checks.
+- `check-suite-handler.ts` -- `check_suite.completed` dispatch. Drives the whole review/merge/fix loop for `pr_lifecycle: v2` entities; for v1 entities it does exactly one thing — merge a parked approval once its CI completes green (#355).
 
 ## Key Concepts
 

--- a/packages/daemon/src/__tests__/check-suite-handler.test.ts
+++ b/packages/daemon/src/__tests__/check-suite-handler.test.ts
@@ -27,6 +27,7 @@ import {
   handle_check_suite,
 } from "../check-suite-handler.js";
 import type { PRReviewState, ProcessedPR } from "../persistence.js";
+import type { AutoMergeResult } from "../review-utils.js";
 
 // ── Fixtures ──
 
@@ -131,6 +132,8 @@ interface DepFixtures {
   rerequest_error?: Error;
   spawn_error?: Error;
   ci_failure_logs?: Array<{ check_name: string; log_tail: string; workflow_url: string }>;
+  merge_result?: AutoMergeResult;
+  merge_error?: Error;
 }
 
 interface DepStubs extends CheckSuiteDeps {
@@ -166,8 +169,29 @@ function make_deps(fixtures: DepFixtures = {}): DepStubs {
     rerequest_check_suite: vi.fn(async () => {
       if (fixtures.rerequest_error) throw fixtures.rerequest_error;
     }),
+    attempt_merge: vi.fn(async () => {
+      if (fixtures.merge_error) throw fixtures.merge_error;
+      return fixtures.merge_result ?? { merged: true, method: "direct" as const };
+    }),
   };
   return deps;
+}
+
+/** Persisted state for a PR the v1 reviewer approved while CI was still running. */
+function parked_approved(
+  overrides: Partial<ProcessedPR> = {},
+  approved_sha: string = SHA_A,
+): PRReviewState {
+  return {
+    [`${ENTITY_ID}:42`]: {
+      entity_id: ENTITY_ID,
+      pr_number: 42,
+      reviewed_at: "2026-08-13T10:00:00Z",
+      outcome: "approved",
+      v1_approved_sha: approved_sha,
+      ...overrides,
+    },
+  };
 }
 
 function make_ctx(entity: EntityConfig = make_entity()): CheckSuiteContext {
@@ -232,12 +256,14 @@ describe("handle_check_suite — gating", () => {
     expect(deps.resolve_token).not.toHaveBeenCalled();
   });
 
-  it("no-ops on entities still on v1 (feature flag gate)", async () => {
+  it("never spawns a reviewer for entities still on v1 (feature flag gate)", async () => {
     const deps = make_deps();
     const ctx = make_ctx(make_entity({ pr_lifecycle: "v1" }));
     const result = await handle_check_suite(make_payload(), ctx, deps);
-    expect(result).toEqual({ kind: "noop", reason: "v1_entity" });
+    // No persisted approval → the v1 branch has nothing to merge.
+    expect(result).toEqual({ kind: "noop", reason: "v1_not_approved" });
     expect(deps.spawn_session).not.toHaveBeenCalled();
+    expect(deps.attempt_merge).not.toHaveBeenCalled();
   });
 
   it("no-ops when check_suite has no associated PRs", async () => {
@@ -685,6 +711,248 @@ describe("handle_check_suite — resilience", () => {
 
     expect(result).toEqual({ kind: "noop", reason: "pr_fetch_failed" });
     expect(deps.spawn_session).not.toHaveBeenCalled();
+  });
+});
+
+// ── v1 merge re-entry (#355) ──
+
+/**
+ * v1 entities never had a CI-completion trigger: the only merge path was
+ * `pull_request.opened/synchronize`. Now that the v1 approved path parks a PR
+ * whose CI is still running (instead of merging past it), `check_suite.completed`
+ * is what wakes it back up.
+ *
+ * The branch is deliberately narrow — it merges or it does nothing. It must
+ * never spawn a reviewer, a ci-fixer, or a flake rerun.
+ */
+describe("handle_check_suite — v1 merge re-entry (#355)", () => {
+  const v1_ctx = () => make_ctx(make_entity({ pr_lifecycle: "v1" }));
+
+  it("merges an approved-and-parked PR when CI completes green", async () => {
+    const deps = make_deps({ state: parked_approved() });
+    const result = await handle_check_suite(make_payload(), v1_ctx(), deps);
+
+    expect(result).toEqual({
+      kind: "merged",
+      pr_number: 42,
+      head_sha: SHA_A,
+      method: "direct",
+    });
+    expect(deps.attempt_merge).toHaveBeenCalledWith(
+      42,
+      "feature/thing",
+      REPO_PATH,
+      "ghs_test_token",
+    );
+    // Merge or nothing — no reviewer, no ci-fixer, no flake rerun.
+    expect(deps.spawn_session).not.toHaveBeenCalled();
+    expect(deps.rerequest_check_suite).not.toHaveBeenCalled();
+  });
+
+  it("merges at most once for repeated completed events on the same SHA", async () => {
+    const deps = make_deps({ state: parked_approved() });
+    const ctx = v1_ctx();
+
+    const first = await handle_check_suite(make_payload(), ctx, deps);
+    const second = await handle_check_suite(make_payload(), ctx, deps);
+
+    expect(first.kind).toBe("merged");
+    expect(second).toEqual({ kind: "noop", reason: "duplicate_sha" });
+    expect(deps.attempt_merge).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses a v1-specific dedup key, not the v2 one", async () => {
+    const deps = make_deps({ state: parked_approved() });
+    await handle_check_suite(make_payload(), v1_ctx(), deps);
+
+    const saved = vi.mocked(deps.save_pr_reviews).mock.calls[0]?.[0];
+    const entry = saved?.[`${ENTITY_ID}:42`];
+    expect(entry?.v1_merge_attempted_sha).toBe(SHA_A);
+    expect(entry?.v2_last_dispatched_sha).toBeUndefined();
+  });
+
+  it("persists the dedup key BEFORE attempting the merge", async () => {
+    const deps = make_deps({ state: parked_approved() });
+    const order: string[] = [];
+    vi.mocked(deps.save_pr_reviews).mockImplementation(async () => {
+      order.push("save");
+    });
+    vi.mocked(deps.attempt_merge).mockImplementation(async () => {
+      order.push("merge");
+      return { merged: true, method: "direct" };
+    });
+
+    await handle_check_suite(make_payload(), v1_ctx(), deps);
+    expect(order).toEqual(["save", "merge"]);
+  });
+
+  it("ignores a v1 PR with no persisted review state", async () => {
+    const deps = make_deps();
+    const result = await handle_check_suite(make_payload(), v1_ctx(), deps);
+
+    expect(result).toEqual({ kind: "noop", reason: "v1_not_approved" });
+    expect(deps.attempt_merge).not.toHaveBeenCalled();
+    // Cheap local state check comes first — no GitHub round-trips for the
+    // overwhelming majority of v1 check_suite events.
+    expect(deps.resolve_token).not.toHaveBeenCalled();
+    expect(deps.fetch_pr_detail).not.toHaveBeenCalled();
+  });
+
+  it("ignores a v1 PR whose last outcome was changes_requested", async () => {
+    const deps = make_deps({ state: parked_approved({ outcome: "changes_requested" }) });
+    const result = await handle_check_suite(make_payload(), v1_ctx(), deps);
+
+    expect(result).toEqual({ kind: "noop", reason: "v1_not_approved" });
+    expect(deps.attempt_merge).not.toHaveBeenCalled();
+  });
+
+  it("ignores a stale approval pinned to a different SHA", async () => {
+    // The v1 CI fix loop seeds entries with outcome=approved. Without the SHA
+    // pin, a green check_suite on the builder's new commit would merge code no
+    // reviewer has seen.
+    const deps = make_deps({
+      state: parked_approved({ ci_fix_attempts: 1 }, SHA_B),
+    });
+    const result = await handle_check_suite(make_payload({ head_sha: SHA_A }), v1_ctx(), deps);
+
+    expect(result).toEqual({ kind: "noop", reason: "v1_not_approved" });
+    expect(deps.attempt_merge).not.toHaveBeenCalled();
+  });
+
+  it("does not merge when the PR head moved past the completed suite", async () => {
+    const deps = make_deps({
+      state: parked_approved(),
+      pr_detail: make_pr_detail({ head_sha: SHA_B }),
+    });
+    const result = await handle_check_suite(make_payload({ head_sha: SHA_A }), v1_ctx(), deps);
+
+    expect(result).toEqual({ kind: "noop", reason: "v1_sha_moved" });
+    expect(deps.attempt_merge).not.toHaveBeenCalled();
+  });
+
+  it("does not merge a PR that went back to draft", async () => {
+    const deps = make_deps({
+      state: parked_approved(),
+      pr_detail: make_pr_detail({ is_draft: true }),
+    });
+    const result = await handle_check_suite(make_payload(), v1_ctx(), deps);
+
+    expect(result).toEqual({ kind: "noop", reason: "draft_pr" });
+    expect(deps.attempt_merge).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-completed actions", async () => {
+    const deps = make_deps({ state: parked_approved() });
+    const result = await handle_check_suite(make_payload({ action: "requested" }), v1_ctx(), deps);
+
+    expect(result).toEqual({ kind: "noop", reason: "wrong_action" });
+    expect(deps.attempt_merge).not.toHaveBeenCalled();
+  });
+
+  for (const conclusion of ["failure", "timed_out", "cancelled"] as const) {
+    it(`does not merge on conclusion=${conclusion} and alerts once`, async () => {
+      const deps = make_deps({ state: parked_approved() });
+      const ctx = v1_ctx();
+
+      const first = await handle_check_suite(make_payload({ conclusion }), ctx, deps);
+      const second = await handle_check_suite(make_payload({ conclusion }), ctx, deps);
+
+      expect(first).toEqual({ kind: "alerted", pr_number: 42, reason: conclusion });
+      expect(second.kind).toBe("noop");
+      expect(deps.notify_alerts).toHaveBeenCalledTimes(1);
+      expect(deps.attempt_merge).not.toHaveBeenCalled();
+      // v1 keeps its existing fix loop — this branch must not duplicate it.
+      expect(deps.spawn_session).not.toHaveBeenCalled();
+      expect(deps.rerequest_check_suite).not.toHaveBeenCalled();
+    });
+  }
+
+  it("re-alerts when CI fails again on a new SHA", async () => {
+    const deps = make_deps({ state: parked_approved() });
+    const ctx = v1_ctx();
+
+    await handle_check_suite(make_payload({ conclusion: "failure" }), ctx, deps);
+    // A new push re-parks the PR at SHA_B (webhook-handler's job); simulate it.
+    deps._state[`${ENTITY_ID}:42`] = {
+      ...deps._state[`${ENTITY_ID}:42`]!,
+      v1_approved_sha: SHA_B,
+    };
+    const second = await handle_check_suite(
+      make_payload({ conclusion: "failure", head_sha: SHA_B }),
+      ctx,
+      deps,
+    );
+
+    expect(second).toEqual({ kind: "alerted", pr_number: 42, reason: "failure" });
+    expect(deps.notify_alerts).toHaveBeenCalledTimes(2);
+  });
+
+  it("no-ops on non-actionable conclusions", async () => {
+    for (const conclusion of ["neutral", "stale", "skipped", "action_required"] as const) {
+      const deps = make_deps({ state: parked_approved() });
+      const result = await handle_check_suite(make_payload({ conclusion }), v1_ctx(), deps);
+
+      expect(result).toEqual({ kind: "noop", reason: "unhandled_conclusion" });
+      expect(deps.attempt_merge).not.toHaveBeenCalled();
+      expect(deps.notify_alerts).not.toHaveBeenCalled();
+    }
+  });
+
+  it("alerts when the merge attempt is rejected", async () => {
+    const deps = make_deps({
+      state: parked_approved(),
+      merge_result: { merged: false, failure: "CONFLICT", error: "rebase conflicts" },
+    });
+    const result = await handle_check_suite(make_payload(), v1_ctx(), deps);
+
+    expect(result).toEqual({ kind: "alerted", pr_number: 42, reason: "merge_failed" });
+    expect(vi.mocked(deps.notify_alerts).mock.calls[0]?.[1]).toContain("rebase conflicts");
+  });
+
+  it("alerts when the merge attempt throws", async () => {
+    const deps = make_deps({
+      state: parked_approved(),
+      merge_error: new Error("gh exploded"),
+    });
+    const result = await handle_check_suite(make_payload(), v1_ctx(), deps);
+
+    expect(result).toEqual({ kind: "alerted", pr_number: 42, reason: "merge_failed" });
+    expect(vi.mocked(deps.notify_alerts).mock.calls[0]?.[1]).toContain("gh exploded");
+  });
+
+  it("alerts if token resolution fails on the merge path", async () => {
+    const deps = make_deps({ state: parked_approved(), token_error: new Error("app auth failed") });
+    const result = await handle_check_suite(make_payload(), v1_ctx(), deps);
+
+    expect(result).toEqual({ kind: "alerted", pr_number: 42, reason: "token_failed" });
+    expect(deps.attempt_merge).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when the PR detail fetch fails", async () => {
+    const deps = make_deps({
+      state: parked_approved(),
+      pr_detail_error: new Error("pr not found"),
+    });
+    const result = await handle_check_suite(make_payload(), v1_ctx(), deps);
+
+    expect(result).toEqual({ kind: "noop", reason: "pr_fetch_failed" });
+    expect(deps.attempt_merge).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when the check suite has no associated PRs", async () => {
+    const deps = make_deps({ state: parked_approved() });
+    const result = await handle_check_suite(make_payload({ pull_requests: [] }), v1_ctx(), deps);
+
+    expect(result).toEqual({ kind: "noop", reason: "no_pull_requests" });
+    expect(deps.attempt_merge).not.toHaveBeenCalled();
+  });
+
+  it("leaves v2 entities on the reviewer path even with parked-approved state", async () => {
+    const deps = make_deps({ state: parked_approved() });
+    const result = await handle_check_suite(make_payload(), make_ctx(), deps);
+
+    expect(result.kind).toBe("spawned_reviewer");
+    expect(deps.attempt_merge).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/daemon/src/__tests__/ci-gating.test.ts
+++ b/packages/daemon/src/__tests__/ci-gating.test.ts
@@ -97,6 +97,7 @@ vi.mock("../persistence.js", () => ({
 
 import type { DiscordBot } from "../discord.js";
 import type { GitHubAppAuth } from "../github-app.js";
+import { save_pr_reviews } from "../persistence.js";
 import type { EntityRegistry } from "../registry.js";
 // Import after mocks are registered
 import { check_ci_status } from "../review-utils.js";
@@ -562,6 +563,9 @@ describe("webhook handler — workflow_run events", () => {
 
 // ── Integration tests: review-completion → CI gating ──
 
+/** Head SHA carried by the PR webhook payload in these tests. */
+const HEAD_SHA = "abc1230000000000000000000000000000000000";
+
 describe("webhook handler — CI gating on review completion", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -596,7 +600,7 @@ describe("webhook handler — CI gating on review completion", () => {
       pull_request: {
         number: 42,
         title: "feat: test feature",
-        head: { ref: "feature/test" },
+        head: { ref: "feature/test", sha: HEAD_SHA },
         body: "Test body",
         user: { login: "test-user" },
       },
@@ -649,15 +653,20 @@ describe("webhook handler — CI gating on review completion", () => {
     );
   });
 
-  it("skips merge when CI checks are pending (no alert, retries on next cycle)", async () => {
-    const { discord } = await trigger_review_completion(() => ({
-      stdout: JSON.stringify([
-        { name: "Lint", state: "COMPLETED", conclusion: "SUCCESS" },
-        { name: "Build", state: "IN_PROGRESS", conclusion: "" },
-      ]),
-    }));
+  it("parks instead of merging when CI checks are still pending", async () => {
+    const merge_route = vi.fn(() => ({ stdout: "merged" }));
+    const { discord } = await trigger_review_completion(
+      () => ({
+        stdout: JSON.stringify([
+          { name: "Lint", state: "COMPLETED", conclusion: "SUCCESS" },
+          { name: "Build", state: "IN_PROGRESS", conclusion: "" },
+        ]),
+      }),
+      {},
+      { "gh pr merge": merge_route },
+    );
 
-    // Should not send any alerts — pending is a silent skip
+    expect(merge_route).not.toHaveBeenCalled();
     expect(discord.send_to_entity).not.toHaveBeenCalled();
   });
 
@@ -668,7 +677,7 @@ describe("webhook handler — CI gating on review completion", () => {
     expect(discord.send_to_entity).not.toHaveBeenCalled();
   });
 
-  it("attempts merge when CI pending and pr-cron is disabled (#233)", async () => {
+  it("does NOT merge past pending CI even when pr-cron is disabled (#355)", async () => {
     const config_with_cron_disabled = {
       paths: { lobsterfarm_dir: "/tmp/test-lf", projects_dir: "/tmp" },
       pr_cron: { enabled: false },
@@ -682,51 +691,59 @@ describe("webhook handler — CI gating on review completion", () => {
       }),
       { config: config_with_cron_disabled },
       {
-        // attempt_auto_merge will call gh pr merge, then fall through to
-        // update-branch → repo view → local rebase. We only need merge to succeed.
         "gh pr merge": merge_route,
         "gh repo view": () => ({ stdout: "test-org/lobster-farm" }),
       },
     );
 
-    // Verify merge was actually attempted, not just that an alert was sent
-    expect(merge_route).toHaveBeenCalled();
-
-    // Assert on success-specific text ("CI pending bypassed" only appears in the
-    // success alert, not the failure one which says "Merge failed")
-    expect(alert_router.post_alert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        entity_id: "test-entity",
-        body: expect.stringContaining("CI pending bypassed"),
-      }),
+    // The pr_cron setting is irrelevant — running CI is never bypassed.
+    expect(merge_route).not.toHaveBeenCalled();
+    expect(alert_router.post_alert).not.toHaveBeenCalledWith(
+      expect.objectContaining({ body: expect.stringContaining("CI pending bypassed") }),
     );
   });
 
-  it("alerts when CI pending, pr-cron disabled, and merge fails (#233)", async () => {
+  it("persists the approval pinned to the reviewed SHA so check_suite can finish it (#355)", async () => {
     const config_with_cron_disabled = {
       paths: { lobsterfarm_dir: "/tmp/test-lf", projects_dir: "/tmp" },
       pr_cron: { enabled: false },
     } as WebhookContext["config"];
 
-    const { alert_router } = await trigger_review_completion(
+    await trigger_review_completion(
       () => ({
         stdout: JSON.stringify([{ name: "Build", state: "IN_PROGRESS", conclusion: "" }]),
       }),
       { config: config_with_cron_disabled },
+    );
+
+    const saved = vi.mocked(save_pr_reviews).mock.calls[0]?.[0];
+    expect(saved?.["test-entity:42"]).toMatchObject({
+      entity_id: "test-entity",
+      pr_number: 42,
+      outcome: "approved",
+      v1_approved_sha: HEAD_SHA,
+    });
+  });
+
+  it("still merges immediately when the repo has no checks configured (#355)", async () => {
+    const merge_route = vi.fn(() => ({ stdout: "merged" }));
+
+    // `gh pr checks --required` exits non-zero with "no required checks
+    // reported" when nothing is configured — the docs-only path.
+    const { alert_router } = await trigger_review_completion(
+      () => new Error("no required checks reported on the 'feature/test' branch"),
+      {},
       {
-        "gh pr merge": () => new Error("merge blocked by branch protection"),
+        "gh pr merge": merge_route,
         "gh repo view": () => ({ stdout: "test-org/lobster-farm" }),
-        // update-branch and local rebase will also fail
-        "gh api": () => new Error("update-branch failed"),
-        "git remote": () => new Error("no remote"),
       },
     );
 
-    // Should alert about the failed merge with pr-cron disabled context
+    expect(merge_route).toHaveBeenCalled();
     expect(alert_router.post_alert).toHaveBeenCalledWith(
       expect.objectContaining({
         entity_id: "test-entity",
-        body: expect.stringContaining("pr-cron disabled"),
+        title: expect.stringContaining("merged"),
       }),
     );
   });

--- a/packages/daemon/src/check-suite-handler.ts
+++ b/packages/daemon/src/check-suite-handler.ts
@@ -14,8 +14,11 @@
  *   Builder pushes  → fresh check_suite fires → loop
  *
  * The handler is gated per-entity by `entity.pr_lifecycle === "v2"`. Entities
- * still on v1 fall through the legacy `pull_request.opened` reviewer spawn in
- * `webhook-handler.ts`.
+ * still on v1 drive review from the legacy `pull_request.opened` spawn in
+ * `webhook-handler.ts` and take one narrow branch here (#355): merging a PR
+ * that was approved while its CI was still running. See
+ * `handle_v1_check_suite` — it merges or does nothing, never spawning a
+ * reviewer, ci-fixer, or flake rerun.
  *
  * Architecture: every external side effect (gh CLI, session spawn, alert) goes
  * through a `CheckSuiteDeps` seam so tests can stub them precisely. Production
@@ -36,7 +39,13 @@ import {
 } from "./persistence.js";
 import type { EntityRegistry } from "./registry.js";
 import { find_entity_for_repo } from "./repo-utils.js";
-import { MAX_CI_FIX_ATTEMPTS, build_ci_fix_prompt, fetch_ci_failure_logs } from "./review-utils.js";
+import {
+  type AutoMergeResult,
+  MAX_CI_FIX_ATTEMPTS,
+  attempt_auto_merge,
+  build_ci_fix_prompt,
+  fetch_ci_failure_logs,
+} from "./review-utils.js";
 import * as sentry from "./sentry.js";
 import type { ClaudeSessionManager } from "./session.js";
 
@@ -126,6 +135,14 @@ export interface CheckSuiteDeps {
     check_suite_id: number,
     gh_token: string,
   ) => Promise<void>;
+  /** Merge an approved PR. Only used by the v1 re-entry path (#355); v2 goes
+   * through the merge-gate in webhook-handler instead. */
+  attempt_merge: (
+    pr_number: number,
+    branch: string,
+    repo_path: string,
+    gh_token: string,
+  ) => Promise<AutoMergeResult>;
 }
 
 export interface SpawnSessionOptions {
@@ -161,6 +178,7 @@ export type CheckSuiteOutcome =
   | { kind: "spawned_ci_fixer"; pr_number: number; head_sha: string; attempt: number }
   | { kind: "rerequested"; check_suite_id: number; pr_number: number }
   | { kind: "ci_fix_exhausted"; pr_number: number; attempts: number }
+  | { kind: "merged"; pr_number: number; head_sha: string; method?: AutoMergeResult["method"] }
   | { kind: "alerted"; pr_number: number; reason: string };
 
 export type NoopReason =
@@ -171,7 +189,8 @@ export type NoopReason =
   | "pr_fetch_failed"
   | "fork_pr"
   | "no_pull_requests"
-  | "v1_entity"
+  | "v1_not_approved"
+  | "v1_sha_moved"
   | "draft_pr"
   | "duplicate_sha"
   | "unhandled_conclusion"
@@ -213,9 +232,11 @@ export async function handle_check_suite(
     return { kind: "noop", reason: "unknown_repo" };
   }
 
-  // v2 gating — entities still on v1 fall through legacy webhook-handler.
+  // v2 gating — entities still on v1 drive review from `pull_request.*` in
+  // webhook-handler. They get one narrow behaviour here: merging a PR that was
+  // approved while CI was still running (#355). Nothing else.
   if (match.entity.entity.pr_lifecycle !== "v2") {
-    return { kind: "noop", reason: "v1_entity" };
+    return await handle_v1_check_suite(suite, match.entity, match.repo_path, payload, ctx, deps);
   }
 
   // No associated PRs — this check_suite ran against `main` (push to main) or
@@ -363,6 +384,224 @@ export async function handle_check_suite(
       // Exhaustiveness — TypeScript will flag if we add a conclusion above.
       return { kind: "noop", reason: "unhandled_conclusion" };
   }
+}
+
+// ── v1 merge re-entry (#355) ──
+
+/**
+ * The only thing `check_suite.completed` does for a v1 entity: finish a merge
+ * that was deliberately parked.
+ *
+ * A v1 reviewer that approves while CI is still running used to be merged
+ * immediately — past red-to-be checks. webhook-handler now parks the PR
+ * (`outcome: "approved"` + `v1_approved_sha`) and returns. CI completing fires
+ * no `pull_request` event, so without this branch the PR would sit unmerged
+ * with nothing to wake it.
+ *
+ * Deliberately narrow: this merges or it does nothing. No reviewers, no
+ * ci-fixers, no flake reruns — v1 already has its own loops for those, driven
+ * by `pull_request.synchronize`.
+ */
+async function handle_v1_check_suite(
+  suite: CheckSuiteData,
+  entity: EntityConfig,
+  repo_path: string,
+  payload: CheckSuiteWebhookPayload,
+  ctx: CheckSuiteContext,
+  deps: CheckSuiteDeps,
+): Promise<CheckSuiteOutcome> {
+  if (suite.pull_requests.length === 0) {
+    return { kind: "noop", reason: "no_pull_requests" };
+  }
+
+  const pr_ref = suite.pull_requests[0]!;
+  const entity_id = entity.entity.id;
+  const state_key = pr_state_key(entity_id, pr_ref.number);
+
+  // Local state first — no GitHub round-trips for the overwhelming majority of
+  // v1 check_suite events, which belong to PRs nobody has approved yet.
+  const state = await deps.load_pr_reviews(ctx.config);
+  const existing = state[state_key];
+
+  if (!existing || existing.outcome !== "approved" || existing.v1_approved_sha !== suite.head_sha) {
+    return { kind: "noop", reason: "v1_not_approved" };
+  }
+
+  switch (suite.conclusion) {
+    case "success":
+      return await v1_merge_parked_pr(
+        suite,
+        entity_id,
+        repo_path,
+        payload,
+        existing,
+        state,
+        ctx,
+        deps,
+      );
+
+    case "failure":
+    case "timed_out":
+    case "cancelled":
+      return await v1_alert_ci_failure(suite, entity_id, existing, state, ctx, deps);
+
+    default:
+      // neutral / stale / skipped / action_required / null. None of these mean
+      // "CI is green", and none warrant an alert of their own — the PR stays
+      // parked until a conclusive suite arrives.
+      return { kind: "noop", reason: "unhandled_conclusion" };
+  }
+}
+
+/** Merge a parked-approved v1 PR now that its CI is green. */
+async function v1_merge_parked_pr(
+  suite: CheckSuiteData,
+  entity_id: string,
+  repo_path: string,
+  payload: CheckSuiteWebhookPayload,
+  existing: ProcessedPR,
+  state: PRReviewState,
+  ctx: CheckSuiteContext,
+  deps: CheckSuiteDeps,
+): Promise<CheckSuiteOutcome> {
+  const pr_number = suite.pull_requests[0]!.number;
+  const state_key = pr_state_key(entity_id, pr_number);
+
+  // One SHA fires one check_suite.completed per workflow — merge at most once.
+  if (existing.v1_merge_attempted_sha === suite.head_sha) {
+    return { kind: "noop", reason: "duplicate_sha" };
+  }
+
+  const installation_id =
+    payload.installation?.id != null ? String(payload.installation.id) : undefined;
+
+  let gh_token: string;
+  try {
+    gh_token = await deps.resolve_token(installation_id);
+  } catch (err) {
+    console.error(`[check-suite:v1] Failed to resolve token: ${String(err)}`);
+    sentry.captureException(err, {
+      tags: { module: "check-suite", entity: entity_id, action: "v1_resolve_token" },
+      contexts: { pr: { number: pr_number } },
+    });
+    await deps.notify_alerts(
+      entity_id,
+      `PR #${String(pr_number)} is approved and its CI is green, but the GitHub token could not be resolved to merge it: ${error_message(err)}`,
+    );
+    return { kind: "alerted", pr_number, reason: "token_failed" };
+  }
+
+  let pr: PRDetail;
+  try {
+    pr = await deps.fetch_pr_detail(pr_number, repo_path, gh_token);
+  } catch (err) {
+    console.error(`[check-suite:v1] Failed to fetch PR #${String(pr_number)}: ${String(err)}`);
+    sentry.captureException(err, {
+      tags: { module: "check-suite", entity: entity_id, action: "v1_fetch_pr" },
+      contexts: { pr: { number: pr_number } },
+    });
+    return { kind: "noop", reason: "pr_fetch_failed" };
+  }
+
+  if (pr.is_fork) return { kind: "noop", reason: "fork_pr" };
+  if (pr.is_draft) return { kind: "noop", reason: "draft_pr" };
+  if (pr.base_ref !== "main" && pr.base_ref !== "master") {
+    return { kind: "noop", reason: "non_default_base" };
+  }
+
+  // The PR head moved after the approval was parked. Those commits went
+  // through `pull_request.synchronize` and are being reviewed on their own —
+  // merging here would land code nobody approved.
+  if (pr.head_sha !== suite.head_sha) {
+    console.log(
+      `[check-suite:v1] PR #${String(pr_number)} head moved (${pr.head_sha.slice(0, 8)} != approved ${suite.head_sha.slice(0, 8)}) — leaving to the fresh review`,
+    );
+    return { kind: "noop", reason: "v1_sha_moved" };
+  }
+
+  // Stamp the dedup key BEFORE merging so a concurrent duplicate event — or a
+  // merge that throws — can't drive a second attempt.
+  const updated = { ...state };
+  updated[state_key] = { ...existing, v1_merge_attempted_sha: suite.head_sha };
+  await deps.save_pr_reviews(updated, ctx.config);
+
+  let result: AutoMergeResult;
+  try {
+    result = await deps.attempt_merge(pr_number, pr.branch, repo_path, gh_token);
+  } catch (err) {
+    console.error(`[check-suite:v1] Merge threw for PR #${String(pr_number)}: ${String(err)}`);
+    sentry.captureException(err, {
+      tags: { module: "check-suite", entity: entity_id, action: "v1_merge" },
+      contexts: { pr: { number: pr_number, title: pr.title, head_sha: pr.head_sha } },
+    });
+    await deps.notify_alerts(
+      entity_id,
+      `PR #${String(pr_number)}: "${pr.title}" — CI went green but the merge failed: ${error_message(err)}`,
+    );
+    return { kind: "alerted", pr_number, reason: "merge_failed" };
+  }
+
+  if (!result.merged) {
+    const failure_tag = result.failure ? ` [${result.failure}]` : "";
+    await deps.notify_alerts(
+      entity_id,
+      `PR #${String(pr_number)}: "${pr.title}" — CI went green but the merge failed${failure_tag}: ${result.error ?? "manual intervention needed."}`,
+    );
+    return { kind: "alerted", pr_number, reason: "merge_failed" };
+  }
+
+  console.log(
+    `[check-suite:v1] Merged parked PR #${String(pr_number)} on ${suite.head_sha.slice(0, 8)} (${result.method ?? "direct"})`,
+  );
+  // Post-merge cleanup (closing linked issues, worktree removal, notifying the
+  // watching bot) is driven by the `pull_request.closed` webhook this merge
+  // fires — see handle_pr_merged in webhook-handler.ts.
+  await deps.notify_alerts(
+    entity_id,
+    `PR #${String(pr_number)}: "${pr.title}" — CI completed green, approved PR merged (${result.method ?? "direct"}).`,
+  );
+
+  return { kind: "merged", pr_number, head_sha: suite.head_sha, method: result.method };
+}
+
+/**
+ * A parked PR whose CI ended red. Do not merge; alert once so the parked state
+ * is visible, then leave it to the existing v1 fix loop (which reacts to the
+ * builder's next push, not to this event).
+ */
+async function v1_alert_ci_failure(
+  suite: CheckSuiteData,
+  entity_id: string,
+  existing: ProcessedPR,
+  state: PRReviewState,
+  ctx: CheckSuiteContext,
+  deps: CheckSuiteDeps,
+): Promise<CheckSuiteOutcome> {
+  const pr_number = suite.pull_requests[0]!.number;
+  const state_key = pr_state_key(entity_id, pr_number);
+  const conclusion = suite.conclusion ?? "failure";
+  const alert_key = v1_ci_failure_key(conclusion, suite.head_sha);
+
+  if (existing.ci_failure_alerted === alert_key) {
+    return { kind: "noop", reason: "duplicate_sha" };
+  }
+
+  const updated = { ...state };
+  updated[state_key] = { ...existing, ci_failure_alerted: alert_key };
+  await deps.save_pr_reviews(updated, ctx.config);
+
+  await deps.notify_alerts(
+    entity_id,
+    `PR #${String(pr_number)} was approved but CI ${conclusion} on ${suite.head_sha.slice(0, 8)} — not merging. The fix loop takes it from here.`,
+  );
+
+  return { kind: "alerted", pr_number, reason: conclusion };
+}
+
+/** Dedup key for the v1 parked-PR CI failure alert. Scoped to the SHA so a
+ * re-parked PR that fails again on a new commit alerts again. */
+function v1_ci_failure_key(conclusion: string, head_sha: string): string {
+  return `v1_check_suite:${conclusion}:${head_sha}`;
 }
 
 // ── Success path: spawn reviewer ──
@@ -763,6 +1002,9 @@ export function make_default_deps(ctx: CheckSuiteContext): CheckSuiteDeps {
     },
 
     rerequest_check_suite: default_rerequest_check_suite,
+
+    attempt_merge: (pr_number, branch, repo_path, gh_token) =>
+      attempt_auto_merge(pr_number, branch, repo_path, undefined, gh_token),
   };
 }
 

--- a/packages/daemon/src/persistence.ts
+++ b/packages/daemon/src/persistence.ts
@@ -50,6 +50,19 @@ export interface ProcessedPR {
    * Reset when new commits arrive from a non-builder source. (#196) */
   ci_fix_attempts?: number;
 
+  // ── v1 PR lifecycle (#355) ──
+  /** Head SHA a v1 reviewer approved while CI was still running.
+   * The daemon parks such a PR instead of merging past pending checks; the
+   * `check_suite.completed` event for this exact SHA re-attempts the merge.
+   * Pinning the SHA matters: `outcome: "approved"` alone is also set by the CI
+   * fix loop, and merging on that would land commits no reviewer has seen. */
+  v1_approved_sha?: string;
+  /** Head SHA the v1 check-suite merge re-entry has already acted on.
+   * One SHA produces one `check_suite.completed` per workflow, so without this
+   * the merge would be attempted several times. Deliberately distinct from
+   * `v2_last_dispatched_sha` — the two lifecycles never share a dedup key. */
+  v1_merge_attempted_sha?: string;
+
   // ── v2 PR lifecycle (#257) ──
   /** Last head SHA the v2 check-suite-handler dispatched on.
    * Used to deduplicate `check_suite.completed` events that fire multiple

--- a/packages/daemon/src/webhook-handler.ts
+++ b/packages/daemon/src/webhook-handler.ts
@@ -763,53 +763,26 @@ async function handle_review_completion(
       const ci = await check_ci_status(pr.number, repo_path, gh_token);
 
       if (ci.pending) {
-        const pr_cron_enabled = ctx.config.pr_cron?.enabled !== false;
-
-        if (pr_cron_enabled) {
-          console.log(
-            `[webhook] CI checks pending for PR #${String(pr.number)} — skipping merge, pr-cron retry pass will handle`,
-          );
-        } else {
-          // pr-cron is disabled — no retry will happen. Attempt the merge now even
-          // though CI is still running: without a cron, approved PRs would otherwise
-          // be stuck indefinitely. The alert makes this bypass explicit.
-          console.log(
-            `[webhook] CI checks pending for PR #${String(pr.number)} but pr-cron is disabled — attempting merge`,
-          );
-
-          const result = await attempt_auto_merge(
-            pr.number,
-            pr.head.ref,
-            repo_path,
-            undefined,
-            gh_token,
-          );
-
-          if (result.merged) {
-            await post_auto_merge_cleanup(pr, entity_id, repo_path, ctx, installation_id);
-            await ctx.alert_router?.post_alert({
-              entity_id,
-              tier: "routine",
-              title: `PR #${String(pr.number)} merged`,
-              body: `${pr.title} — approved and merged (CI pending bypassed)`,
-            });
-            await notify_pr_watcher(
-              repo_full_name,
-              pr.number,
-              `PR #${String(pr.number)} ("${pr.title}") was approved and merged to main. Continue your work.`,
-              ctx,
-            );
-          } else {
-            const failure_tag = result.failure ? ` [${result.failure}]` : "";
-            await ctx.alert_router?.post_alert({
-              entity_id,
-              tier: "action_required",
-              title: `\u26a0\ufe0f Merge failed — PR #${String(pr.number)}`,
-              body: `${pr.title} — CI pending, pr-cron disabled. Merge failed${failure_tag}: ${result.error ?? "manual intervention needed."}`,
-              embed_color: ALERT_COLOR_AMBER,
-            });
-          }
-        }
+        // Never merge past running CI (#355). The v1 reviewer is told it may
+        // approve-and-wait because "the daemon gates the actual merge on CI
+        // completion" — this is that gate. Park the approval instead, pinned to
+        // the reviewed SHA; the `check_suite.completed` event for that SHA
+        // re-enters through check-suite-handler's v1 branch and merges once CI
+        // is green.
+        //
+        // Unconditional on purpose. pr_cron has been disabled since 2026-04-24
+        // (webhooks-only architecture), and its state says nothing about whether
+        // bypassing a running check is safe — it never was.
+        console.log(
+          `[webhook] CI checks pending for PR #${String(pr.number)} — parking approval, check_suite.completed will drive the merge`,
+        );
+        await park_approved_pr(entity_id, pr, ctx);
+        await ctx.alert_router?.post_alert({
+          entity_id,
+          tier: "routine",
+          title: `PR #${String(pr.number)} approved — awaiting CI`,
+          body: `${pr.title} — approved while checks are still running. Merge is parked until CI completes.`,
+        });
       } else if (ci.failures.length > 0) {
         // Spawn builder to fix CI failures (#196)
         await spawn_ci_fixer(entity_id, repo_path, pr, ci.failures, ctx, installation_id);
@@ -1202,6 +1175,49 @@ async function spawn_fixer(
     console.error(`[webhook] Failed to spawn builder for PR #${String(pr.number)}: ${String(err)}`);
     sentry.captureException(err, {
       tags: { module: "webhook", entity: entity_id, action: "spawn_fixer" },
+      contexts: { pr: { number: pr.number, title: pr.title } },
+    });
+  }
+}
+
+// ── Parking an approval until CI finishes (#355) ──
+
+/**
+ * Persist that a v1 reviewer approved this PR at this exact head SHA, without
+ * merging it.
+ *
+ * The SHA pin is what makes the parked state safe to act on later: the CI fix
+ * loop also writes `outcome: "approved"` entries, and merging on that alone
+ * would land commits no reviewer has seen. check-suite-handler's v1 branch
+ * merges only when the completed suite's SHA equals `v1_approved_sha`.
+ *
+ * Best-effort: a persistence failure means the PR stays unmerged and a human
+ * picks it up from the #alerts message — strictly better than merging blind.
+ */
+async function park_approved_pr(
+  entity_id: string,
+  pr: WebhookPR,
+  ctx: WebhookContext,
+): Promise<void> {
+  const key = ci_retry_key(entity_id, pr.number);
+  try {
+    const state = await load_pr_reviews(ctx.config);
+    const existing = state[key];
+    state[key] = {
+      ...existing,
+      entity_id,
+      pr_number: pr.number,
+      reviewed_at: new Date().toISOString(),
+      outcome: "approved",
+      v1_approved_sha: pr.head.sha,
+    };
+    await save_pr_reviews(state, ctx.config);
+  } catch (err) {
+    console.error(
+      `[webhook] Failed to persist parked approval for PR #${String(pr.number)}: ${String(err)}`,
+    );
+    sentry.captureException(err, {
+      tags: { module: "webhook", entity: entity_id, action: "park_approved_pr" },
       contexts: { pr: { number: pr.number, title: pr.title } },
     });
   }
@@ -1679,9 +1695,10 @@ export function build_reviewer_prompt(
     "   review is orthogonal to CI execution time. Review the code on its merits",
     "   and either:",
     "     - Approve (if the code is clean). The daemon gates the actual merge on",
-    "       CI completion — pr-cron retries the merge once checks finish, so an",
-    "       approve-and-wait is safe. Note in your review body that merge will",
-    "       happen after CI clears.",
+    "       CI completion — it parks your approval and merges when the",
+    "       check_suite for this commit completes green, so an approve-and-wait",
+    "       is safe. Note in your review body that merge will happen after CI",
+    "       clears.",
     "     - Request changes (only if the code itself has issues, independent of",
     "       CI status).",
     "   Do NOT request changes just because checks haven't finished yet — that",


### PR DESCRIPTION
## Problem

On the v1 approved path, `webhook-handler.ts` read `pr_cron.enabled` and — because pr-cron has been disabled globally since the move to a webhooks-only architecture — always took the `else` branch and merged **while CI was still running**. The alert even said so: `(CI pending bypassed)`.

The v1 reviewer prompt tells the reviewer it may approve-and-wait because "the daemon gates the actual merge on CI completion." That gate did not exist. A reviewer finishing before CI could land red code on main, in any of the 10 entities.

Deleting the bypass alone would have stranded those PRs: CI finishing fires `check_suite.completed`, and `check-suite-handler.ts` hard-returned `{ kind: "noop", reason: "v1_entity" }` for every non-v2 entity. (Daemon logs confirm those events do arrive for v1 repos — the branch was reachable, just inert.) Both halves are in this PR.

## Changes

**1. `webhook-handler.ts` — park instead of bypassing**

When `ci.pending`, the approval is persisted (`outcome: "approved"` + the reviewed head SHA) and the handler returns without merging. No `pr_cron` read: its state never said anything about whether bypassing a running check was safe. A routine alert makes the parked state visible.

**2. `check-suite-handler.ts` — narrow v1 merge re-entry**

The blanket v1 no-op becomes a branch that, for v1 entities only:

- acts only on `action === "completed"`;
- loads persisted state first (no GitHub round-trip for the vast majority of events) and proceeds only for a parked approval;
- on `success` → re-attempts the merge through the existing `attempt_auto_merge` path;
- on `failure` / `timed_out` / `cancelled` → does **not** merge, posts one alert (dedup via `ci_failure_alerted`), leaves the fix loop to the existing v1 machinery;
- on anything else (`neutral` / `skipped` / `stale` / `action_required` / null) → no-op.

It never spawns a reviewer, a ci-fixer, or a flake rerun. It merges or it does nothing.

**3. Two new persistence fields**

- `v1_approved_sha` — the SHA the reviewer approved. The merge re-entry fires only when the completed suite's SHA matches. This is load-bearing: the CI fix loop also writes `outcome: "approved"` entries, so merging on the outcome alone would land commits nobody reviewed the moment a builder pushed a green fix.
- `v1_merge_attempted_sha` — dedup for the merge re-attempt, so the several `check_suite.completed` events one SHA produces merge at most once. Deliberately distinct from `v2_last_dispatched_sha`.

Post-merge cleanup (closing linked issues, worktree removal, notifying the watching bot) still happens — the merge fires `pull_request.closed`, which `handle_pr_merged` already covers.

Also updated: the v1 reviewer prompt no longer promises a pr-cron retry that cannot happen, and the daemon module README describes both handlers' new roles.

## Verification

`pnpm typecheck`, `biome check .`, and the full daemon suite: **1323 tests / 71 files passing**.

Per-file, including the suites named in the issue:

| suite | before | after |
|---|---|---|
| `check-suite-handler.test.ts` | 34 | 55 |
| `merge-gate.test.ts` | 16 | 16 (untouched) |
| `v2-review-completion.test.ts` | 15 | 15 (untouched) |
| `ci-gating.test.ts` | 20 | 21 |

Tests were written first and observed failing against the old behaviour (20 red in `check-suite-handler.test.ts`, 2 in `ci-gating.test.ts`) before the implementation landed.

Acceptance criteria → covering test:

- approved-with-pending-CI is parked, not merged → *"does NOT merge past pending CI even when pr-cron is disabled"*, *"parks instead of merging when CI checks are still pending"*, *"persists the approval pinned to the reviewed SHA"*
- green `check_suite.completed` merges it → *"merges an approved-and-parked PR when CI completes green"*
- red CI does not merge, one alert → *"does not merge on conclusion=failure/timed_out/cancelled and alerts once"* (×3)
- no-checks-configured still merges immediately → *"still merges immediately when the repo has no checks configured"*
- repeat events for one SHA merge at most once → *"merges at most once for repeated completed events on the same SHA"*, *"uses a v1-specific dedup key, not the v2 one"*
- v2 entirely unaffected → all 34 pre-existing v2 cases unchanged, plus *"leaves v2 entities on the reviewer path even with parked-approved state"*

Extra guards worth noting in review: the merge re-entry re-checks fork/draft/base and bails if the PR head has moved past the completed suite (`v1_sha_moved`), and the dedup key is persisted *before* the merge so a throwing merge cannot loop.

## Out of scope (respected)

- `pr_cron` stays disabled — not re-enabled, and the approved path no longer consults it at all.
- No entity migrated to `pr_lifecycle: v2`.
- No branch-protection changes.

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)
