### PR TITLE
fix(daemon): stop the worktree sweep destroying unpushed agent work

### DIFF
--- a/packages/daemon/src/__tests__/worktree-cleanup.integration.test.ts
+++ b/packages/daemon/src/__tests__/worktree-cleanup.integration.test.ts
@@ -1,15 +1,15 @@
 /**
- * Integration coverage for the worktree sweep guard (issue #351).
+ * Integration coverage for the worktree sweep guards (issues #351 and #357).
  *
  * Unlike worktree-cleanup.test.ts, nothing here is mocked: these tests drive
- * real `git` against real temporary repositories. The bug they guard against
- * was a wrong assumption about what git reports for a never-pushed branch, so
- * the only test that can actually prove the fix is one that asks git.
+ * real `git` against real temporary repositories. The bugs they guard against
+ * were wrong assumptions about what git reports for a never-pushed branch, so
+ * the only tests that can actually prove the fixes are ones that ask git.
  */
 
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, realpath, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -21,6 +21,27 @@ const exec = promisify(execFile);
 async function git(cwd: string, args: string[]): Promise<string> {
   const { stdout } = await exec("git", args, { cwd, timeout: 30_000 });
   return stdout;
+}
+
+/**
+ * Push a directory's mtime far enough into the past that the sweep's grace
+ * period has lapsed. Tests that assert removal must call this — every
+ * worktree a test creates is seconds old, and the grace period alone would
+ * otherwise explain the result.
+ */
+async function age_out(path: string): Promise<void> {
+  const when = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  await utimes(path, when, when);
+}
+
+/** Does a local branch still exist in `repo`? */
+async function branch_exists(repo_path: string, branch: string): Promise<boolean> {
+  try {
+    await git(repo_path, ["rev-parse", "--verify", `refs/heads/${branch}`]);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /** Registry stub exposing a single repo, matching what the sweep consumes. */
@@ -69,6 +90,9 @@ describe("sweep_stale_worktrees (real git)", () => {
     await writeFile(join(wt, "work.ts"), "export const answer = 42;\n");
     await git(wt, ["add", "-A"]);
     await git(wt, ["commit", "--quiet", "-m", "20 minutes of work"]);
+    // Aged out, so the grace period is not what saves it — the never-pushed
+    // guard has to hold on its own. ("never swept, at any age".)
+    await age_out(wt);
 
     // Precondition: this is genuinely the state the old code deleted on.
     await expect(
@@ -118,13 +142,23 @@ describe("sweep_stale_worktrees (real git)", () => {
     }
   });
 
-  it("still removes a genuinely stale worktree: merged, clean, nothing unpushed", async () => {
+  it("does not remove a never-pushed worktree even when merged, clean and old", async () => {
+    // Before #357 this was the sweep's showcase "genuinely stale" case: a
+    // branch sitting exactly on main, nothing committed, nothing dirty.
+    //
+    // It is also indistinguishable from a worktree an agent was handed
+    // seconds before it started work. The only thing separating the two is
+    // whether the branch has ever reached the remote, so a branch with no
+    // upstream ever configured is now off-limits regardless of age. The cost
+    // is a leaked directory; the alternative cost is the agent's work.
     const wt = join(root, "wt-stale");
     await git(repo, ["worktree", "add", "--quiet", "-b", "feature/stale", wt]);
+    await age_out(wt);
 
     await sweep_stale_worktrees(registry_for(repo) as never);
 
-    expect(existsSync(wt)).toBe(false);
+    expect(existsSync(wt)).toBe(true);
+    expect(await branch_exists(repo, "feature/stale")).toBe(true);
   });
 
   it("still removes a worktree whose work was merged into main and remote branch deleted", async () => {
@@ -139,10 +173,161 @@ describe("sweep_stale_worktrees (real git)", () => {
     await git(repo, ["merge", "--quiet", "--no-ff", "-m", "merge", "feature/shipped"]);
     await git(repo, ["push", "--quiet", "origin", "main"]);
     await git(repo, ["push", "--quiet", "origin", "--delete", "feature/shipped"]);
+    await age_out(wt);
 
     await sweep_stale_worktrees(registry_for(repo) as never);
 
     expect(existsSync(wt)).toBe(false);
+  });
+
+  it("still removes a pushed worktree whose remote ref is gone but is not merged locally", async () => {
+    // The behaviour the fix must not regress, isolated to case 2: the branch
+    // reached the remote, was merged there, and its remote ref was deleted —
+    // while this clone's local `main` never moved. `git branch --merged main`
+    // does not list it, so only the remote-gone path can clean it up.
+    const wt = join(root, "wt-remote-gone");
+    await git(repo, ["worktree", "add", "--quiet", "-b", "feature/gone", wt]);
+    await writeFile(join(wt, "gone.ts"), "export const gone = true;\n");
+    await git(wt, ["add", "-A"]);
+    await git(wt, ["commit", "--quiet", "-m", "shipped work"]);
+    await git(wt, ["push", "--quiet", "-u", "origin", "feature/gone"]);
+
+    // Land and delete the branch from a different clone, so `repo`'s local
+    // main stays behind and learns about it only through `fetch --prune`.
+    const elsewhere = join(root, "elsewhere");
+    await git(root, ["clone", "--quiet", origin, elsewhere]);
+    await git(elsewhere, ["config", "user.email", "test@example.com"]);
+    await git(elsewhere, ["config", "user.name", "Integration Test"]);
+    await git(elsewhere, ["merge", "--quiet", "--no-ff", "-m", "merge", "origin/feature/gone"]);
+    await git(elsewhere, ["push", "--quiet", "origin", "main"]);
+    await git(elsewhere, ["push", "--quiet", "origin", "--delete", "feature/gone"]);
+
+    // Preconditions: local main has not moved, and the branch was pushed.
+    const merged_locally = await git(repo, ["branch", "--merged", "main"]);
+    expect(merged_locally).not.toContain("feature/gone");
+    expect((await git(repo, ["config", "--get", "branch.feature/gone.remote"])).trim()).toBe(
+      "origin",
+    );
+    await age_out(wt);
+
+    await sweep_stale_worktrees(registry_for(repo) as never);
+
+    expect(existsSync(wt)).toBe(false);
+  });
+
+  it("does not sweep a worktree younger than the grace period", async () => {
+    // Same setup as the test above, minus the age_out() call. Everything the
+    // sweep looks at says "stale"; only the worktree's mtime says otherwise.
+    const wt = join(root, "wt-young");
+    await git(repo, ["worktree", "add", "--quiet", "-b", "feature/young", wt]);
+    await writeFile(join(wt, "young.ts"), "export const young = true;\n");
+    await git(wt, ["add", "-A"]);
+    await git(wt, ["commit", "--quiet", "-m", "shipped work"]);
+    await git(wt, ["push", "--quiet", "-u", "origin", "feature/young"]);
+
+    await git(repo, ["merge", "--quiet", "--no-ff", "-m", "merge", "feature/young"]);
+    await git(repo, ["push", "--quiet", "origin", "main"]);
+    await git(repo, ["push", "--quiet", "origin", "--delete", "feature/young"]);
+
+    await sweep_stale_worktrees(registry_for(repo) as never);
+
+    expect(existsSync(wt)).toBe(true);
+    expect(await branch_exists(repo, "feature/young")).toBe(true);
+  });
+
+  it("never deletes a branch git reports as not fully merged", async () => {
+    // Pushed once, then the remote branch was deleted without ever landing —
+    // an abandoned PR. The remote ref is genuinely gone, so case 2 fires, but
+    // the branch still carries commits that exist nowhere else.
+    const wt = join(root, "wt-unmerged");
+    await git(repo, ["worktree", "add", "--quiet", "-b", "feature/unmerged", wt]);
+    await writeFile(join(wt, "unmerged.ts"), "export const unmerged = true;\n");
+    await git(wt, ["add", "-A"]);
+    await git(wt, ["commit", "--quiet", "-m", "work nobody merged"]);
+    await git(wt, ["push", "--quiet", "-u", "origin", "feature/unmerged"]);
+    await git(repo, ["push", "--quiet", "origin", "--delete", "feature/unmerged"]);
+    await age_out(wt);
+
+    // Precondition: the branch is not an ancestor of main, which is exactly
+    // the state `git branch -d` refuses to delete. (`branch -d` itself cannot
+    // be asked yet — git blocks it while a worktree has the branch checked
+    // out, which is why the old code only heard "not fully merged" *after*
+    // it had already removed the worktree.)
+    await expect(
+      git(repo, ["merge-base", "--is-ancestor", "refs/heads/feature/unmerged", "main"]),
+    ).rejects.toThrow();
+
+    await sweep_stale_worktrees(registry_for(repo) as never);
+
+    expect(existsSync(wt)).toBe(true);
+    expect(await branch_exists(repo, "feature/unmerged")).toBe(true);
+  });
+
+  it("post-merge cleanup leaves a locked worktree alone", async () => {
+    // cleanup_after_merge has positive evidence the PR landed, but a lock is
+    // an explicit "something is still running in here" from whoever took it.
+    const wt = join(root, "wt-merged-locked");
+    await git(repo, ["worktree", "add", "--quiet", "-b", "feature/locked-merge", wt]);
+    await writeFile(join(wt, "landed.ts"), "export const landed = true;\n");
+    await git(wt, ["add", "-A"]);
+    await git(wt, ["commit", "--quiet", "-m", "work"]);
+    await git(repo, ["merge", "--quiet", "--no-ff", "-m", "merge", "feature/locked-merge"]);
+    await git(repo, ["worktree", "lock", wt, "--reason", "builder still running"]);
+
+    const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await cleanup_after_merge(repo, "feature/locked-merge");
+      expect(existsSync(wt)).toBe(true);
+      expect(await branch_exists(repo, "feature/locked-merge")).toBe(true);
+      // The lock must be read as a skip, not discovered as a removal failure —
+      // otherwise every locked worktree is a Sentry event.
+      expect(
+        errors.mock.calls.map((c) => String(c[0])).filter((l) => l.includes("Failed to remove")),
+      ).toEqual([]);
+    } finally {
+      errors.mockRestore();
+      await git(repo, ["worktree", "unlock", wt]);
+    }
+  });
+
+  it("post-merge cleanup leaves a locked .claude/worktrees directory alone", async () => {
+    const claude_dir = join(repo, ".claude", "worktrees");
+    await mkdir(claude_dir, { recursive: true });
+    const wt = join(claude_dir, "agent-341-locked");
+    await git(repo, ["worktree", "add", "--quiet", "-b", "feature/341-locked", wt]);
+    await writeFile(join(wt, "landed.ts"), "export const landed = true;\n");
+    await git(wt, ["add", "-A"]);
+    await git(wt, ["commit", "--quiet", "-m", "work"]);
+    await git(repo, ["worktree", "lock", wt, "--reason", "builder still running"]);
+
+    const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await cleanup_after_merge(repo, "feature/341-locked");
+      expect(existsSync(wt)).toBe(true);
+      expect(
+        errors.mock.calls.map((c) => String(c[0])).filter((l) => l.includes("Failed to remove")),
+      ).toEqual([]);
+    } finally {
+      errors.mockRestore();
+      await git(repo, ["worktree", "unlock", wt]);
+    }
+  });
+
+  it("post-merge cleanup does not remove a .claude/ worktree checked out on another branch", async () => {
+    // Slug matching is a substring test: cleaning up "feature/12" must not
+    // reach into the live worktree for "feature/123".
+    const claude_dir = join(repo, ".claude", "worktrees");
+    await mkdir(claude_dir, { recursive: true });
+    const neighbour = join(claude_dir, "agent-123-neighbour");
+    await git(repo, ["worktree", "add", "--quiet", "-b", "feature/123-neighbour", neighbour]);
+    await writeFile(join(neighbour, "wip.ts"), "export const wip = true;\n");
+    await git(neighbour, ["add", "-A"]);
+    await git(neighbour, ["commit", "--quiet", "-m", "in progress"]);
+
+    await cleanup_after_merge(repo, "feature/123");
+
+    expect(existsSync(neighbour)).toBe(true);
+    expect(await branch_exists(repo, "feature/123-neighbour")).toBe(true);
   });
 
   it("conservatively keeps a squash-merged worktree, whose commits are not in main", async () => {

--- a/packages/daemon/src/__tests__/worktree-cleanup.test.ts
+++ b/packages/daemon/src/__tests__/worktree-cleanup.test.ts
@@ -76,6 +76,18 @@ function make_porcelain(
 }
 
 /**
+ * An execFile-style failure: git exited non-zero, and `code` carries the exit
+ * status. The sweep distinguishes git's documented "no, and here is a clean
+ * exit code" answers from "the command blew up", so mocks have to as well.
+ */
+function git_exit(code: number, message: string): Error {
+  return Object.assign(new Error(message), { code });
+}
+
+/** Timestamps old enough that the sweep's grace period has lapsed. */
+const OLD_MTIME = Date.now() - 24 * 60 * 60 * 1000;
+
+/**
  * State of an individual worktree directory, keyed by path in `trees`.
  * Drives the git commands the protection guard runs with `cwd: <worktree>`.
  */
@@ -109,6 +121,14 @@ function setup_git_mocks(
     merged_branches?: string;
     fetch_error?: Error;
     rev_parse_missing?: string[]; // branches whose remote ref is gone
+    /**
+     * Branches with no `branch.<name>.remote` config — i.e. never pushed.
+     * Every other branch is treated as having been pushed at some point,
+     * which is what "the remote ref is gone" is supposed to mean.
+     */
+    never_pushed_branches?: string[];
+    /** Branches git does not consider an ancestor of main / origin/main. */
+    unmerged_branches?: string[];
     /** Refs that resolve for the `origin/main` / `main` base-ref probe. */
     existing_refs?: string[];
     /** Per-worktree state, keyed by absolute worktree path. */
@@ -152,6 +172,27 @@ function setup_git_mocks(
       return "";
     }
 
+    // ── "Has this branch ever been pushed?" — `git config --get branch.X.remote` ──
+
+    if (subcmd === "config") {
+      const key = args[args.length - 1] ?? "";
+      const branch = key.replace(/^branch\./, "").replace(/\.remote$/, "");
+      if (opts.never_pushed_branches?.includes(branch)) {
+        throw git_exit(1, "");
+      }
+      return "origin\n";
+    }
+
+    // ── "Is this branch fully merged?" — `git merge-base --is-ancestor` ──
+
+    if (subcmd === "merge-base") {
+      const branch = (args[2] ?? "").replace("refs/heads/", "");
+      if (opts.unmerged_branches?.includes(branch)) {
+        throw git_exit(1, "");
+      }
+      return "";
+    }
+
     // ── Guard checks: always run with cwd set to the worktree directory ──
 
     if (subcmd === "status") {
@@ -181,7 +222,7 @@ function setup_git_mocks(
       if (args[1] === "--verify" && args[2] === "--quiet") {
         if (tree?.error) throw tree.error;
         const ref = (args[3] ?? "").replace("^{commit}", "");
-        if (!existing_refs.includes(ref)) throw new Error("exit code 1");
+        if (!existing_refs.includes(ref)) throw git_exit(1, "");
         return "abc123";
       }
 
@@ -189,7 +230,8 @@ function setup_git_mocks(
       const ref = args[2] ?? "";
       const branch = ref.replace("refs/remotes/origin/", "");
       if (opts.rev_parse_missing?.includes(branch)) {
-        throw new Error("fatal: Needed a single revision");
+        // `git rev-parse --verify` on a missing ref is a fatal, exit 128.
+        throw git_exit(128, "fatal: Needed a single revision");
       }
       return "abc123";
     }
@@ -198,8 +240,8 @@ function setup_git_mocks(
   });
 }
 
-/** Paths passed to `git worktree remove` across all mock calls. */
-function removed_worktree_paths(): string[] {
+/** Argument arrays of every `git worktree remove` call. */
+function removed_worktree_calls(): string[][] {
   return mock_exec_file.mock.calls
     .filter(
       (c: unknown[]) =>
@@ -207,7 +249,19 @@ function removed_worktree_paths(): string[] {
         (c[1] as string[])[0] === "worktree" &&
         (c[1] as string[])[1] === "remove",
     )
-    .map((c: unknown[]) => (c[1] as string[])[2] as string);
+    .map((c: unknown[]) => c[1] as string[]);
+}
+
+/** Paths passed to `git worktree remove` across all mock calls. */
+function removed_worktree_paths(): string[] {
+  return removed_worktree_calls().map((args) => args[2] as string);
+}
+
+/** Argument arrays of every `git branch` call. */
+function branch_calls(): string[][] {
+  return mock_exec_file.mock.calls
+    .filter((c: unknown[]) => (c[0] as string) === "git" && (c[1] as string[])[0] === "branch")
+    .map((c: unknown[]) => c[1] as string[]);
 }
 
 /** A registry stub exposing a single repo at `/repo`. */
@@ -228,7 +282,9 @@ function single_repo_registry() {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mock_stat.mockResolvedValue({ isDirectory: () => true });
+  // Default worktrees are old enough that the sweep's grace period has
+  // lapsed — tests that care about the grace period set their own mtime.
+  mock_stat.mockResolvedValue({ isDirectory: () => true, mtimeMs: OLD_MTIME });
   mock_readdir.mockResolvedValue([]);
   // Default: tmux not running (execFileSync throws)
   mock_exec_file_sync.mockImplementation(() => {
@@ -653,10 +709,11 @@ describe("sweep_stale_worktrees", () => {
 
     await sweep_stale_worktrees(registry as any);
 
-    // Should remove the merged worktree
+    // Should remove the merged worktree — unforced, so the removal still
+    // respects locks and a dirty tree (issue #357).
     expect(mock_exec_file).toHaveBeenCalledWith(
       "git",
-      ["worktree", "remove", "/repo/worktrees/done", "--force"],
+      ["worktree", "remove", "/repo/worktrees/done"],
       expect.objectContaining({ cwd: "/repo" }),
     );
 
@@ -698,7 +755,7 @@ describe("sweep_stale_worktrees", () => {
     // Should remove the orphaned worktree
     expect(mock_exec_file).toHaveBeenCalledWith(
       "git",
-      ["worktree", "remove", "/repo/worktrees/orphan", "--force"],
+      ["worktree", "remove", "/repo/worktrees/orphan"],
       expect.objectContaining({ cwd: "/repo" }),
     );
   });
@@ -861,6 +918,9 @@ describe("sweep_stale_worktrees — unpushed/dirty guard", () => {
   });
 
   it("still removes a stale worktree whose remote branch is gone and work is pushed", async () => {
+    // Not listed by `git branch --merged main` — this clone's local main is
+    // behind — but the branch is an ancestor of origin/main, so the merge
+    // gate clears it. Case 2 is the only path that can clean this up.
     setup_git_mocks({
       worktree_list: listing(),
       merged_branches: "",
@@ -1077,6 +1137,437 @@ describe("sweep_stale_worktrees — .claude/worktrees/ guard", () => {
         .filter((l) => l.includes("Skipping"))
         .join("\n"),
     ).toContain("builder running");
+  });
+});
+
+// ── Issue #357: "no remote ref" is not evidence a branch is finished ──
+
+describe("sweep_stale_worktrees — never-pushed branches", () => {
+  const WT = "/repo/worktrees/fresh";
+  let log_spy: ReturnType<typeof vi.spyOn>;
+
+  function listing(): string {
+    return make_porcelain(
+      { path: "/repo", branch: "refs/heads/main" },
+      { path: WT, branch: "refs/heads/feature/fresh" },
+    );
+  }
+
+  function skip_logs(): string {
+    return log_spy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((line) => line.includes("Skipping"))
+      .join("\n");
+  }
+
+  beforeEach(() => {
+    log_spy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  it("never sweeps a branch with no upstream ever configured", async () => {
+    // The root cause: a branch that has never been pushed has no
+    // refs/remotes/origin/<branch> either, so the old code called it "remote
+    // gone" and destroyed it.
+    setup_git_mocks({
+      worktree_list: listing(),
+      merged_branches: "",
+      rev_parse_missing: ["feature/fresh"],
+      never_pushed_branches: ["feature/fresh"],
+      trees: { [WT]: { status: "", upstream: undefined, unpushed: 0 } },
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(removed_worktree_paths()).not.toContain(WT);
+    expect(skip_logs()).toContain("never been pushed");
+  });
+
+  it("never sweeps a never-pushed branch even when it is merged and clean", async () => {
+    // Nothing about the branch says "in use": it sits on main, the tree is
+    // clean, there is nothing unpushed. It is still off-limits, because that
+    // is also what a worktree looks like the second an agent is handed it.
+    setup_git_mocks({
+      worktree_list: listing(),
+      merged_branches: "  feature/fresh\n",
+      rev_parse_missing: ["feature/fresh"],
+      never_pushed_branches: ["feature/fresh"],
+      trees: { [WT]: { status: "", upstream: undefined, unpushed: 0 } },
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(removed_worktree_paths()).not.toContain(WT);
+  });
+
+  it("never sweeps a never-pushed branch no matter how old the worktree is", async () => {
+    // "at any age" — the grace period is a second line of defence, not this one.
+    mock_stat.mockResolvedValue({ isDirectory: () => true, mtimeMs: 0 });
+    setup_git_mocks({
+      worktree_list: listing(),
+      merged_branches: "  feature/fresh\n",
+      rev_parse_missing: ["feature/fresh"],
+      never_pushed_branches: ["feature/fresh"],
+      trees: { [WT]: { status: "", upstream: undefined, unpushed: 0 } },
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(removed_worktree_paths()).not.toContain(WT);
+  });
+
+  it("never deletes the branch of a never-pushed worktree", async () => {
+    setup_git_mocks({
+      worktree_list: listing(),
+      merged_branches: "  feature/fresh\n",
+      rev_parse_missing: ["feature/fresh"],
+      never_pushed_branches: ["feature/fresh"],
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(branch_calls().filter((args) => args[1] === "-d" || args[1] === "-D")).toEqual([]);
+  });
+
+  it("logs the never-pushed skip with the worktree path and branch", async () => {
+    setup_git_mocks({
+      worktree_list: listing(),
+      merged_branches: "  feature/fresh\n",
+      rev_parse_missing: ["feature/fresh"],
+      never_pushed_branches: ["feature/fresh"],
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(skip_logs()).toContain(WT);
+    expect(skip_logs()).toContain("feature/fresh");
+  });
+
+  it("skips the worktree when the upstream-config check errors (fail-safe)", async () => {
+    // `git config --get` exits 1 for "not set". Any other failure means we do
+    // not know, and not knowing is not a licence to delete.
+    setup_git_mocks({
+      worktree_list: listing(),
+      merged_branches: "  feature/fresh\n",
+      rev_parse_missing: ["feature/fresh"],
+    });
+    const inner = mock_exec_file.getMockImplementation();
+    mock_exec_file.mockImplementation((cmd: string, args: string[], exec_opts: unknown) => {
+      if (cmd === "git" && args[0] === "config") throw git_exit(128, "fatal: bad config line");
+      return inner?.(cmd, args, exec_opts);
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(removed_worktree_paths()).not.toContain(WT);
+  });
+
+  it("does not sweep a .claude/ worktree whose merged branch was never pushed", async () => {
+    mock_readdir.mockImplementation(async (dir: string) =>
+      dir.includes(".claude/worktrees") ? [{ name: "agent-fresh", isDirectory: () => true }] : [],
+    );
+    setup_git_mocks({
+      worktree_list: make_porcelain({ path: "/repo", branch: "refs/heads/main" }),
+      merged_branches: "  feature/fresh\n",
+      rev_parse_missing: ["feature/fresh"],
+      never_pushed_branches: ["feature/fresh"],
+      trees: { "/repo/.claude/worktrees/agent-fresh": { status: "", unpushed: 0 } },
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(removed_worktree_paths()).not.toContain("/repo/.claude/worktrees/agent-fresh");
+  });
+
+  it("still sweeps a branch whose upstream was configured and whose remote ref is gone", async () => {
+    // The behaviour that must not regress: pushed once, remote ref deleted.
+    setup_git_mocks({
+      worktree_list: listing(),
+      merged_branches: "",
+      rev_parse_missing: ["feature/fresh"],
+      never_pushed_branches: [], // branch.feature/fresh.remote is set
+      trees: { [WT]: { status: "", upstream: undefined, unpushed: 0 } },
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(removed_worktree_paths()).toContain(WT);
+  });
+});
+
+describe("sweep_stale_worktrees — grace period", () => {
+  const WT = "/repo/worktrees/young";
+  let log_spy: ReturnType<typeof vi.spyOn>;
+
+  function listing(): string {
+    return make_porcelain(
+      { path: "/repo", branch: "refs/heads/main" },
+      { path: WT, branch: "refs/heads/feature/young" },
+    );
+  }
+
+  /** Every mock check says "stale and safe" — only mtime differs per test. */
+  function stale_and_safe(): void {
+    setup_git_mocks({
+      worktree_list: listing(),
+      merged_branches: "  feature/young\n",
+      rev_parse_missing: ["feature/young"],
+      trees: { [WT]: { status: "", upstream: "origin/feature/young", unpushed: 0 } },
+    });
+  }
+
+  /** mtime for the worktree only; everything else stays old. */
+  function set_worktree_mtime(mtime_ms: number | undefined): void {
+    mock_stat.mockImplementation(async (path: string) => ({
+      isDirectory: () => true,
+      mtimeMs: path === WT ? mtime_ms : OLD_MTIME,
+    }));
+  }
+
+  beforeEach(() => {
+    log_spy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  it("does not sweep a worktree modified within the grace period", async () => {
+    set_worktree_mtime(Date.now() - 60_000);
+    stale_and_safe();
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(removed_worktree_paths()).not.toContain(WT);
+    expect(
+      log_spy.mock.calls
+        .map((c) => String(c[0]))
+        .filter((l) => l.includes("Skipping"))
+        .join("\n"),
+    ).toContain("grace period");
+  });
+
+  it("does not sweep a worktree just inside the 6h grace period", async () => {
+    set_worktree_mtime(Date.now() - (6 * 60 * 60 * 1000 - 60_000));
+    stale_and_safe();
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(removed_worktree_paths()).not.toContain(WT);
+  });
+
+  it("sweeps once the worktree is older than the grace period", async () => {
+    set_worktree_mtime(Date.now() - (6 * 60 * 60 * 1000 + 60_000));
+    stale_and_safe();
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(removed_worktree_paths()).toContain(WT);
+  });
+
+  it("skips a worktree whose mtime is unreadable (fail-safe)", async () => {
+    set_worktree_mtime(undefined);
+    stale_and_safe();
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(removed_worktree_paths()).not.toContain(WT);
+  });
+});
+
+describe("sweep_stale_worktrees — not-fully-merged branches", () => {
+  const WT = "/repo/worktrees/unmerged";
+  let log_spy: ReturnType<typeof vi.spyOn>;
+
+  function listing(): string {
+    return make_porcelain(
+      { path: "/repo", branch: "refs/heads/main" },
+      { path: WT, branch: "refs/heads/feature/unmerged" },
+    );
+  }
+
+  beforeEach(() => {
+    log_spy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  it("does not remove a worktree whose branch git would refuse to delete", async () => {
+    // Every other signal says "disposable": remote ref gone, tree clean,
+    // nothing ahead of its upstream. Git still says the branch is not fully
+    // merged, and that is a stop — the exact sequence in the #357 report was
+    // "Removed worktree" immediately followed by "not fully merged".
+    setup_git_mocks({
+      worktree_list: listing(),
+      merged_branches: "",
+      rev_parse_missing: ["feature/unmerged"],
+      unmerged_branches: ["feature/unmerged"],
+      trees: { [WT]: { status: "", upstream: "origin/feature/unmerged", unpushed: 0 } },
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(removed_worktree_paths()).not.toContain(WT);
+    expect(
+      log_spy.mock.calls
+        .map((c) => String(c[0]))
+        .filter((l) => l.includes("Skipping"))
+        .join("\n"),
+    ).toContain("not fully merged");
+  });
+
+  it("never escalates to `git branch -D`", async () => {
+    setup_git_mocks({
+      worktree_list: listing(),
+      merged_branches: "",
+      rev_parse_missing: ["feature/unmerged"],
+      unmerged_branches: ["feature/unmerged"],
+      branch_delete_error: new Error("error: the branch 'x' is not fully merged"),
+      trees: { [WT]: { status: "", upstream: "origin/feature/unmerged", unpushed: 0 } },
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(branch_calls().filter((args) => args[1] === "-D")).toEqual([]);
+  });
+
+  it("skips when the merge check cannot be resolved (fail-safe)", async () => {
+    setup_git_mocks({
+      worktree_list: listing(),
+      merged_branches: "  feature/unmerged\n",
+      existing_refs: [], // no main/master to compare against
+      trees: { [WT]: { status: "", upstream: "origin/feature/unmerged", unpushed: 0 } },
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    expect(removed_worktree_paths()).not.toContain(WT);
+  });
+});
+
+describe("sweep_stale_worktrees — removal is never forced", () => {
+  it("removes a stale worktree without --force", async () => {
+    const WT = "/repo/worktrees/stale";
+    setup_git_mocks({
+      worktree_list: make_porcelain(
+        { path: "/repo", branch: "refs/heads/main" },
+        { path: WT, branch: "refs/heads/feature/stale" },
+      ),
+      merged_branches: "  feature/stale\n",
+      trees: { [WT]: { status: "", upstream: "origin/feature/stale", unpushed: 0 } },
+    });
+
+    await sweep_stale_worktrees(single_repo_registry() as any);
+
+    const call = removed_worktree_calls().find((args) => args[2] === WT);
+    expect(call).toBeDefined();
+    expect(call).not.toContain("--force");
+  });
+
+  it("keeps --force on the post-merge path, where the work is known to have landed", async () => {
+    const WT = "/repo/worktrees/merged";
+    setup_git_mocks({
+      worktree_list: make_porcelain(
+        { path: "/repo", branch: "refs/heads/main" },
+        { path: WT, branch: "refs/heads/feature/merged" },
+      ),
+    });
+
+    await cleanup_after_merge("/repo", "feature/merged");
+
+    expect(removed_worktree_calls().find((args) => args[2] === WT)).toContain("--force");
+  });
+});
+
+describe("cleanup_after_merge — worktree locks", () => {
+  let log_spy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    log_spy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  function skip_logs(): string {
+    return log_spy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((line) => line.includes("Skipping"))
+      .join("\n");
+  }
+
+  it("does not remove a locked worktree found by branch name", async () => {
+    const WT = "/repo/worktrees/locked";
+    setup_git_mocks({
+      worktree_list: make_porcelain(
+        { path: "/repo", branch: "refs/heads/main" },
+        { path: WT, branch: "refs/heads/feature/locked", locked_reason: "builder running" },
+      ),
+    });
+
+    await cleanup_after_merge("/repo", "feature/locked");
+
+    expect(removed_worktree_paths()).not.toContain(WT);
+    expect(skip_logs()).toContain("builder running");
+  });
+
+  it("does not delete the branch of a locked worktree", async () => {
+    const WT = "/repo/worktrees/locked";
+    setup_git_mocks({
+      worktree_list: make_porcelain(
+        { path: "/repo", branch: "refs/heads/main" },
+        { path: WT, branch: "refs/heads/feature/locked", locked_reason: "builder running" },
+      ),
+    });
+
+    await cleanup_after_merge("/repo", "feature/locked");
+
+    expect(branch_calls().filter((args) => args[1] === "-d" || args[1] === "-D")).toEqual([]);
+  });
+
+  it("does not remove a locked .claude/ worktree", async () => {
+    const WT = "/repo/.claude/worktrees/agent-locked";
+    mock_readdir.mockImplementation(async (dir: string) =>
+      dir.includes(".claude/worktrees") ? [{ name: "agent-locked", isDirectory: () => true }] : [],
+    );
+    setup_git_mocks({
+      worktree_list: make_porcelain(
+        { path: "/repo", branch: "refs/heads/main" },
+        { path: WT, branch: "refs/heads/feature/agent-locked", locked_reason: "session live" },
+      ),
+    });
+
+    await cleanup_after_merge("/repo", "feature/agent-locked");
+
+    expect(removed_worktree_paths()).not.toContain(WT);
+    expect(skip_logs()).toContain("session live");
+  });
+
+  it("does not remove a .claude/ directory registered to a different branch", async () => {
+    // Slug matching is a substring test: "12" matches "agent-123-neighbour".
+    const WT = "/repo/.claude/worktrees/agent-123-neighbour";
+    mock_readdir.mockImplementation(async (dir: string) =>
+      dir.includes(".claude/worktrees")
+        ? [{ name: "agent-123-neighbour", isDirectory: () => true }]
+        : [],
+    );
+    setup_git_mocks({
+      worktree_list: make_porcelain(
+        { path: "/repo", branch: "refs/heads/main" },
+        { path: WT, branch: "refs/heads/feature/123-neighbour" },
+      ),
+    });
+
+    await cleanup_after_merge("/repo", "feature/12");
+
+    expect(removed_worktree_paths()).not.toContain(WT);
+  });
+
+  it("still removes an unlocked .claude/ worktree for the merged branch", async () => {
+    const WT = "/repo/.claude/worktrees/agent-shipped";
+    mock_readdir.mockImplementation(async (dir: string) =>
+      dir.includes(".claude/worktrees") ? [{ name: "agent-shipped", isDirectory: () => true }] : [],
+    );
+    setup_git_mocks({
+      worktree_list: make_porcelain(
+        { path: "/repo", branch: "refs/heads/main" },
+        { path: WT, branch: "refs/heads/feature/shipped" },
+      ),
+    });
+
+    await cleanup_after_merge("/repo", "feature/shipped");
+
+    expect(removed_worktree_paths()).toContain(WT);
   });
 });
 

--- a/packages/daemon/src/worktree-cleanup.ts
+++ b/packages/daemon/src/worktree-cleanup.ts
@@ -9,10 +9,22 @@
  *
  * The periodic sweep decides staleness from branch state alone, which cannot
  * distinguish an abandoned branch from a live one that has not been pushed
- * yet. Before removing anything it therefore consults
- * `worktree_protection_reason`, which refuses to give up a worktree holding
- * unpushed commits, uncommitted changes, or a lock — and refuses on any check
- * that errors. See issue #351.
+ * yet. Four independent guards stand between a staleness guess and an
+ * irreversible `git worktree remove`:
+ *
+ *  1. `branch_remote_state` — a branch with no upstream *ever* configured has
+ *     never reached the remote, so "no remote ref" says nothing about whether
+ *     it is finished. Those branches are off-limits at any age (#357).
+ *  2. `grace_period_reason` — a recently touched worktree directory is not
+ *     swept, whatever the branch state suggests (#357).
+ *  3. `worktree_protection_reason` — refuses to give up a worktree holding
+ *     unpushed commits, uncommitted changes, or a lock (#351).
+ *  4. `branch_merge_state` — git must confirm the branch's commits are
+ *     reachable from main before anything is removed. "Not fully merged" is a
+ *     stop, never a warning to log past (#357).
+ *
+ * Every guard fails closed: a check that errors protects the worktree. Losing
+ * an hour of agent work is far more expensive than leaking a directory.
  */
 
 import { execFile, execFileSync } from "node:child_process";
@@ -28,6 +40,23 @@ const exec = promisify(execFile);
 
 /** Timeout for git commands — generous but bounded. */
 const GIT_TIMEOUT_MS = 30_000;
+
+/**
+ * A worktree whose directory has been touched more recently than this is
+ * never swept, however stale its branch looks.
+ *
+ * The window that destroyed work in #357 was worktree creation → first push,
+ * usually minutes. Six hours covers that with room to spare while still
+ * letting the sweep reclaim genuinely abandoned trees the same day.
+ */
+const SWEEP_GRACE_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * Refs the sweep will accept as proof that a branch's commits survive its
+ * deletion, in the order they are tried. `origin/main` matters on its own:
+ * a clone whose local `main` is behind still has the merge recorded there.
+ */
+const MERGE_TARGET_REFS = ["main", "origin/main", "master", "origin/master"];
 
 // ── Session relocation ──
 
@@ -170,6 +199,31 @@ function err_msg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+/** Outcome of a git command whose non-zero exit codes are part of its answer. */
+type GitProbe = { ok: true; stdout: string } | { ok: false; code: number | null; message: string };
+
+/**
+ * Run a git command and report its exit status instead of throwing.
+ *
+ * Several of git's queries answer "no" by exiting non-zero, and the sweep has
+ * to tell that apart from "the command failed". `code` is the exit status when
+ * git ran and exited, and null when it never got that far (timeout, signal,
+ * missing binary) — the cases where no conclusion may be drawn.
+ */
+async function git_probe(cwd: string, args: string[]): Promise<GitProbe> {
+  try {
+    const { stdout } = await exec("git", args, { cwd, timeout: GIT_TIMEOUT_MS });
+    return { ok: true, stdout };
+  } catch (err) {
+    const code = (err as { code?: unknown }).code;
+    return {
+      ok: false,
+      code: typeof code === "number" ? code : null,
+      message: err_msg(err),
+    };
+  }
+}
+
 /**
  * Return the first ref in `refs` that resolves to a commit, or null if none do.
  */
@@ -231,6 +285,124 @@ async function unpushed_commits_reason(worktree_path: string): Promise<string | 
   }
 }
 
+// ── Branch state (issue #357) ──
+
+/**
+ * What the remote knows about a branch.
+ *
+ * - `present`     — `refs/remotes/origin/<branch>` still exists.
+ * - `gone`        — an upstream was configured, and the remote ref is now
+ *                   absent. The branch reached the remote and was deleted
+ *                   there, which is the only thing the sweep may read as
+ *                   "finished".
+ * - `never-pushed`— no upstream was ever configured. The branch exists only
+ *                   on this machine, so nothing about the remote can say
+ *                   whether its work is done.
+ * - `unknown`     — a check failed. Draw no conclusions.
+ */
+type BranchRemoteState = "present" | "gone" | "never-pushed" | "unknown";
+
+/**
+ * Classify a branch by what the remote knows about it.
+ *
+ * This is the root-cause fix for #357. The old check asked only whether
+ * `refs/remotes/origin/<branch>` existed, and a branch created ten minutes ago
+ * answers that question exactly like a branch whose remote was deleted after
+ * merge. `branch.<name>.remote` separates them: git writes it on the first
+ * `push -u`, so its absence means the branch has never been pushed at all.
+ */
+async function branch_remote_state(repo_path: string, branch: string): Promise<BranchRemoteState> {
+  const ref = await git_probe(repo_path, [
+    "rev-parse",
+    "--verify",
+    `refs/remotes/origin/${branch}`,
+  ]);
+  if (ref.ok) return "present";
+  // git exits 128 for a ref it cannot resolve and 1 for a quiet failure;
+  // anything else (timeout, signal) means the probe never answered.
+  if (ref.code !== 1 && ref.code !== 128) return "unknown";
+
+  const configured = await git_probe(repo_path, ["config", "--get", `branch.${branch}.remote`]);
+  if (configured.ok) {
+    return configured.stdout.trim() === "" ? "never-pushed" : "gone";
+  }
+  // `git config --get` exits 1 when the key is not set — the whole point.
+  if (configured.code === 1) return "never-pushed";
+  return "unknown";
+}
+
+/** Whether a branch's commits survive deleting the branch. */
+type BranchMergeState = "merged" | "unmerged" | "unknown";
+
+/**
+ * Ask git whether every commit on `branch` is already reachable from a merge
+ * target — the same question `git branch -d` asks before it agrees to delete.
+ *
+ * The sweep asks *before* touching the worktree. In the #357 incident the
+ * answer arrived the other way round: `Removed worktree` was logged first, and
+ * `the branch ... is not fully merged` second, by which point the only copy of
+ * the work was already gone. (git will not even run `branch -d` while a
+ * worktree has the branch checked out, so the pre-check cannot use it.)
+ */
+async function branch_merge_state(repo_path: string, branch: string): Promise<BranchMergeState> {
+  let compared_against_something = false;
+  let a_check_failed = false;
+
+  for (const ref of MERGE_TARGET_REFS) {
+    const exists = await git_probe(repo_path, [
+      "rev-parse",
+      "--verify",
+      "--quiet",
+      `${ref}^{commit}`,
+    ]);
+    if (!exists.ok) continue;
+
+    compared_against_something = true;
+    const ancestor = await git_probe(repo_path, [
+      "merge-base",
+      "--is-ancestor",
+      `refs/heads/${branch}`,
+      ref,
+    ]);
+    if (ancestor.ok) return "merged";
+    // Exit 1 is git's "no". Anything else is a failure to answer.
+    if (ancestor.code !== 1) a_check_failed = true;
+  }
+
+  if (!compared_against_something || a_check_failed) return "unknown";
+  return "unmerged";
+}
+
+/**
+ * Refuse to sweep a worktree that has been touched recently, whatever its
+ * branch state suggests.
+ *
+ * Belt and braces for anything the branch-level guards miss: the branch checks
+ * reason about history, and history says nothing about whether an agent is
+ * sitting in the directory right now.
+ */
+async function grace_period_reason(worktree_path: string): Promise<string | null> {
+  let mtime_ms: number;
+  try {
+    ({ mtimeMs: mtime_ms } = await stat(worktree_path));
+  } catch {
+    // Already gone — nothing to protect, and the registration should be pruned.
+    return null;
+  }
+
+  if (typeof mtime_ms !== "number" || !Number.isFinite(mtime_ms)) {
+    return "worktree age could not be determined";
+  }
+
+  const age_ms = Date.now() - mtime_ms;
+  if (age_ms < SWEEP_GRACE_MS) {
+    const age_min = Math.max(0, Math.round(age_ms / 60_000));
+    const grace_h = SWEEP_GRACE_MS / (60 * 60 * 1000);
+    return `modified ${String(age_min)}m ago, inside the ${String(grace_h)}h grace period`;
+  }
+  return null;
+}
+
 /**
  * Decide whether a worktree still holds work that must not be destroyed.
  *
@@ -241,20 +413,16 @@ async function unpushed_commits_reason(worktree_path: string): Promise<string | 
  * disposable, we leave it alone. Losing an hour of agent work is far more
  * expensive than leaking a directory until the next sweep.
  *
- * @param locks - Lock reason by worktree path, from `git worktree list`.
- *                Presence of the path means the worktree is locked.
+ * @param index - The repo's worktree listing, for lock state.
  */
 async function worktree_protection_reason(
   worktree_path: string,
-  locks: Map<string, string | null>,
+  index: WorktreeIndex,
 ): Promise<string | null> {
-  // A lock is an explicit "do not touch" from whoever created the worktree.
-  // Detecting it here turns what used to be a `git worktree remove` failure
-  // into a logged skip, so genuine removal errors stay visible.
-  if (locks.has(worktree_path)) {
-    const reason = locks.get(worktree_path);
-    return reason ? `worktree is locked (${reason})` : "worktree is locked";
-  }
+  // Detecting the lock here turns what used to be a `git worktree remove`
+  // failure into a logged skip, so genuine removal errors stay visible.
+  const locked = lock_reason(index, worktree_path);
+  if (locked !== null) return locked;
 
   // A directory that is already gone holds nothing worth saving, and leaving
   // it registered leaks a stale entry forever.
@@ -315,17 +483,24 @@ function short_branch(ref: string): string {
  * @param repo_path - Root repo path (not the worktree itself)
  * @param worktree_path - Absolute path to the worktree directory
  * @param branch - Branch name (short form, e.g. "feature/134-auto-cleanup")
+ * @param options.force - Pass `--force` to `git worktree remove`. Appropriate
+ *   after a merge, where the work is known to have landed and leftover build
+ *   output should not block cleanup. The sweep passes false: there, `--force`
+ *   overrides git's own refusal to remove a locked or dirty tree, which is
+ *   the last line of defence between a wrong staleness guess and lost work.
  */
 export async function remove_worktree(
   repo_path: string,
   worktree_path: string,
   branch: string,
+  options: { force?: boolean } = {},
 ): Promise<boolean> {
+  const { force = true } = options;
   let removed_worktree = false;
 
   // Step 1: Remove the worktree
   try {
-    await exec("git", ["worktree", "remove", worktree_path, "--force"], {
+    await exec("git", ["worktree", "remove", worktree_path, ...(force ? ["--force"] : [])], {
       cwd: repo_path,
       timeout: GIT_TIMEOUT_MS,
     });
@@ -356,7 +531,22 @@ export async function remove_worktree(
     // Non-critical — prune is housekeeping
   }
 
-  // Step 3: Delete the branch (soft delete — fails if not fully merged, which is fine)
+  // Step 3: Delete the branch.
+  //
+  // Only once the worktree is actually gone: if removal was refused (locked,
+  // dirty, still in use) the branch is the last handle on that work and must
+  // outlive the failure.
+  //
+  // Always `-d`, never `-D`. Git refusing with "not fully merged" means the
+  // branch holds commits reachable from nowhere else, and this function is
+  // best-effort cleanup — it has no standing to overrule that.
+  if (!removed_worktree) {
+    console.log(
+      `[worktree-cleanup] Keeping branch ${branch}: its worktree ${worktree_path} was not removed`,
+    );
+    return removed_worktree;
+  }
+
   try {
     await exec("git", ["branch", "-d", branch], {
       cwd: repo_path,
@@ -377,6 +567,71 @@ export async function remove_worktree(
   return removed_worktree;
 }
 
+// ── Worktree index ──
+
+/**
+ * What `git worktree list` knows about a repo, keyed by path.
+ *
+ * Both cleanup paths need the same two facts about a directory before they
+ * touch it — is it locked, and which branch is checked out in it — so both
+ * read them from one listing.
+ */
+interface WorktreeIndex {
+  /** Lock reason by path. Presence of the key means the worktree is locked. */
+  locks: Map<string, string | null>;
+  /** Short branch name by worktree path. */
+  branch_by_path: Map<string, string>;
+  /** Worktree path by short branch name. */
+  path_by_branch: Map<string, string>;
+}
+
+function index_worktrees(entries: WorktreeEntry[]): WorktreeIndex {
+  const index: WorktreeIndex = {
+    locks: new Map(),
+    branch_by_path: new Map(),
+    path_by_branch: new Map(),
+  };
+
+  for (const entry of entries) {
+    if (entry.locked) index.locks.set(entry.path, entry.locked_reason);
+    if (entry.branch) {
+      const branch = short_branch(entry.branch);
+      index.branch_by_path.set(entry.path, branch);
+      if (!index.path_by_branch.has(branch)) index.path_by_branch.set(branch, entry.path);
+    }
+  }
+
+  return index;
+}
+
+/** Read the repo's worktree listing. Returns an empty index if git fails. */
+async function load_worktree_index(repo_path: string): Promise<WorktreeIndex> {
+  try {
+    const { stdout } = await exec("git", ["worktree", "list", "--porcelain"], {
+      cwd: repo_path,
+      timeout: GIT_TIMEOUT_MS,
+    });
+    return index_worktrees(parse_worktree_list(stdout));
+  } catch (err) {
+    console.error(`[worktree-cleanup] Failed to list worktrees in ${repo_path}: ${String(err)}`);
+    return index_worktrees([]);
+  }
+}
+
+/**
+ * A lock is an explicit "do not touch" from whoever created the worktree, and
+ * it outranks every reason either cleanup path has for removing it — including
+ * a confirmed merge, which says the *work* landed but nothing about whether a
+ * session is still living in the directory.
+ *
+ * Returns a skip reason, or null when the worktree is not locked.
+ */
+function lock_reason(index: WorktreeIndex, worktree_path: string): string | null {
+  if (!index.locks.has(worktree_path)) return null;
+  const reason = index.locks.get(worktree_path);
+  return reason ? `worktree is locked (${reason})` : "worktree is locked";
+}
+
 // ── Find worktree for a specific branch ──
 
 /**
@@ -387,23 +642,8 @@ export async function find_worktree_for_branch(
   repo_path: string,
   branch: string,
 ): Promise<string | null> {
-  try {
-    const { stdout } = await exec("git", ["worktree", "list", "--porcelain"], {
-      cwd: repo_path,
-      timeout: GIT_TIMEOUT_MS,
-    });
-
-    const entries = parse_worktree_list(stdout);
-    for (const entry of entries) {
-      if (entry.branch && short_branch(entry.branch) === branch) {
-        return entry.path;
-      }
-    }
-  } catch (err) {
-    console.error(`[worktree-cleanup] Failed to list worktrees in ${repo_path}: ${String(err)}`);
-  }
-
-  return null;
+  const index = await load_worktree_index(repo_path);
+  return index.path_by_branch.get(branch) ?? null;
 }
 
 // ── Cleanup on PR merge ──
@@ -417,17 +657,26 @@ export async function find_worktree_for_branch(
 export async function cleanup_after_merge(repo_path: string, branch: string): Promise<void> {
   console.log(`[worktree-cleanup] Cleaning up after merge of branch: ${branch}`);
 
+  const index = await load_worktree_index(repo_path);
+
   // 1. Check git worktree list for a worktree on this branch
-  const worktree_path = await find_worktree_for_branch(repo_path, branch);
-  if (worktree_path) {
-    // Relocate any sessions whose cwd is inside this worktree before removal
-    const relocated = relocate_sessions_from_path(worktree_path, repo_path);
-    if (relocated > 0) {
-      console.log(
-        `[worktree-cleanup] Relocated ${String(relocated)} session(s) from ${worktree_path}`,
-      );
+  const worktree_path = index.path_by_branch.get(branch);
+  if (worktree_path !== undefined) {
+    const locked = lock_reason(index, worktree_path);
+    if (locked !== null) {
+      // Leave the branch alone too: it is the handle on whatever the lock
+      // holder is still doing in that directory.
+      console.log(`[worktree-cleanup] Skipping ${worktree_path} [${branch}]: ${locked}`);
+    } else {
+      // Relocate any sessions whose cwd is inside this worktree before removal
+      const relocated = relocate_sessions_from_path(worktree_path, repo_path);
+      if (relocated > 0) {
+        console.log(
+          `[worktree-cleanup] Relocated ${String(relocated)} session(s) from ${worktree_path}`,
+        );
+      }
+      await remove_worktree(repo_path, worktree_path, branch);
     }
-    await remove_worktree(repo_path, worktree_path, branch);
   } else {
     console.log(`[worktree-cleanup] No git worktree found for branch: ${branch}`);
     // Still try to delete the branch even if no worktree was found
@@ -443,7 +692,7 @@ export async function cleanup_after_merge(repo_path: string, branch: string): Pr
   }
 
   // 2. Check .claude/worktrees/ for agent-created worktrees matching this branch
-  await cleanup_claude_worktrees(repo_path, branch);
+  await cleanup_claude_worktrees(repo_path, branch, index);
 }
 
 /**
@@ -451,18 +700,25 @@ export async function cleanup_after_merge(repo_path: string, branch: string): Pr
  * given branch. Agent-created worktrees follow the pattern of branch slug
  * as directory name (e.g., .claude/worktrees/agent-feature-134-auto-cleanup).
  *
- * @param sweep_locks - Supplied only by the periodic sweep. Its presence turns
- *   on the work-in-progress guard, using the map for worktree lock state.
+ * Directory names are matched by substring, which is loose enough to catch a
+ * neighbour: cleaning up "feature/12" also matches "agent-123-something". The
+ * worktree listing settles it — a directory git has registered against a
+ * different branch is never the one we were asked to clean up.
+ *
+ * @param sweep - Supplied only by the periodic sweep. Its presence turns on
+ *   the age and work-in-progress guards, and drops `--force` from the removal.
  *
  *   The post-merge path deliberately omits it: a merge event is positive
  *   evidence the work landed, whereas the sweep is only guessing. A squash
  *   merge also always leaves the local branch ahead of main, so guarding the
- *   post-merge path would disable it entirely.
+ *   post-merge path would disable it entirely. Locks are honoured either way —
+ *   they say something about the directory, not about the work.
  */
 async function cleanup_claude_worktrees(
   repo_path: string,
   branch: string,
-  sweep_locks?: Map<string, string | null>,
+  index: WorktreeIndex,
+  sweep = false,
 ): Promise<void> {
   const claude_wt_dir = join(repo_path, ".claude", "worktrees");
 
@@ -486,8 +742,28 @@ async function cleanup_claude_worktrees(
       if (entry.name.includes(branch_slug)) {
         const wt_path = join(claude_wt_dir, entry.name);
 
-        if (sweep_locks) {
-          const protection = await worktree_protection_reason(wt_path, sweep_locks);
+        const locked = lock_reason(index, wt_path);
+        if (locked !== null) {
+          console.log(`[worktree-cleanup] Skipping ${wt_path} [${branch}]: ${locked}`);
+          continue;
+        }
+
+        const registered_branch = index.branch_by_path.get(wt_path);
+        if (registered_branch !== undefined && registered_branch !== branch) {
+          console.log(
+            `[worktree-cleanup] Skipping ${wt_path} [${branch}]: name matched, but git has it checked out on ${registered_branch}`,
+          );
+          continue;
+        }
+
+        if (sweep) {
+          const young = await grace_period_reason(wt_path);
+          if (young !== null) {
+            console.log(`[worktree-cleanup] Skipping ${wt_path} [${branch}]: ${young}`);
+            continue;
+          }
+
+          const protection = await worktree_protection_reason(wt_path, index);
           if (protection !== null) {
             console.log(`[worktree-cleanup] Skipping ${wt_path} [${branch}]: ${protection}`);
             continue;
@@ -502,7 +778,7 @@ async function cleanup_claude_worktrees(
             `[worktree-cleanup] Relocated ${String(relocated)} session(s) from ${wt_path}`,
           );
         }
-        await remove_worktree(repo_path, wt_path, branch);
+        await remove_worktree(repo_path, wt_path, branch, { force: !sweep });
       }
     }
   } catch (err) {
@@ -513,9 +789,12 @@ async function cleanup_claude_worktrees(
 // ── Periodic stale worktree sweep ──
 
 /**
- * Sweep all entity repos for stale worktrees. A worktree is stale if:
- * - Its branch has been merged into main, or
- * - Its branch's remote tracking ref no longer exists
+ * Sweep all entity repos for stale worktrees. A worktree is a *candidate* if
+ * its branch has been merged into main, or its branch reached the remote and
+ * its remote tracking ref has since been deleted.
+ *
+ * Being a candidate is not sufficient — see the four guards described at the
+ * top of this file, every one of which can veto the removal.
  *
  * Designed to run periodically (e.g., hourly) as a safety net.
  */
@@ -591,12 +870,7 @@ async function sweep_repo(repo_path: string): Promise<number> {
     return 0;
   }
 
-  // Lock state by worktree path, so a locked tree becomes an explicit skip
-  // rather than a `git worktree remove --force` failure.
-  const locks = new Map<string, string | null>();
-  for (const entry of entries) {
-    if (entry.locked) locks.set(entry.path, entry.locked_reason);
-  }
+  const index = index_worktrees(entries);
 
   let cleaned = 0;
 
@@ -612,6 +886,23 @@ async function sweep_repo(repo_path: string): Promise<number> {
     // Check if this is the main working tree (same path as repo_path)
     if (entry.path === repo_path) continue;
 
+    // Guard 1 (#357): a branch that has never been pushed is new, not stale.
+    // Nothing on the remote can vouch for its commits, so nothing about the
+    // remote may be used to decide the worktree is disposable — at any age.
+    const remote_state = await branch_remote_state(repo_path, branch);
+    if (remote_state === "never-pushed") {
+      console.log(
+        `[worktree-cleanup] Skipping ${entry.path} [${branch}]: branch has never been pushed`,
+      );
+      continue;
+    }
+    if (remote_state === "unknown") {
+      console.log(
+        `[worktree-cleanup] Skipping ${entry.path} [${branch}]: could not determine remote state`,
+      );
+      continue;
+    }
+
     let stale_reason: string | null = null;
 
     // Case 1: Branch is merged into main
@@ -619,21 +910,37 @@ async function sweep_repo(repo_path: string): Promise<number> {
       stale_reason = "branch merged";
     }
 
-    // Case 2: Remote tracking ref is gone (branch deleted on remote)
-    if (stale_reason === null && (await is_remote_branch_gone(repo_path, branch))) {
+    // Case 2: The branch reached the remote and its ref has since been deleted
+    if (stale_reason === null && remote_state === "gone") {
       stale_reason = "remote gone";
     }
 
     if (stale_reason === null) continue;
 
-    // Both cases above are heuristics about whether the *work* is finished.
-    // Neither is evidence that the *worktree* is empty: a merged branch can
-    // pick up new commits at any time, and "no remote ref" is also the normal
-    // state of a branch that has simply never been pushed. Check the disk
-    // before destroying anything.
-    const protection = await worktree_protection_reason(entry.path, locks);
+    // Both cases above are heuristics about whether the *work* is finished,
+    // and neither is evidence that the *worktree* is idle: a merged branch can
+    // pick up new commits at any time. Check the disk before destroying
+    // anything.
+    const young = await grace_period_reason(entry.path);
+    if (young !== null) {
+      console.log(`[worktree-cleanup] Skipping ${entry.path} [${branch}]: ${young}`);
+      continue;
+    }
+
+    const protection = await worktree_protection_reason(entry.path, index);
     if (protection !== null) {
       console.log(`[worktree-cleanup] Skipping ${entry.path} [${branch}]: ${protection}`);
+      continue;
+    }
+
+    // Last gate: git must agree the branch's commits outlive the branch.
+    const merge_state = await branch_merge_state(repo_path, branch);
+    if (merge_state !== "merged") {
+      const detail =
+        merge_state === "unmerged"
+          ? "branch is not fully merged"
+          : "could not confirm the branch is fully merged";
+      console.log(`[worktree-cleanup] Skipping ${entry.path} [${branch}]: ${detail}`);
       continue;
     }
 
@@ -646,33 +953,29 @@ async function sweep_repo(repo_path: string): Promise<number> {
         `[worktree-cleanup] Relocated ${String(relocated)} session(s) from ${entry.path}`,
       );
     }
-    const removed = await remove_worktree(repo_path, entry.path, branch);
+    // Unforced: git's own refusal to remove a locked or dirty tree is the last
+    // thing standing between a wrong guess above and lost work.
+    const removed = await remove_worktree(repo_path, entry.path, branch, { force: false });
     if (removed) cleaned++;
   }
 
   // Also sweep .claude/worktrees/ for agent directories referencing merged
-  // branches. Guarded, for the same reason the loop above is.
+  // branches. Guarded, for the same reasons the loop above is.
+  //
+  // Checked once up front: without a .claude/worktrees/ directory this loop
+  // has nothing to do, and it would otherwise cost two git calls per merged
+  // branch on every sweep of every repo.
+  try {
+    await stat(join(repo_path, ".claude", "worktrees"));
+  } catch {
+    return cleaned;
+  }
+
   for (const branch of merged_branches) {
-    await cleanup_claude_worktrees(repo_path, branch, locks);
+    const remote_state = await branch_remote_state(repo_path, branch);
+    if (remote_state === "never-pushed" || remote_state === "unknown") continue;
+    await cleanup_claude_worktrees(repo_path, branch, index, true);
   }
 
   return cleaned;
-}
-
-/**
- * Check if a branch's remote tracking ref (origin/<branch>) no longer exists.
- * Returns true if the remote ref is gone, false if it still exists or on error.
- */
-async function is_remote_branch_gone(repo_path: string, branch: string): Promise<boolean> {
-  try {
-    await exec("git", ["rev-parse", "--verify", `refs/remotes/origin/${branch}`], {
-      cwd: repo_path,
-      timeout: GIT_TIMEOUT_MS,
-    });
-    // Ref exists — not stale
-    return false;
-  } catch {
-    // Ref doesn't exist — remote branch is gone
-    return true;
-  }
 }


### PR DESCRIPTION
## The defect

`is_remote_branch_gone()` asked one question — does `refs/remotes/origin/<branch>` exist? — and read "no" as "this branch was merged and its remote was deleted". A branch created minutes ago and not yet pushed answers identically. Case 2 of the sweep then called `remove_worktree()`, which ran `git worktree remove --force` and deleted the branch.

The exposure window was worktree creation → first push: exactly when there is unpushed work and nothing on the remote to recover from. The 2026-08-18 daemon.log has the signature — `Removed worktree` followed by `the branch ... is not fully merged`. Git knew the commits were unique; it was asked too late to matter.

## The fix

Four guards now stand between a staleness guess and an irreversible removal, each failing closed:

1. **`branch_remote_state`** — the root cause. `branch.<name>.remote` is written on the first `push -u`, so its absence means the branch has never reached the remote at all. Those branches are never swept, at any age. `refs/remotes/origin/<branch>` present → `present`; absent but configured → `gone` (the only state the sweep may read as "finished"); absent and unconfigured → `never-pushed`; any probe that fails to answer → `unknown`, which also stops the sweep.
2. **`grace_period_reason`** — a worktree whose directory mtime is younger than `SWEEP_GRACE_MS` (6h) is never swept. An unreadable mtime protects it.
3. **`worktree_protection_reason`** — unchanged from #351 (unpushed commits, dirty tree, lock).
4. **`branch_merge_state`** — git must confirm the branch's commits are reachable from `main` / `origin/main` / `master` / `origin/master` *before* anything is removed. "Not fully merged" is a stop. The sweep never escalates to `git branch -D`. (`git branch -d` cannot be used as the pre-check — git refuses to run it while a worktree has the branch checked out, which is precisely why the old code only heard the answer after removing the worktree.)

Two supporting changes:

- **The stale path drops `--force`.** Force is right after a confirmed merge; on the stale path it overrides git's own refusal to remove a locked or dirty tree, which is the last line of defence behind a wrong guess. `remove_worktree` also no longer deletes the branch when the worktree removal failed — the branch is the last handle on that work.
- **The post-merge path respects locks** (issue item 5). It matched `.claude/worktrees/` directories by branch slug with no lock check, so it could remove a locked worktree, and a substring match could reach a neighbour (`feature/12` matches `agent-123-something`). Both cleanup paths now read lock state and checked-out branch from a single `git worktree list --porcelain` index; a directory git has registered against a different branch is skipped.

## Non-regression

A worktree whose branch **was** pushed and whose remote ref is now genuinely gone is still cleaned. Two real-git integration tests cover it: one where the merge is visible in the local `main`, and one where the branch was merged and deleted from another clone so only `origin/main` and case 2 can see it.

## Deliberate behaviour change

A worktree on a branch that was never pushed is no longer swept even when it is merged, clean and old — the acceptance criterion is "never swept, at any age", and that state is indistinguishable from a worktree an agent was handed seconds ago. The integration test that previously asserted the opposite (`still removes a genuinely stale worktree: merged, clean, nothing unpushed`) is inverted and documented. The cost is a leaked directory; the alternative cost was the agent's work.

## Tests

Written first and observed red against the current implementation — 20 of the new assertions failed before the fix. `1323 → 1351` passing, 71 files, whole monorepo green, biome clean, typecheck clean.

Every acceptance-criteria bullet has a test:

| Criterion | Coverage |
|---|---|
| Never-pushed branch never swept, at any age | 4 unit + 2 integration (worktree explicitly aged out past the grace period) |
| Pushed branch, remote ref gone → still cleaned | 1 unit + 2 integration (merged locally; merged only on `origin/main`) |
| Worktree younger than the grace period not swept | 4 unit (inside/outside/boundary/unreadable mtime) + 1 integration |
| Not-fully-merged branch never deleted | 3 unit (incl. "never runs `git branch -D`") + 1 integration |
| Stale path does not force-remove | 2 unit (unforced on sweep, forced on post-merge) |
| Post-merge path respects locks | 4 unit + 3 integration |
| Fixture repo with a never-pushed branch | The whole integration file drives real `git` against real temp repos |

## Out of scope

Worth a follow-up, not touched here: agent worktrees are still not locked at creation (`create_worktree` in `actions.ts` does not `git worktree lock`), which is why the unlocked ones were the ones that died. And the wrong-repo worktree dispatch bug named in the issue is a different subsystem.

Closes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)
