### PR TITLE
fix(daemon): lock agent worktrees at creation

### DIFF
--- a/packages/daemon/src/__tests__/actions.test.ts
+++ b/packages/daemon/src/__tests__/actions.test.ts
@@ -286,6 +286,58 @@ describe("create_worktree", () => {
 
     await expect(create_worktree(feature, config)).rejects.toThrow("permission denied");
   });
+
+  it("locks the new worktree with a reason naming the owning issue", async () => {
+    exec_mock_impl = async () => ({ stdout: "", stderr: "" });
+
+    await create_worktree(make_feature({ githubIssue: 570 }), make_entity_config());
+
+    const git_args = exec_calls.filter((c) => c.command === "git").map((c) => c.args);
+    const add_at = git_args.findIndex((a) => a[0] === "worktree" && a[1] === "add");
+    const lock_at = git_args.findIndex((a) => a[0] === "worktree" && a[1] === "lock");
+
+    expect(git_args[lock_at]).toEqual([
+      "worktree",
+      "lock",
+      "/repos/test-repo/worktrees/42-widget",
+      "--reason",
+      "issue-570 active build",
+    ]);
+    // The window between creating and locking is exactly the window #357
+    // destroyed work in, so the order is part of the contract.
+    expect(lock_at).toBeGreaterThan(add_at);
+  });
+
+  it("still returns the worktree path when locking fails", async () => {
+    // Best-effort: a repo on a git old enough to reject the flag, or a tree
+    // already locked, must not abort the build the worktree was created for.
+    exec_mock_impl = async (_cmd, args) => {
+      if (args[0] === "worktree" && args[1] === "lock") {
+        throw new Error("fatal: '/repos/test-repo/worktrees/42-widget' is already locked");
+      }
+      return { stdout: "", stderr: "" };
+    };
+
+    const result = await create_worktree(make_feature(), make_entity_config());
+
+    expect(result).toBe("/repos/test-repo/worktrees/42-widget");
+  });
+
+  it("locks the worktree even when it already existed", async () => {
+    exec_mock_impl = async (_cmd, args) => {
+      if (args[0] === "worktree" && args[1] === "add") {
+        throw new Error("fatal: '/repos/test-repo/worktrees/42-widget' already exists");
+      }
+      return { stdout: "", stderr: "" };
+    };
+
+    await create_worktree(make_feature(), make_entity_config());
+
+    const lock_call = exec_calls.find(
+      (c) => c.command === "git" && c.args[0] === "worktree" && c.args[1] === "lock",
+    );
+    expect(lock_call).toBeDefined();
+  });
 });
 
 describe("cleanup_worktree", () => {
@@ -373,6 +425,50 @@ describe("cleanup_worktree", () => {
         tags: { module: "actions", action: "cleanup_worktree" },
       }),
     );
+  });
+
+  it("unlocks before removing, so a locked worktree is still removable", async () => {
+    exec_mock_impl = async () => ({ stdout: "", stderr: "" });
+
+    await cleanup_worktree(
+      make_feature({ worktreePath: "/repos/test-repo/worktrees/42-widget" }),
+      make_entity_config(),
+    );
+
+    const git_args = exec_calls.filter((c) => c.command === "git").map((c) => c.args);
+    const unlock_at = git_args.findIndex((a) => a[0] === "worktree" && a[1] === "unlock");
+    const remove_at = git_args.findIndex((a) => a[0] === "worktree" && a[1] === "remove");
+
+    expect(git_args[unlock_at]).toEqual([
+      "worktree",
+      "unlock",
+      "/repos/test-repo/worktrees/42-widget",
+    ]);
+    expect(unlock_at).toBeGreaterThanOrEqual(0);
+    expect(unlock_at).toBeLessThan(remove_at);
+  });
+
+  it("removes the worktree even when the unlock fails", async () => {
+    // `git worktree unlock` errors on a tree that was never locked. That is
+    // the common case for worktrees created before this change shipped.
+    exec_mock_impl = async (_cmd, args) => {
+      if (args[0] === "worktree" && args[1] === "unlock") {
+        throw new Error("fatal: '/repos/test-repo/worktrees/42-widget' is not locked");
+      }
+      return { stdout: "", stderr: "" };
+    };
+
+    await cleanup_worktree(
+      make_feature({ worktreePath: "/repos/test-repo/worktrees/42-widget" }),
+      make_entity_config(),
+    );
+
+    const remove_call = exec_calls.find(
+      (c) => c.command === "git" && c.args[0] === "worktree" && c.args[1] === "remove",
+    );
+    expect(remove_call).toBeDefined();
+    // git did the removal, so the rm -rf fallback must not have been reached.
+    expect(rm_calls).toHaveLength(0);
   });
 });
 

--- a/packages/daemon/src/__tests__/worktree-lock.integration.test.ts
+++ b/packages/daemon/src/__tests__/worktree-lock.integration.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Integration coverage for locking agent worktrees at creation (issue #359).
+ *
+ * Nothing here is mocked: these tests drive real `git` against real temporary
+ * repositories. A lock is only worth anything if git itself honours it, and
+ * the one thing a mocked exec cannot tell us is whether `git worktree remove`
+ * actually refuses. So we ask git.
+ *
+ * The pairing under test is:
+ *   - `create_worktree` locks, so nothing can remove the tree by accident.
+ *   - the intended cleanup paths unlock first, so a finished tree still goes.
+ */
+
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, realpath, rm, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import type { EntityConfig } from "@lobster-farm/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type FeatureData, cleanup_worktree, create_worktree } from "../actions.js";
+import { cleanup_after_merge, sweep_stale_worktrees } from "../worktree-cleanup.js";
+import { agent_lock_reason } from "../worktree-lock.js";
+
+const exec = promisify(execFile);
+
+async function git(cwd: string, args: string[]): Promise<string> {
+  const { stdout } = await exec("git", args, { cwd, timeout: 30_000 });
+  return stdout;
+}
+
+/** Backdate a directory past the sweep's grace period. */
+async function age_out(path: string): Promise<void> {
+  const when = new Date(Date.now() - 48 * 60 * 60 * 1000);
+  await utimes(path, when, when);
+}
+
+/**
+ * The lock reason git reports for a worktree, or null when it is unlocked.
+ * Read straight from porcelain rather than from our own parser, so the test
+ * fails if git's format and our expectations ever diverge.
+ */
+async function lock_reason_of(repo: string, worktree_path: string): Promise<string | null> {
+  const out = await git(repo, ["worktree", "list", "--porcelain"]);
+  for (const block of out.trim().split("\n\n")) {
+    const lines = block.trim().split("\n");
+    if (!lines.includes(`worktree ${worktree_path}`)) continue;
+    const locked = lines.find((l) => l === "locked" || l.startsWith("locked "));
+    if (locked === undefined) return null;
+    return locked === "locked" ? "" : locked.slice("locked ".length);
+  }
+  return null;
+}
+
+async function branch_exists(repo: string, branch: string): Promise<boolean> {
+  try {
+    await git(repo, ["rev-parse", "--verify", `refs/heads/${branch}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function make_feature(overrides: Partial<FeatureData> = {}): FeatureData {
+  return {
+    id: "lock-test",
+    entity: "integration",
+    githubIssue: 42,
+    title: "Add widget support",
+    branch: "feature/42-widget",
+    worktreePath: null,
+    discordWorkRoom: null,
+    activeArchetype: null,
+    prNumber: null,
+    ...overrides,
+  };
+}
+
+function config_for(repo_path: string): EntityConfig {
+  return {
+    entity: {
+      id: "integration",
+      name: "integration",
+      repos: [{ name: "repo", url: "file://origin", path: repo_path }],
+      channels: { category_id: "cat-1", list: [] },
+      memory: { path: "/tmp/lock-test-memory" },
+      secrets: { vault_name: "integration" },
+    },
+  } as EntityConfig;
+}
+
+/** Registry stub exposing a single repo, matching what the sweep consumes. */
+function registry_for(repo_path: string) {
+  return {
+    get_active: () => [
+      { entity: { id: "integration", repos: [{ path: repo_path, url: "file://origin" }] } },
+    ],
+  };
+}
+
+describe("worktree locking (real git)", () => {
+  let root: string;
+  let repo: string;
+  let origin: string;
+
+  beforeEach(async () => {
+    // realpath matters on macOS, where tmpdir() is a symlink into /private and
+    // git always reports the resolved path.
+    root = await realpath(await mkdtemp(join(tmpdir(), "wt-lock-")));
+    origin = join(root, "origin.git");
+    repo = join(root, "repo");
+
+    await git(root, ["init", "--quiet", "--bare", "--initial-branch=main", origin]);
+    await git(root, ["clone", "--quiet", origin, repo]);
+    await git(repo, ["config", "user.email", "test@example.com"]);
+    await git(repo, ["config", "user.name", "Integration Test"]);
+    await writeFile(join(repo, "README.md"), "base\n");
+    await git(repo, ["add", "-A"]);
+    await git(repo, ["commit", "--quiet", "-m", "base"]);
+    await git(repo, ["push", "--quiet", "-u", "origin", "main"]);
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  /**
+   * Take a worktree through everything the sweep reads as "finished": commit,
+   * push, merge into main, delete the remote branch, and backdate the
+   * directory past the grace period. What survives that is protected by the
+   * lock and nothing else.
+   */
+  async function land(worktree_path: string, branch: string): Promise<void> {
+    // Branch-specific content: two worktrees landing the same bytes would
+    // leave the second with nothing to commit.
+    await writeFile(join(worktree_path, "work.ts"), `export const branch = "${branch}";\n`);
+    await git(worktree_path, ["add", "-A"]);
+    await git(worktree_path, ["commit", "--quiet", "-m", `work on ${branch}`]);
+    await git(worktree_path, ["push", "--quiet", "-u", "origin", branch]);
+    await git(repo, ["merge", "--quiet", "--no-ff", "-m", `merge ${branch}`, branch]);
+    await git(repo, ["push", "--quiet", "origin", "main"]);
+    await git(repo, ["push", "--quiet", "origin", "--delete", branch]);
+    await age_out(worktree_path);
+  }
+
+  // ── create_worktree ──
+
+  describe("create_worktree", () => {
+    it("locks the worktree it creates", async () => {
+      const wt = await create_worktree(make_feature(), config_for(repo));
+
+      expect(existsSync(wt)).toBe(true);
+      expect(await lock_reason_of(repo, wt)).not.toBeNull();
+    });
+
+    it("names the owning issue in the lock reason, not a generic constant", async () => {
+      const a = await create_worktree(
+        make_feature({ githubIssue: 42, branch: "feature/42-widget" }),
+        config_for(repo),
+      );
+      const b = await create_worktree(
+        make_feature({ githubIssue: 570, branch: "feature/570-gadget" }),
+        config_for(repo),
+      );
+
+      expect(await lock_reason_of(repo, a)).toBe("issue-42 active build");
+      expect(await lock_reason_of(repo, b)).toBe("issue-570 active build");
+    });
+
+    it("falls back to the branch when the feature carries no issue number", async () => {
+      const wt = await create_worktree(
+        make_feature({ githubIssue: 0, branch: "feature/no-issue" }),
+        config_for(repo),
+      );
+
+      expect(await lock_reason_of(repo, wt)).toBe("feature/no-issue active build");
+    });
+
+    it("produces a lock git itself refuses to remove, even with --force", async () => {
+      // This is the whole point of the issue: `--force` alone is not enough to
+      // remove a locked worktree, so a stray sweep cannot destroy the tree.
+      const wt = await create_worktree(make_feature(), config_for(repo));
+
+      await expect(git(repo, ["worktree", "remove", wt, "--force"])).rejects.toThrow(/lock/i);
+      expect(existsSync(wt)).toBe(true);
+    });
+
+    it("re-locks on the already-exists path without throwing", async () => {
+      const feature = make_feature();
+      const first = await create_worktree(feature, config_for(repo));
+      await git(repo, ["worktree", "unlock", first]);
+
+      const second = await create_worktree(feature, config_for(repo));
+
+      expect(second).toBe(first);
+      expect(await lock_reason_of(repo, first)).toBe("issue-42 active build");
+    });
+  });
+
+  // ── The sweep must never unlock ──
+
+  describe("sweep_stale_worktrees", () => {
+    it("leaves a worktree locked by create_worktree alone, and leaves it locked", async () => {
+      // Two worktrees the sweep considers equally disposable — merged into
+      // main, pushed, remote ref deleted, clean, well past the grace period.
+      // The only difference is the lock, so the control proves the sweep
+      // really would have taken the other one.
+      const locked = await create_worktree(make_feature(), config_for(repo));
+      await land(locked, "feature/42-widget");
+
+      const control = join(root, "wt-control");
+      await git(repo, ["worktree", "add", "--quiet", "-b", "feature/99-control", control]);
+      await land(control, "feature/99-control");
+
+      await sweep_stale_worktrees(registry_for(repo) as never);
+
+      expect(existsSync(control)).toBe(false);
+      expect(existsSync(locked)).toBe(true);
+      // The sweep must never clear a lock — only an intended removal may.
+      expect(await lock_reason_of(repo, locked)).toBe("issue-42 active build");
+    });
+  });
+
+  // ── Intended cleanup still works ──
+
+  describe("cleanup_worktree", () => {
+    it("unlocks and removes a worktree it locked at creation", async () => {
+      const feature = make_feature();
+      const wt = await create_worktree(feature, config_for(repo));
+
+      const logs = vi.spyOn(console, "log").mockImplementation(() => {});
+      try {
+        await cleanup_worktree({ ...feature, worktreePath: wt }, config_for(repo));
+
+        expect(existsSync(wt)).toBe(false);
+        // git must have done the removal — the rm -rf fallback would hide a
+        // broken unlock behind a directory that happens to be gone.
+        const lines = logs.mock.calls.map((c) => String(c[0]));
+        expect(lines.some((l) => l.includes(`Removed worktree at ${wt}`))).toBe(true);
+        expect(lines.some((l) => l.includes("Force-removed worktree"))).toBe(false);
+      } finally {
+        logs.mockRestore();
+      }
+
+      expect(await git(repo, ["worktree", "list", "--porcelain"])).not.toContain(wt);
+    });
+  });
+
+  describe("cleanup_after_merge", () => {
+    it("unlocks and removes an agent-locked worktree whose branch merged", async () => {
+      const feature = make_feature();
+      const wt = await create_worktree(feature, config_for(repo));
+      await writeFile(join(wt, "work.ts"), "export const done = true;\n");
+      await git(wt, ["add", "-A"]);
+      await git(wt, ["commit", "--quiet", "-m", "work"]);
+      await git(repo, ["merge", "--quiet", "--no-ff", "-m", "merge", feature.branch]);
+
+      await cleanup_after_merge(repo, feature.branch);
+
+      expect(existsSync(wt)).toBe(false);
+      expect(await branch_exists(repo, feature.branch)).toBe(false);
+    });
+
+    it("unlocks and removes an agent-locked .claude/worktrees directory", async () => {
+      const claude_dir = join(repo, ".claude", "worktrees");
+      await mkdir(claude_dir, { recursive: true });
+      const wt = join(claude_dir, "agent-359-locked");
+      await git(repo, ["worktree", "add", "--quiet", "-b", "feature/359-locked", wt]);
+      await git(repo, ["worktree", "lock", wt, "--reason", agent_lock_reason("issue-359")]);
+
+      await cleanup_after_merge(repo, "feature/359-locked");
+
+      expect(existsSync(wt)).toBe(false);
+    });
+
+    it("still leaves a lock it did not place alone", async () => {
+      // #358's guarantee, unchanged: a lock reason we do not recognise is a
+      // human or an external tool saying "do not touch", and a merge is no
+      // answer to that.
+      const wt = join(root, "wt-foreign");
+      await git(repo, ["worktree", "add", "--quiet", "-b", "feature/foreign", wt]);
+      await git(repo, ["merge", "--quiet", "--no-ff", "-m", "merge", "feature/foreign"]);
+      await git(repo, ["worktree", "lock", wt, "--reason", "builder still running"]);
+
+      try {
+        await cleanup_after_merge(repo, "feature/foreign");
+
+        expect(existsSync(wt)).toBe(true);
+        expect(await branch_exists(repo, "feature/foreign")).toBe(true);
+        expect(await lock_reason_of(repo, wt)).toBe("builder still running");
+      } finally {
+        await git(repo, ["worktree", "unlock", wt]);
+      }
+    });
+  });
+});

--- a/packages/daemon/src/__tests__/worktree-lock.test.ts
+++ b/packages/daemon/src/__tests__/worktree-lock.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Unit coverage for the agent lock vocabulary (issue #359).
+ *
+ * This predicate decides whether a cleanup path may clear a lock, so its edge
+ * cases are worth pinning down: too loose and cleanup walks over a human's
+ * "do not touch"; too strict and every agent worktree leaks forever.
+ */
+
+import { describe, expect, it } from "vitest";
+import { agent_lock_reason, is_agent_lock } from "../worktree-lock.js";
+
+describe("agent_lock_reason", () => {
+  it("matches the reason format already used in the daemon logs", () => {
+    expect(agent_lock_reason("issue-570")).toBe("issue-570 active build");
+  });
+
+  it("produces reasons its own predicate recognises", () => {
+    expect(is_agent_lock(agent_lock_reason("issue-1"))).toBe(true);
+    expect(is_agent_lock(agent_lock_reason("feature/no-issue"))).toBe(true);
+  });
+});
+
+describe("is_agent_lock", () => {
+  it("rejects locks placed by anyone else", () => {
+    expect(is_agent_lock("builder still running")).toBe(false);
+    expect(is_agent_lock("agent session running")).toBe(false);
+    expect(is_agent_lock("debugging a flaky test")).toBe(false);
+  });
+
+  it("rejects a lock with no reason at all", () => {
+    expect(is_agent_lock(null)).toBe(false);
+    expect(is_agent_lock(undefined)).toBe(false);
+    expect(is_agent_lock("")).toBe(false);
+  });
+
+  it("rejects the bare marker, which identifies no owner", () => {
+    // Requiring an owner is what keeps the reason useful in `git worktree
+    // list` — and stops a generic constant from being clearable.
+    expect(is_agent_lock("active build")).toBe(false);
+    expect(is_agent_lock(" active build")).toBe(false);
+  });
+
+  it("ignores surrounding whitespace, which git may fold in", () => {
+    expect(is_agent_lock("  issue-42 active build  ")).toBe(true);
+  });
+});

--- a/packages/daemon/src/actions.ts
+++ b/packages/daemon/src/actions.ts
@@ -30,6 +30,7 @@ import { is_discord_snowflake } from "./discord.js";
 import type { DiscordBot } from "./discord.js";
 import type { BotPool } from "./pool.js";
 import * as sentry from "./sentry.js";
+import { agent_lock_reason } from "./worktree-lock.js";
 
 const exec = promisify(execFile);
 const exec_shell = promisify(execCb);
@@ -51,6 +52,19 @@ async function run(
 }
 
 // ── Git operations ──
+
+/**
+ * The lock reason recorded against a feature's worktree.
+ *
+ * Names the owning feature so `git worktree list` is self-explanatory to
+ * whoever finds a locked tree. Falls back to the branch when there is no
+ * issue number to name — an anonymous lock protects the directory but tells
+ * nobody who to ask about it.
+ */
+function worktree_lock_reason(feature: FeatureData): string {
+  const owner = feature.githubIssue > 0 ? `issue-${String(feature.githubIssue)}` : feature.branch;
+  return agent_lock_reason(owner);
+}
 
 /** Create a git worktree for a feature branch. */
 export async function create_worktree(
@@ -78,6 +92,23 @@ export async function create_worktree(
     console.log(`[actions] Worktree already exists at ${worktree_path}`);
   }
 
+  // Lock it. `git worktree remove` refuses a locked tree even with --force,
+  // so this is what stands between an active build and anything that decides
+  // the worktree looks stale (#357). Applied on the already-exists path too:
+  // a re-entered build should get its protection back.
+  //
+  // Best-effort by design — a build that could not be locked is still a build
+  // worth running, and failing here would abort the very work being protected.
+  const reason = worktree_lock_reason(feature);
+  try {
+    await run("git", ["worktree", "lock", worktree_path, "--reason", reason], repo_path);
+    console.log(`[actions] Locked worktree at ${worktree_path} (${reason})`);
+  } catch (err) {
+    console.warn(
+      `[actions] Could not lock worktree at ${worktree_path}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
   return worktree_path;
 }
 
@@ -89,6 +120,18 @@ export async function cleanup_worktree(
   if (!feature.worktreePath) return;
 
   const repo_path = expand_home(entity_config.entity.repos[0]?.path ?? ".");
+
+  // This removal was asked for, so release the lock create_worktree placed.
+  // Without it git refuses the removal below and the rm -rf fallback takes
+  // over, leaving a stale worktree registration behind.
+  try {
+    await run("git", ["worktree", "unlock", feature.worktreePath], repo_path);
+    console.log(`[actions] Unlocked worktree at ${feature.worktreePath}`);
+  } catch {
+    // git errors when a worktree was never locked, which is the normal case
+    // for trees created before this shipped. The removal below is the step
+    // whose success actually matters.
+  }
 
   try {
     await run("git", ["worktree", "remove", feature.worktreePath, "--force"], repo_path);

--- a/packages/daemon/src/worktree-cleanup.ts
+++ b/packages/daemon/src/worktree-cleanup.ts
@@ -35,6 +35,7 @@ import { expand_home } from "@lobster-farm/shared";
 import type { EntityRegistry } from "./registry.js";
 import * as sentry from "./sentry.js";
 import { sq } from "./shell.js";
+import { is_agent_lock } from "./worktree-lock.js";
 
 const exec = promisify(execFile);
 
@@ -620,9 +621,12 @@ async function load_worktree_index(repo_path: string): Promise<WorktreeIndex> {
 
 /**
  * A lock is an explicit "do not touch" from whoever created the worktree, and
- * it outranks every reason either cleanup path has for removing it — including
- * a confirmed merge, which says the *work* landed but nothing about whether a
- * session is still living in the directory.
+ * it outranks every reason the sweep has for removing it — a merged branch
+ * says the *work* landed but nothing about whether a session is still living
+ * in the directory.
+ *
+ * The one exception is our own lock on the post-merge path; see
+ * `clear_lock_for_intended_removal`.
  *
  * Returns a skip reason, or null when the worktree is not locked.
  */
@@ -630,6 +634,41 @@ function lock_reason(index: WorktreeIndex, worktree_path: string): string | null
   if (!index.locks.has(worktree_path)) return null;
   const reason = index.locks.get(worktree_path);
   return reason ? `worktree is locked (${reason})` : "worktree is locked";
+}
+
+/**
+ * The lock check for an *intended* removal — the post-merge path, which has
+ * positive evidence the PR landed.
+ *
+ * Since #359 every agent worktree is locked from the moment it is created, so
+ * honouring locks unconditionally here would mean nothing is ever cleaned up.
+ * Our own lock is a note-to-self that expires when the work lands, and this is
+ * the one place entitled to release it. Anyone else's lock still wins.
+ *
+ * Returns a skip reason, or null once the worktree is clear to remove.
+ */
+async function clear_lock_for_intended_removal(
+  repo_path: string,
+  worktree_path: string,
+  index: WorktreeIndex,
+): Promise<string | null> {
+  const locked = lock_reason(index, worktree_path);
+  if (locked === null) return null;
+  if (!is_agent_lock(index.locks.get(worktree_path))) return locked;
+
+  // Best-effort: if the unlock fails, git refuses the removal below and
+  // remove_worktree reports it — which is the correct outcome, not a reason
+  // to bypass git with an rm.
+  try {
+    await exec("git", ["worktree", "unlock", worktree_path], {
+      cwd: repo_path,
+      timeout: GIT_TIMEOUT_MS,
+    });
+    console.log(`[worktree-cleanup] Released our own lock on ${worktree_path}`);
+  } catch (err) {
+    console.log(`[worktree-cleanup] Could not unlock ${worktree_path}: ${err_msg(err)}`);
+  }
+  return null;
 }
 
 // ── Find worktree for a specific branch ──
@@ -662,7 +701,7 @@ export async function cleanup_after_merge(repo_path: string, branch: string): Pr
   // 1. Check git worktree list for a worktree on this branch
   const worktree_path = index.path_by_branch.get(branch);
   if (worktree_path !== undefined) {
-    const locked = lock_reason(index, worktree_path);
+    const locked = await clear_lock_for_intended_removal(repo_path, worktree_path, index);
     if (locked !== null) {
       // Leave the branch alone too: it is the handle on whatever the lock
       // holder is still doing in that directory.
@@ -711,8 +750,11 @@ export async function cleanup_after_merge(repo_path: string, branch: string): Pr
  *   The post-merge path deliberately omits it: a merge event is positive
  *   evidence the work landed, whereas the sweep is only guessing. A squash
  *   merge also always leaves the local branch ahead of main, so guarding the
- *   post-merge path would disable it entirely. Locks are honoured either way —
- *   they say something about the directory, not about the work.
+ *   post-merge path would disable it entirely.
+ *
+ *   Locks are honoured either way, with one exception: the post-merge path
+ *   releases the lock `create_worktree` placed on its own worktrees (#359),
+ *   which would otherwise make every agent worktree permanent.
  */
 async function cleanup_claude_worktrees(
   repo_path: string,
@@ -742,7 +784,11 @@ async function cleanup_claude_worktrees(
       if (entry.name.includes(branch_slug)) {
         const wt_path = join(claude_wt_dir, entry.name);
 
-        const locked = lock_reason(index, wt_path);
+        // The sweep is only guessing at staleness, so it honours every lock,
+        // including our own. Only the post-merge path may release one.
+        const locked = sweep
+          ? lock_reason(index, wt_path)
+          : await clear_lock_for_intended_removal(repo_path, wt_path, index);
         if (locked !== null) {
           console.log(`[worktree-cleanup] Skipping ${wt_path} [${branch}]: ${locked}`);
           continue;

--- a/packages/daemon/src/worktree-lock.ts
+++ b/packages/daemon/src/worktree-lock.ts
@@ -1,0 +1,43 @@
+/**
+ * The vocabulary of an agent build lock.
+ *
+ * `create_worktree` locks every worktree it creates, because `git worktree
+ * remove` refuses a locked tree even with `--force`. That refusal is the only
+ * thing that resisted the destructive stale sweep in #357 — every worktree it
+ * destroyed was an unlocked one.
+ *
+ * A universal lock only works if the *intended* cleanup paths can tell our own
+ * lock from someone else's. A lock we placed at creation is a note-to-self
+ * that expires the moment the work lands; a lock a human or another tool
+ * placed is a "do not touch" that outranks any evidence we have, including a
+ * confirmed merge (#358). Both halves of that distinction live here so they
+ * cannot drift apart.
+ */
+
+/**
+ * The trailing phrase that marks a lock as ours, matching the reason format
+ * already visible in the daemon logs (e.g. "issue-570 active build").
+ */
+const AGENT_LOCK_SUFFIX = " active build";
+
+/**
+ * Build the lock reason for a worktree owned by `owner`.
+ *
+ * The owner half is what makes the reason useful: "locked" alone says a tree
+ * is protected, "issue-570 active build" says which build to go and look at.
+ */
+export function agent_lock_reason(owner: string): string {
+  return `${owner}${AGENT_LOCK_SUFFIX}`;
+}
+
+/**
+ * True when a lock reason is one we placed at worktree creation.
+ *
+ * Deliberately strict about the owner half: a reason of exactly "active build"
+ * identifies nothing, so it is treated as foreign and left alone.
+ */
+export function is_agent_lock(reason: string | null | undefined): boolean {
+  if (typeof reason !== "string") return false;
+  const trimmed = reason.trim();
+  return trimmed.length > AGENT_LOCK_SUFFIX.length && trimmed.endsWith(AGENT_LOCK_SUFFIX);
+}


### PR DESCRIPTION
## Summary

`create_worktree()` created worktrees and never locked them. Locking is the only thing that resisted the destructive stale sweep documented in #357 — every worktree that sweep destroyed was an unlocked one. #358 fixed the sweep's *selection* logic; this adds the *protection* that should have made the bug impossible in the first place.

`git worktree remove` refuses a locked tree **even with `--force`** (it wants `--force --force`), so the lock is a real structural guard rather than a convention. There's a test that proves exactly that against real git.

## What changed

**`packages/daemon/src/worktree-lock.ts` (new, 42 lines)** — the shared vocabulary of an agent build lock: `agent_lock_reason(owner)` and `is_agent_lock(reason)`. Both halves live in one module so the side that writes the reason and the side that reads it cannot drift apart.

**`actions.ts`**
- `create_worktree()` locks immediately after creation, with reason `issue-570 active build` — matching the format already visible in the logs. Falls back to the branch name when the feature carries no issue number. Applied on the already-exists path too, so a re-entered build gets its protection back.
- Locking is best-effort: a failure is logged and creation continues.
- `cleanup_worktree()` unlocks before removing, so the intended cleanup still works.

**`worktree-cleanup.ts` — minimal and confined, see the note below**
- New `clear_lock_for_intended_removal()`: on the post-merge path only, releases a lock we recognise as our own, then proceeds. A lock anyone *else* placed still wins.
- Two call sites switched to it (`cleanup_after_merge`, and `cleanup_claude_worktrees` when `sweep === false`).
- **The periodic sweep is untouched.** No changes to `worktree_protection_reason`, `sweep_repo`, or any selection logic. The sweep still honours every lock, ours included.

## Why `worktree-cleanup.ts` had to be touched

The issue asked me to avoid it because #358 was open. #358 merged (`a5ebfe9`) while I was reading, so I branched off it — and it turns out the two changes collide head-on:

> #358: *"A lock … outranks every reason either cleanup path has for removing it — including a confirmed merge."*

Locking at creation makes locks **universal**. Combined with #358's absolute post-merge lock guard, the result is that **no agent worktree is ever cleaned up again** — the 80 stale worktrees in #357's discussion would grow without bound. Shipping the lock without this would have been a regression.

The reconciliation keeps both properties: our own lock is a note-to-self that expires when the work lands, and the post-merge path (which has positive evidence the PR landed) is the one place entitled to release it. A lock a human or another tool placed is still absolute. #358's own tests for that behaviour pass unmodified, and there's a new real-git test pinning it.

## Tests

`worktree-lock.integration.test.ts` (new, 10 tests) drives real `git` against temp repos, as the existing worktree tests do:
- create_worktree leaves the tree locked, read straight from `git worktree list --porcelain`
- the reason names the owning issue — two features get two different reasons; a feature without an issue number falls back to its branch
- `git worktree remove --force` genuinely fails against the resulting lock
- the sweep leaves the locked tree alone **and leaves it locked**, with an identical-but-unlocked control worktree in the same test that the sweep *does* remove
- `cleanup_worktree` unlocks and removes it — asserting git did the removal, not the `rm -rf` fallback
- `cleanup_after_merge` unlocks and removes both a plain worktree and a `.claude/worktrees/` one
- a lock we did not place still survives a merge

`worktree-lock.test.ts` (new, 6 tests) covers the predicate's edges — including that a bare `"active build"` with no owner is treated as foreign, so a generic constant could never be clearable.

`actions.test.ts` (+5 mocked tests): lock args and ordering, lock failure not failing creation, locking on the already-exists path, unlock-before-remove ordering, and removal still happening when the unlock fails.

**Full daemon suite: 1372 passed (73 files)** — 1351 before, +21 added. `tsc --noEmit` clean, `biome check` clean, `pnpm -r build` succeeds.

Each guard was verified red-first: reverting the lock line makes the sweep test fail with the worktree destroyed.

## Findings outside this issue's scope

Two things I hit while testing, neither addressed here:

1. **`create_worktree()` and `cleanup_worktree()` have no production callers.** Every daemon caller passes `repo_path` as `worktree_path`; the worktrees agents actually run in are `.claude/worktrees/agent-*`, created by Claude Code itself. So this hardens the function but does not yet lock the worktrees currently at risk. Locking those needs a different hook.

2. **`sweep_repo`'s "branch merged" case never fires for a live worktree.** `git branch --merged main` prefixes a branch checked out in another worktree with `+ `, and the parser only strips `^\* `. So `+ feature/x` never matches `merged_branches`. Case 1 is effectively dead; the #357 damage came through Case 2 ("remote gone"). This is currently protective, so I left it alone — fixing it would make the sweep *more* aggressive and belongs in its own issue with its own discussion.

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)
