### PR TITLE
fix(daemon): read CI status when branch protection is unavailable

### DIFF
--- a/packages/daemon/src/__tests__/ci-gating.test.ts
+++ b/packages/daemon/src/__tests__/ci-gating.test.ts
@@ -269,6 +269,231 @@ describe("check_ci_status", () => {
   });
 });
 
+// ── Fallback to unfiltered checks when branch protection is unavailable (#361) ──
+
+/**
+ * `gh pr checks --required` only reports checks marked required by branch
+ * protection. On repos where branch protection cannot be configured, it reports
+ * nothing even though CI is running — so `check_ci_status` must retry without
+ * `--required`. These tests route the two shapes independently.
+ */
+function route_required_and_unfiltered(
+  required: ExecRoute,
+  unfiltered: ExecRoute,
+): { calls: string[][] } {
+  const calls: string[][] = [];
+  route_exec({
+    "gh pr checks": (args, opts) => {
+      calls.push(args);
+      return args.includes("--required") ? required(args, opts) : unfiltered(args, opts);
+    },
+  });
+  return { calls };
+}
+
+/** gh's error when `--required` matches nothing (cli/cli checks.go). */
+const NO_REQUIRED_CHECKS = new Error("no required checks reported on the 'feature/test' branch");
+
+/** gh's error when the PR has no checks at all. */
+const NO_CHECKS_AT_ALL = new Error("no checks reported on the 'feature/test' branch");
+
+describe("check_ci_status — falls back to unfiltered checks (#361)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    for (const key of Object.keys(routes)) delete routes[key];
+  });
+
+  it("reports the real state when --required errors but CI exists", async () => {
+    const { calls } = route_required_and_unfiltered(
+      () => NO_REQUIRED_CHECKS,
+      () => ({
+        stdout: JSON.stringify([
+          { name: "Detect changes", state: "COMPLETED", conclusion: "SUCCESS" },
+          { name: "backend", state: "COMPLETED", conclusion: "SUCCESS" },
+          { name: "frontend", state: "COMPLETED", conclusion: "SUCCESS" },
+          { name: "gate", state: "COMPLETED", conclusion: "SUCCESS" },
+        ]),
+      }),
+    );
+
+    const result = await check_ci_status(42, "/tmp/test-repo");
+
+    expect(result).toEqual({ passed: true, pending: false, failures: [] });
+    expect(calls).toHaveLength(2);
+    expect(calls[1]).not.toContain("--required");
+    expect(calls[1]).toEqual(["pr", "checks", "42", "--json", "name,state,conclusion"]);
+  });
+
+  it("reports the real state when --required returns an empty list", async () => {
+    const { calls } = route_required_and_unfiltered(
+      () => ({ stdout: JSON.stringify([]) }),
+      () => ({
+        stdout: JSON.stringify([{ name: "backend", state: "COMPLETED", conclusion: "SUCCESS" }]),
+      }),
+    );
+
+    const result = await check_ci_status(42, "/tmp/test-repo");
+
+    expect(result).toEqual({ passed: true, pending: false, failures: [] });
+    expect(calls).toHaveLength(2);
+  });
+
+  it("reports pending when the unfiltered checks are still running", async () => {
+    const { calls } = route_required_and_unfiltered(
+      () => NO_REQUIRED_CHECKS,
+      () => ({
+        stdout: JSON.stringify([
+          { name: "Detect changes", state: "COMPLETED", conclusion: "SUCCESS" },
+          { name: "backend", state: "IN_PROGRESS", conclusion: "" },
+          { name: "frontend", state: "QUEUED", conclusion: "" },
+          { name: "gate", state: "PENDING", conclusion: "" },
+        ]),
+      }),
+    );
+
+    const result = await check_ci_status(42, "/tmp/test-repo");
+
+    expect(result).toEqual({ passed: false, pending: true, failures: [] });
+    expect(calls).toHaveLength(2);
+  });
+
+  it("reports failures from the unfiltered checks", async () => {
+    const { calls } = route_required_and_unfiltered(
+      () => NO_REQUIRED_CHECKS,
+      () => ({
+        stdout: JSON.stringify([
+          { name: "backend", state: "COMPLETED", conclusion: "FAILURE" },
+          { name: "frontend", state: "COMPLETED", conclusion: "SUCCESS" },
+          { name: "gate", state: "COMPLETED", conclusion: "TIMED_OUT" },
+        ]),
+      }),
+    );
+
+    const result = await check_ci_status(42, "/tmp/test-repo");
+
+    expect(result.passed).toBe(false);
+    expect(result.pending).toBe(false);
+    expect(result.failures).toEqual(["backend", "gate"]);
+    expect(calls).toHaveLength(2);
+  });
+
+  it("treats SKIPPED and NEUTRAL unfiltered checks as passing (partial CI must not wedge)", async () => {
+    const { calls } = route_required_and_unfiltered(
+      () => NO_REQUIRED_CHECKS,
+      () => ({
+        stdout: JSON.stringify([
+          { name: "Detect changes", state: "COMPLETED", conclusion: "SUCCESS" },
+          { name: "backend", state: "COMPLETED", conclusion: "SKIPPED" },
+          { name: "frontend", state: "COMPLETED", conclusion: "SUCCESS" },
+          { name: "gate", state: "COMPLETED", conclusion: "NEUTRAL" },
+        ]),
+      }),
+    );
+
+    const result = await check_ci_status(42, "/tmp/test-repo");
+
+    expect(result).toEqual({ passed: true, pending: false, failures: [] });
+    expect(calls).toHaveLength(2);
+  });
+
+  it("reports no CI only when the unfiltered query also reports nothing", async () => {
+    const { calls } = route_required_and_unfiltered(
+      () => NO_REQUIRED_CHECKS,
+      () => NO_CHECKS_AT_ALL,
+    );
+
+    const result = await check_ci_status(42, "/tmp/test-repo");
+
+    expect(result).toEqual({ passed: true, pending: false, failures: [] });
+    expect(calls).toHaveLength(2);
+  });
+
+  it("reports no CI when the unfiltered query returns an empty list", async () => {
+    const { calls } = route_required_and_unfiltered(
+      () => NO_REQUIRED_CHECKS,
+      () => ({ stdout: JSON.stringify([]) }),
+    );
+
+    const result = await check_ci_status(42, "/tmp/test-repo");
+
+    expect(result).toEqual({ passed: true, pending: false, failures: [] });
+    expect(calls).toHaveLength(2);
+  });
+
+  it("fails closed when the fallback query hits an infrastructure error", async () => {
+    route_required_and_unfiltered(
+      () => NO_REQUIRED_CHECKS,
+      () => new Error("HTTP 401: Bad credentials"),
+    );
+
+    const result = await check_ci_status(42, "/tmp/test-repo");
+
+    expect(result).toEqual({ passed: false, pending: true, failures: [] });
+  });
+
+  it("fails closed without falling back when the --required query hits an infrastructure error", async () => {
+    const { calls } = route_required_and_unfiltered(
+      () => new Error("API rate limit exceeded"),
+      () => ({
+        stdout: JSON.stringify([{ name: "backend", state: "COMPLETED", conclusion: "SUCCESS" }]),
+      }),
+    );
+
+    const result = await check_ci_status(42, "/tmp/test-repo");
+
+    expect(result).toEqual({ passed: false, pending: true, failures: [] });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("--required");
+  });
+
+  it("does not fall back when --required reports checks", async () => {
+    const { calls } = route_required_and_unfiltered(
+      () => ({
+        stdout: JSON.stringify([
+          { name: "required-gate", state: "COMPLETED", conclusion: "FAILURE" },
+        ]),
+      }),
+      () => ({
+        stdout: JSON.stringify([{ name: "optional", state: "COMPLETED", conclusion: "SUCCESS" }]),
+      }),
+    );
+
+    const result = await check_ci_status(42, "/tmp/test-repo");
+
+    expect(result.failures).toEqual(["required-gate"]);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("fails closed when the fallback returns unparseable output", async () => {
+    route_required_and_unfiltered(
+      () => NO_REQUIRED_CHECKS,
+      () => ({ stdout: "not json" }),
+    );
+
+    const result = await check_ci_status(42, "/tmp/test-repo");
+
+    expect(result).toEqual({ passed: false, pending: true, failures: [] });
+  });
+
+  it("passes GH_TOKEN to the fallback query too", async () => {
+    const envs: Array<Record<string, unknown>> = [];
+    route_exec({
+      "gh pr checks": (args, opts) => {
+        envs.push(opts.env as Record<string, unknown>);
+        if (args.includes("--required")) return NO_REQUIRED_CHECKS;
+        return {
+          stdout: JSON.stringify([{ name: "backend", state: "COMPLETED", conclusion: "SUCCESS" }]),
+        };
+      },
+    });
+
+    await check_ci_status(42, "/tmp/test-repo", "ghs_test_token");
+
+    expect(envs).toHaveLength(2);
+    expect(envs[1]!.GH_TOKEN).toBe("ghs_test_token");
+  });
+});
+
 // ── Webhook handler workflow_run tests ──
 
 const WEBHOOK_SECRET = "test-secret-for-ci-gating";
@@ -746,5 +971,35 @@ describe("webhook handler — CI gating on review completion", () => {
         title: expect.stringContaining("merged"),
       }),
     );
+  });
+
+  it("does NOT merge when --required reports nothing but CI is still running (#361)", async () => {
+    const merge_route = vi.fn(() => ({ stdout: "merged" }));
+
+    // Repo without branch protection: `--required` errors, but the unfiltered
+    // query shows four real jobs, one of them still executing.
+    const { discord } = await trigger_review_completion(
+      (args) => {
+        if (args.includes("--required")) {
+          return new Error("no required checks reported on the 'feature/test' branch");
+        }
+        return {
+          stdout: JSON.stringify([
+            { name: "Detect changes", state: "COMPLETED", conclusion: "SUCCESS" },
+            { name: "backend", state: "IN_PROGRESS", conclusion: "" },
+            { name: "frontend", state: "COMPLETED", conclusion: "SUCCESS" },
+            { name: "gate", state: "QUEUED", conclusion: "" },
+          ]),
+        };
+      },
+      {},
+      {
+        "gh pr merge": merge_route,
+        "gh repo view": () => ({ stdout: "test-org/lobster-farm" }),
+      },
+    );
+
+    expect(merge_route).not.toHaveBeenCalled();
+    expect(discord.send_to_entity).not.toHaveBeenCalled();
   });
 });

--- a/packages/daemon/src/review-utils.ts
+++ b/packages/daemon/src/review-utils.ts
@@ -786,13 +786,89 @@ export interface CICheckStatus {
   failures: string[];
 }
 
+interface GhCheck {
+  name: string;
+  state: string;
+  conclusion: string;
+}
+
+/**
+ * Outcome of a single `gh pr checks` query.
+ *
+ * `none` means gh answered "nothing matches this query" — either an empty JSON
+ * array or the non-zero exit carrying "no [required] checks reported on the
+ * 'x' branch". `error` means we never got an answer (auth, rate limit, network).
+ */
+type ChecksQuery = { kind: "checks"; checks: GhCheck[] } | { kind: "none" } | { kind: "error" };
+
+async function query_pr_checks(
+  pr_number: number,
+  repo_path: string,
+  env: NodeJS.ProcessEnv,
+  gh_bin: string,
+  required: boolean,
+): Promise<ChecksQuery> {
+  const args = ["pr", "checks", String(pr_number)];
+  if (required) args.push("--required");
+  args.push("--json", "name,state,conclusion");
+
+  try {
+    const { stdout } = await exec_async(gh_bin, args, {
+      cwd: repo_path,
+      env,
+      timeout: 15_000,
+    });
+    const checks = JSON.parse(stdout) as GhCheck[];
+    return checks.length === 0 ? { kind: "none" } : { kind: "checks", checks };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/no.*checks?\s+reported/i.test(msg)) return { kind: "none" };
+    return { kind: "error" };
+  }
+}
+
+/**
+ * Classify a non-empty list of checks into pass / pending / failures.
+ *
+ * SUCCESS, NEUTRAL and SKIPPED all count as passing — our workflows use change
+ * detection, so a frontend-only PR legitimately skips the backend job. Treating
+ * skipped as pending would wedge every partial-CI PR forever.
+ */
+function classify_checks(checks: GhCheck[]): CICheckStatus {
+  const failures: string[] = [];
+  let has_pending = false;
+
+  for (const check of checks) {
+    if (check.state === "PENDING" || check.state === "QUEUED" || check.state === "IN_PROGRESS") {
+      has_pending = true;
+    } else if (
+      check.conclusion !== "SUCCESS" &&
+      check.conclusion !== "NEUTRAL" &&
+      check.conclusion !== "SKIPPED"
+    ) {
+      failures.push(check.name);
+    }
+  }
+
+  return {
+    passed: failures.length === 0 && !has_pending,
+    pending: has_pending,
+    failures,
+  };
+}
+
 /**
  * Query the CI check status for a PR.
  *
- * Uses `gh pr checks` to get the current state of all status checks.
- * Returns whether all checks passed, any are pending, or which ones failed.
- * When no checks are configured, returns { passed: true, pending: false, failures: [] }
- * so the merge flow proceeds normally.
+ * Asks `gh pr checks --required` first — required checks are the authoritative
+ * merge gate where branch protection exists. When that reports nothing, falls
+ * back to the unfiltered list (#361): `--required` only sees checks pinned by
+ * branch protection, and private repos without GitHub Pro cannot configure
+ * branch protection at all (the API 403s), so it comes back empty on repos whose
+ * CI is running right now. Only an empty *unfiltered* list means "no CI".
+ *
+ * Fails closed on infrastructure errors — an unanswered query reports pending,
+ * never mergeable, so a rate limit or auth blip can't wave a PR through.
  */
 export async function check_ci_status(
   pr_number: number,
@@ -802,57 +878,15 @@ export async function check_ci_status(
 ): Promise<CICheckStatus> {
   const env = gh_token ? { ...process.env, GH_TOKEN: gh_token } : process.env;
 
-  try {
-    const { stdout } = await exec_async(
-      gh_bin,
-      ["pr", "checks", String(pr_number), "--required", "--json", "name,state,conclusion"],
-      { cwd: repo_path, env, timeout: 15_000 },
-    );
+  const required = await query_pr_checks(pr_number, repo_path, env, gh_bin, true);
+  if (required.kind === "error") return { passed: false, pending: true, failures: [] };
+  if (required.kind === "checks") return classify_checks(required.checks);
 
-    const checks = JSON.parse(stdout) as Array<{
-      name: string;
-      state: string;
-      conclusion: string;
-    }>;
-
-    // No checks configured — proceed with merge normally
-    if (checks.length === 0) {
-      return { passed: true, pending: false, failures: [] };
-    }
-
-    const failures: string[] = [];
-    let has_pending = false;
-
-    for (const check of checks) {
-      if (check.state === "PENDING" || check.state === "QUEUED" || check.state === "IN_PROGRESS") {
-        has_pending = true;
-      } else if (
-        check.conclusion !== "SUCCESS" &&
-        check.conclusion !== "NEUTRAL" &&
-        check.conclusion !== "SKIPPED"
-      ) {
-        failures.push(check.name);
-      }
-    }
-
-    return {
-      passed: failures.length === 0 && !has_pending,
-      pending: has_pending,
-      failures,
-    };
-  } catch (err: unknown) {
-    // `gh pr checks --required` exits non-zero when no required checks exist,
-    // with stderr like "no required checks reported". That's not an error — it
-    // means the repo has no CI configured, so the PR is mergeable.
-    const msg = err instanceof Error ? err.message : String(err);
-    if (/no.*checks?\s+reported/i.test(msg)) {
-      return { passed: true, pending: false, failures: [] };
-    }
-
-    // Genuine failure (rate limit, auth, network) — treat as pending so we
-    // don't bypass CI gates on infrastructure errors. pr-cron will retry.
-    return { passed: false, pending: true, failures: [] };
-  }
+  const all = await query_pr_checks(pr_number, repo_path, env, gh_bin, false);
+  if (all.kind === "error") return { passed: false, pending: true, failures: [] };
+  // Nothing required *and* nothing at all — the repo really has no CI.
+  if (all.kind === "none") return { passed: true, pending: false, failures: [] };
+  return classify_checks(all.checks);
 }
 
 /** Maximum number of CI fix attempts before escalating to a human (#196). */


### PR DESCRIPTION
## The bug

`check_ci_status()` asked GitHub only for **required** checks:

```
gh pr checks <n> --required --json name,state,conclusion
```

`--required` reports only checks pinned by branch protection. On a private repo without GitHub Pro, branch protection cannot be configured at all — `repos/OWNER/REPO/branches/main/protection` returns `403 "Upgrade to GitHub Pro…"`. So gh matched nothing and exited non-zero with `no required checks reported on the '<branch>' branch`, and the catch block read that as *"no CI configured, safe to merge"*:

```ts
if (/no.*checks?\s+reported/i.test(msg)) {
  return { passed: true, pending: false, failures: [] };   // ← merge away
}
```

The same PR, queried unfiltered, has four live jobs. The daemon saw zero and merged immediately. This is why #356 didn't fix it — `pending` was never `true`, because we never observed a single check.

Confirmed against gh's own source (`cli/cli` `pkg/cmd/pr/checks/checks.go` v2.87.3): `populateStatusChecks` returns `no checks reported on the 'x' branch` when the PR has nothing at all, and `no required checks reported on the 'x' branch` when `--required` filters everything out — two distinguishable answers we were collapsing into one.

## The fix

`check_ci_status` now runs two-stage:

1. Ask `--required` first — where branch protection exists, required checks are the authoritative merge gate.
2. If that reports nothing (empty JSON array **or** the `no … checks reported` non-zero exit), ask again **without** `--required` and evaluate that list.
3. Report "no CI" (`passed: true, pending: false`) only when the **unfiltered** list is also empty.
4. Infrastructure errors (auth, rate limit, network, unparseable output) on **either** query still fail closed as `pending: true` — a blip can never wave a PR through.

Conclusion semantics are untouched and now live in a named `classify_checks` helper: `SUCCESS` / `NEUTRAL` / `SKIPPED` pass, only `PENDING` / `QUEUED` / `IN_PROGRESS` pend. Our workflows use change detection, so a frontend-only PR legitimately skips the backend job; treating skipped as pending would wedge every partial-CI PR forever.

The query itself is extracted into `query_pr_checks(..., required: boolean)` returning a three-way `ChecksQuery` — `checks` / `none` / `error` — so "gh has no answer" and "gh answered: nothing" stop being the same value.

## Tests

13 new tests, all observed **red** before the fix (11 unit + 1 vacuous-guard adjustment + 1 end-to-end). Both gh output shapes are stubbed independently — the mock routes on whether `--required` is in the argv — so the fallback path is genuinely exercised rather than accidentally satisfied.

| Acceptance criterion | Test |
|---|---|
| Real state reported on a repo with CI but no branch protection | `reports the real state when --required errors but CI exists` (+ empty-list variant) |
| Running checks report `pending`, no merge | `reports pending when the unfiltered checks are still running` |
| Failing check appears in `failures` | `reports failures from the unfiltered checks` |
| `SKIPPED`/`NEUTRAL` pass — partial CI must not wedge | `treats SKIPPED and NEUTRAL unfiltered checks as passing` |
| Genuinely zero checks still `passed: true` | `reports no CI only when the unfiltered query also reports nothing` (+ empty-list variant) |
| Infra errors fail closed | `fails closed when the fallback query hits an infrastructure error`, `fails closed without falling back when the --required query hits an infrastructure error`, `fails closed when the fallback returns unparseable output` |

Plus `does not fall back when --required reports checks` (no regression where branch protection *is* configured), `passes GH_TOKEN to the fallback query too`, and an end-to-end webhook test — `does NOT merge when --required reports nothing but CI is still running (#361)` — which asserts `gh pr merge` is never invoked. That last one reproduces the production symptom directly: before the fix it failed with *"expected spy to not be called at all, but actually been called 1 times."*

Verification: `1385 passed (73 files)`, up from 1372. `pnpm typecheck` and `pnpm lint` clean.

## Follow-up found while here (not fixed — out of this issue's scope)

The **reviewer prompt** has the same blind spot on a parallel code path. `webhook-handler.ts:1687` and `pr-cron.ts:444` hand the ephemeral reviewer `gh pr checks <n> --required`, and the prompt then tells it:

> 3. PASSING required checks (all success/neutral/skipped), **or no checks configured: safe to merge if you approved.**
> - If you approved AND all required checks are passing (or none configured), merge the PR: `gh pr merge <n> --squash --delete-branch`

On these same repos that command prints "no required checks reported", so a reviewer can merge past running CI itself, without `check_ci_status` ever being consulted. Dropping `--required` from those two prompt strings is a one-line change each, but it alters reviewer instructions rather than daemon logic and there's a test asserting the exact string — worth its own issue.

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)