### PR TITLE
fix(daemon): re-review on pull_request.edited when changes were requested

### DIFF
--- a/packages/daemon/src/__tests__/webhook-handler.test.ts
+++ b/packages/daemon/src/__tests__/webhook-handler.test.ts
@@ -97,7 +97,12 @@ function make_pr_payload(
   pr_number = 42,
   repo_full_name = "test-org/lobster-farm",
   overrides: Record<string, unknown> = {},
-  options: { installation_id?: number; head_sha?: string } = {},
+  options: {
+    installation_id?: number;
+    head_sha?: string;
+    /** Top-level `changes` object GitHub sends with `pull_request.edited`. */
+    changes?: Record<string, unknown>;
+  } = {},
 ): string {
   // Default SHA is deterministic per PR so same-PR events collide by default.
   // Tests that exercise HEAD movement pass an explicit head_sha override.
@@ -126,6 +131,10 @@ function make_pr_payload(
     },
     repository: { full_name: repo_full_name },
   };
+
+  if (options.changes != null) {
+    payload.changes = options.changes;
+  }
 
   if (options.installation_id != null) {
     payload.installation = { id: options.installation_id };
@@ -1873,6 +1882,274 @@ describe("handle_github_webhook", () => {
       // reviewDecision and does not unblock auto-merge. The #311 "Round 2
       // Approved" plain-comment anomaly must not be reintroduced.
       expect(prompt).not.toContain("gh pr comment");
+    });
+  });
+
+  // ── pull_request.edited (issue #362) ──
+  //
+  // A reviewer that requests changes about the PR *description* (a missing
+  // `Closes #N`, a wrong summary) is satisfied by the builder editing the PR
+  // body. That emits `pull_request.edited` and nothing else — no push, no
+  // `synchronize`. Before #362 the handler dropped those events and the fix
+  // loop dead-ended with the work already done.
+  describe("pull_request.edited re-review (issue #362)", () => {
+    beforeEach(async () => {
+      // vi.clearAllMocks() clears calls but not implementations — restore the
+      // module default so an outcome set by one test can't leak into the next.
+      const { detect_review_outcome } = await import("../actions.js");
+      vi.mocked(detect_review_outcome).mockImplementation(async () => "approved" as never);
+    });
+
+    /** Count reviewer spawns only — the fix loop also spawns builders. */
+    function reviewer_spawns(ctx: WebhookContext): number {
+      return (ctx.session_manager as any).spawn.mock.calls.filter(
+        (call: any[]) => (call[0] as { archetype?: string } | undefined)?.archetype === "reviewer",
+      ).length;
+    }
+
+    /** Drive the most recently spawned reviewer session to completion. */
+    async function complete_review(ctx: WebhookContext): Promise<void> {
+      const spawn = (ctx.session_manager as any).spawn;
+      let idx = -1;
+      spawn.mock.calls.forEach((call: any[], i: number) => {
+        if ((call[0] as { archetype?: string } | undefined)?.archetype === "reviewer") idx = i;
+      });
+      const result = await spawn.mock.results[idx].value;
+      (ctx.session_manager as any).emit("session:completed", {
+        session_id: result.session_id,
+        exit_code: 0,
+      });
+    }
+
+    async function deliver(body: string, ctx: WebhookContext): Promise<void> {
+      const req = make_request(body, {
+        "x-github-event": "pull_request",
+        "x-hub-signature-256": sign_payload(body),
+      });
+      await handle_github_webhook(req, make_response(), ctx);
+    }
+
+    function edited_payload(
+      pr_number: number,
+      changes: Record<string, unknown> | undefined,
+      pr_overrides: Record<string, unknown> = {},
+      head_sha?: string,
+    ): string {
+      return make_pr_payload("edited", pr_number, "test-org/lobster-farm", pr_overrides, {
+        head_sha,
+        changes,
+      });
+    }
+
+    /** Let the async route_event pipeline settle before a no-op assertion. */
+    function settle(): Promise<void> {
+      return new Promise((r) => setTimeout(r, 150));
+    }
+
+    async function set_outcome(outcome: string): Promise<void> {
+      const { detect_review_outcome } = await import("../actions.js");
+      vi.mocked(detect_review_outcome).mockImplementation(async () => outcome as never);
+    }
+
+    it("spawns a fresh review when the body is edited after changes were requested", async () => {
+      await set_outcome("changes_requested");
+      const ctx = make_context();
+
+      await deliver(edited_payload(700, { body: { from: "old body" } }), ctx);
+
+      await vi.waitFor(
+        () => {
+          expect(reviewer_spawns(ctx)).toBe(1);
+        },
+        { timeout: 2000 },
+      );
+    });
+
+    it("does not spawn a review when the body is edited on an approved PR", async () => {
+      await set_outcome("approved");
+      const ctx = make_context();
+
+      await deliver(edited_payload(701, { body: { from: "old body" } }), ctx);
+      await settle();
+
+      expect(reviewer_spawns(ctx)).toBe(0);
+    });
+
+    it("treats a title-only edit the same as a body edit", async () => {
+      await set_outcome("changes_requested");
+      const ctx = make_context();
+
+      await deliver(edited_payload(702, { title: { from: "old title" } }), ctx);
+
+      await vi.waitFor(
+        () => {
+          expect(reviewer_spawns(ctx)).toBe(1);
+        },
+        { timeout: 2000 },
+      );
+    });
+
+    it("ignores a base-branch-only edit", async () => {
+      const { detect_review_outcome } = await import("../actions.js");
+      await set_outcome("changes_requested");
+      const ctx = make_context();
+
+      await deliver(edited_payload(703, { base: { ref: { from: "main" } } }), ctx);
+      await settle();
+
+      expect(reviewer_spawns(ctx)).toBe(0);
+      // Cheap guards come first — a base edit must not even cost a GitHub round-trip.
+      expect(detect_review_outcome).not.toHaveBeenCalled();
+    });
+
+    it("ignores an edited event with no changes object", async () => {
+      await set_outcome("changes_requested");
+      const ctx = make_context();
+
+      await deliver(edited_payload(704, undefined), ctx);
+      await settle();
+
+      expect(reviewer_spawns(ctx)).toBe(0);
+    });
+
+    it("ignores body edits on draft PRs", async () => {
+      await set_outcome("changes_requested");
+      const ctx = make_context();
+
+      await deliver(edited_payload(705, { body: { from: "old body" } }, { draft: true }), ctx);
+      await settle();
+
+      expect(reviewer_spawns(ctx)).toBe(0);
+    });
+
+    it("ignores body edits on closed PRs", async () => {
+      await set_outcome("changes_requested");
+      const ctx = make_context();
+
+      await deliver(
+        edited_payload(706, { body: { from: "old body" } }, { state: "closed", merged: true }),
+        ctx,
+      );
+      await settle();
+
+      expect(reviewer_spawns(ctx)).toBe(0);
+    });
+
+    it("re-reviews at most once per head SHA, however many edits arrive", async () => {
+      // The loop guard. A re-review can itself request changes again, and the
+      // builder it spawns can edit the body again — on a HEAD that never moves.
+      // Without a per-SHA cap that is an unbounded review loop.
+      await set_outcome("changes_requested");
+      const ctx = make_context();
+
+      await deliver(edited_payload(707, { body: { from: "v1" } }, {}, "sha-707-a"), ctx);
+      await vi.waitFor(
+        () => {
+          expect(reviewer_spawns(ctx)).toBe(1);
+        },
+        { timeout: 2000 },
+      );
+
+      // Let the reviewer finish. That releases the in-flight dedup entry, so
+      // the edit memory is the only thing left that can stop the next edit.
+      await complete_review(ctx);
+      await vi.waitFor(
+        () => {
+          expect(get_active_webhook_reviews().find((r) => r.pr_number === 707)?.state).toBe(
+            "completed",
+          );
+        },
+        { timeout: 2000 },
+      );
+
+      await deliver(edited_payload(707, { body: { from: "v2" } }, {}, "sha-707-a"), ctx);
+      await settle();
+
+      expect(reviewer_spawns(ctx)).toBe(1);
+    });
+
+    it("allows an edit-triggered review again once HEAD moves", async () => {
+      // The per-SHA cap must not permanently disable edit-triggered reviews —
+      // a new commit is a new review budget.
+      await set_outcome("changes_requested");
+      const ctx = make_context();
+
+      await deliver(edited_payload(708, { body: { from: "v1" } }, {}, "sha-708-a"), ctx);
+      await vi.waitFor(
+        () => {
+          expect(reviewer_spawns(ctx)).toBe(1);
+        },
+        { timeout: 2000 },
+      );
+
+      await complete_review(ctx);
+      await vi.waitFor(
+        () => {
+          expect(
+            get_active_webhook_reviews().find(
+              (r) => r.pr_number === 708 && r.head_sha === "sha-708-a",
+            )?.state,
+          ).toBe("completed");
+        },
+        { timeout: 2000 },
+      );
+
+      await deliver(edited_payload(708, { body: { from: "v2" } }, {}, "sha-708-b"), ctx);
+
+      await vi.waitFor(
+        () => {
+          expect(reviewer_spawns(ctx)).toBe(2);
+        },
+        { timeout: 2000 },
+      );
+    });
+
+    it("does not spawn a second reviewer while a review is already in flight", async () => {
+      await set_outcome("changes_requested");
+      const ctx = make_context();
+
+      await deliver(make_pr_payload("opened", 709), ctx);
+      await vi.waitFor(
+        () => {
+          expect(reviewer_spawns(ctx)).toBe(1);
+        },
+        { timeout: 2000 },
+      );
+
+      await deliver(edited_payload(709, { body: { from: "old body" } }), ctx);
+      await settle();
+
+      expect(reviewer_spawns(ctx)).toBe(1);
+    });
+
+    it("skips edited events for entities on pr_lifecycle=v2", async () => {
+      // v2 drives its whole review loop from check_suite.completed, with its
+      // own persisted state and reviewer prompt. Spawning a v1-style review
+      // from here would bypass both.
+      await set_outcome("changes_requested");
+      const registry = {
+        get_active: vi.fn().mockReturnValue([
+          {
+            entity: {
+              id: "lobster-farm",
+              pr_lifecycle: "v2",
+              repos: [
+                {
+                  name: "lobster-farm",
+                  url: "https://github.com/test-org/lobster-farm.git",
+                  path: "/tmp/test-repo",
+                },
+              ],
+            },
+          },
+        ]),
+      } as unknown as EntityRegistry;
+      const ctx = make_context({ registry });
+
+      await deliver(edited_payload(710, { body: { from: "old body" } }), ctx);
+      await settle();
+
+      expect(reviewer_spawns(ctx)).toBe(0);
     });
   });
 });

--- a/packages/daemon/src/webhook-handler.ts
+++ b/packages/daemon/src/webhook-handler.ts
@@ -85,6 +85,18 @@ export interface WebhookPR {
   user: { login: string };
   merged?: boolean;
   draft?: boolean;
+  /** "open" | "closed". Absent on payloads from older tests/fixtures. */
+  state?: string;
+}
+
+/**
+ * The `changes` object GitHub sends with `pull_request.edited`. Only the keys
+ * that actually changed are present, each carrying its previous value.
+ */
+interface WebhookPREditChanges {
+  body?: { from?: string | null };
+  title?: { from?: string | null };
+  base?: unknown;
 }
 
 /** Minimal workflow_run shape from webhook payload. */
@@ -103,6 +115,8 @@ interface WebhookPayload {
   pull_request?: WebhookPR;
   workflow_run?: WebhookWorkflowRun;
   repository?: { full_name: string };
+  /** Present on `pull_request.edited` — names which fields changed. */
+  changes?: WebhookPREditChanges;
   /** GitHub includes the installation that generated the webhook event. */
   installation?: { id: number };
 }
@@ -284,6 +298,27 @@ function find_review_for_pr(
   return completed_entry;
 }
 
+/**
+ * head_sha keys that a `pull_request.edited` event has already re-reviewed,
+ * with the timestamp we recorded them. Values are timestamps only — presence
+ * is the guard (#362).
+ *
+ * This is the loop bound. An edit-triggered review can itself request changes
+ * again, and the builder it spawns can fix the complaint by editing the body
+ * again — on a HEAD that never moves, that is an unbounded review loop. One
+ * edit-triggered review per {entity, pr, head_sha} caps it. A new commit
+ * produces a new key and therefore a fresh budget.
+ */
+const edit_triggered_reviews = new Map<string, number>();
+
+/**
+ * How long an edit-triggered review is remembered. Long enough that no fix
+ * loop can churn through it (loops turn over in minutes), short enough that
+ * a human editing a long-stalled PR still gets a review — and that the map
+ * doesn't grow without bound.
+ */
+const EDIT_REVIEW_MEMORY_MS = 6 * 60 * 60 * 1000;
+
 const REVIEW_TIMEOUT_MS = 30 * 60 * 1000;
 
 /**
@@ -310,6 +345,12 @@ function cleanup_stale_reviews(): void {
       now - review.completed_at > REVIEW_DEDUP_HOLD_MS
     ) {
       active_reviews.delete(key);
+    }
+  }
+
+  for (const [key, recorded_at] of edit_triggered_reviews) {
+    if (now - recorded_at > EDIT_REVIEW_MEMORY_MS) {
+      edit_triggered_reviews.delete(key);
     }
   }
 }
@@ -459,6 +500,22 @@ async function route_event(
     return;
   }
 
+  // A PR body/title edit is the only signal the fix loop emits when the
+  // reviewer's complaint was about the description itself (#362). It gets its
+  // own guards — see handle_pr_edited.
+  if (action === "edited") {
+    await handle_pr_edited(
+      payload.changes,
+      pr,
+      repo_full_name,
+      match.entity_id,
+      match.repo_path,
+      ctx,
+      installation_id,
+    );
+    return;
+  }
+
   // Only handle PR events that warrant a review
   const reviewable_actions = ["opened", "synchronize", "reopened", "ready_for_review"];
   if (!reviewable_actions.includes(action)) {
@@ -555,6 +612,111 @@ async function route_event(
 
   // No in-flight review for this SHA — spawn fresh.
   await spawn_review(match.entity_id, match.repo_path, repo_full_name, pr, ctx, installation_id);
+}
+
+// ── PR description edits (#362) ──
+
+/**
+ * Handle `pull_request.edited`.
+ *
+ * When a reviewer requests changes about the PR *description* — a missing
+ * `Closes #N`, a wrong summary — the builder resolves it by editing the PR
+ * body. That emits `pull_request.edited` and nothing else: no push, so no
+ * `synchronize`, so no re-review. The fix loop dead-ended with the work
+ * already done (observed on PR #691: fixed in six minutes, sat four hours).
+ *
+ * Guards, cheapest first:
+ *  1. only body/title edits are review input — a base-branch retarget is not
+ *  2. the PR must be open and out of draft
+ *  3. v1 only — v2 drives its loop from check_suite, with its own persisted
+ *     state and reviewer prompt, and spawning here would bypass both
+ *  4. one edit-triggered review per head SHA — the loop bound
+ *  5. nothing already in flight for this PR
+ *  6. the last recorded outcome must be `changes_requested` — an edit on an
+ *     approved or not-yet-reviewed PR has nothing to re-review
+ */
+async function handle_pr_edited(
+  changes: WebhookPREditChanges | undefined,
+  pr: WebhookPR,
+  repo_full_name: string,
+  entity_id: string,
+  repo_path: string,
+  ctx: WebhookContext,
+  installation_id?: string,
+): Promise<void> {
+  const tag = `pull_request.edited for #${String(pr.number)}`;
+
+  if (changes?.body === undefined && changes?.title === undefined) {
+    console.log(`[webhook] Ignoring ${tag} — no body or title change`);
+    return;
+  }
+
+  if (pr.state != null && pr.state !== "open") {
+    console.log(`[webhook] Ignoring ${tag} — PR is ${pr.state}`);
+    return;
+  }
+
+  if (pr.draft) {
+    console.log(`[webhook] Ignoring ${tag} — draft PR`);
+    return;
+  }
+
+  if (get_pr_lifecycle(ctx.registry, entity_id) === "v2") {
+    console.log(`[webhook] Ignoring ${tag} — entity ${entity_id} is on pr_lifecycle=v2`);
+    return;
+  }
+
+  const head_sha = pr.head.sha;
+  if (!head_sha) {
+    // Without a SHA there is no loop bound. Refuse rather than risk one.
+    console.log(`[webhook] Ignoring ${tag} — missing head.sha`);
+    return;
+  }
+
+  const key = review_key(entity_id, pr.number, head_sha);
+  if (edit_triggered_reviews.has(key)) {
+    console.log(
+      `[webhook] Ignoring ${tag} — an edit already triggered a review @ ${head_sha.slice(0, 7)}`,
+    );
+    return;
+  }
+
+  const existing = find_review_for_pr(entity_id, pr.number);
+  if (existing?.review.state === "in_flight") {
+    // A reviewer is running right now and will read the PR as it stands.
+    console.log(
+      `[webhook] Ignoring ${tag} — review in flight @ ${existing.review.head_sha.slice(0, 7)}`,
+    );
+    return;
+  }
+
+  let gh_token: string | undefined;
+  try {
+    gh_token = await resolve_token(ctx.github_app, installation_id);
+  } catch (err) {
+    // Fall through — detect_review_outcome falls back to the daemon's auth.
+    console.warn(`[webhook] Token resolution failed for ${tag}: ${String(err)}`);
+  }
+
+  const outcome = await detect_review_outcome(pr.number, repo_path, gh_token);
+  if (outcome !== "changes_requested") {
+    console.log(`[webhook] Ignoring ${tag} — last review outcome is "${outcome}"`);
+    return;
+  }
+
+  console.log(
+    `[webhook] ${tag} in ${entity_id} — changes were requested, re-reviewing @ ${head_sha.slice(0, 7)}`,
+  );
+
+  sentry.addBreadcrumb({
+    category: "daemon.api",
+    message: `Webhook: pull_request.edited PR #${String(pr.number)} — re-review`,
+    data: { entity: entity_id, pr_number: pr.number, head_sha },
+  });
+
+  // Record before spawning so a burst of edits can't race past the guard.
+  edit_triggered_reviews.set(key, Date.now());
+  await spawn_review(entity_id, repo_path, repo_full_name, pr, ctx, installation_id);
 }
 
 // ── Reviewer spawning ──
@@ -2052,4 +2214,5 @@ export function get_active_webhook_reviews(): Array<{
  */
 export function _reset_active_reviews_for_testing(): void {
   active_reviews.clear();
+  edit_triggered_reviews.clear();
 }


### PR DESCRIPTION
## Summary

`packages/daemon/src/webhook-handler.ts` acted only on `closed` and `synchronize`, so every `pull_request.edited` event was dropped — 52 of 52 in the daemon log.

That broke the daemon's own fix loop. When a reviewer requests changes about the PR *description* (a missing `Closes #N`, a wrong summary), the builder resolves it by editing the PR body. That emits `edited` and nothing else: no push, no `synchronize`, no re-review. The loop dead-ended silently with the work already done — on PR #691 the fix landed in six minutes and the PR then sat four hours.

`edited` now routes to a new `handle_pr_edited`, which re-reviews only when it matters.

## Guards, cheapest first

| # | Guard | Why |
|---|---|---|
| 1 | `changes.body` or `changes.title` must be present | A base-branch retarget is not review input. Rejected before any GitHub round-trip. |
| 2 | PR must be open and out of draft | Consistent with existing behaviour. |
| 3 | `pr_lifecycle=v1` only | v2 drives its whole loop from `check_suite.completed`, with its own persisted state and `build_v2_reviewer_prompt`. Spawning a v1-style review here would bypass both. All entities are on v1 today. |
| 4 | One edit-triggered review per `{entity, pr, head_sha}` | The loop bound — see below. |
| 5 | Nothing already in flight for the PR | A running reviewer already reads the PR as it stands. |
| 6 | Last recorded outcome must be `changes_requested` | An edit on an approved or not-yet-reviewed PR has nothing to re-review. Read via the existing `detect_review_outcome`. |

**Guard 4 is the loop bound.** A re-review can itself request changes again, and the builder it spawns can fix that complaint by editing the body again — on a HEAD that never moves, that is an unbounded review loop. Capping at one edit-triggered review per head SHA makes it terminate; a new commit produces a new key and therefore a fresh budget. The memory ages out after 6h in the existing `cleanup_stale_reviews` sweep, so the map stays bounded, and `_reset_active_reviews_for_testing()` clears it.

## Tests

11 new tests in `webhook-handler.test.ts`, one per acceptance-criteria bullet plus the lifecycle and in-flight cases:

- body edit after `changes_requested` → fresh review
- body edit on an approved PR → nothing
- title-only edit behaves like a body edit
- base-branch-only edit → nothing, and `detect_review_outcome` is never called
- `edited` with no `changes` object → nothing
- draft PR → nothing
- closed PR → nothing
- repeated edits on the same head SHA → exactly one review (loop guard)
- edit-triggered review is allowed again once HEAD moves
- no second reviewer while one is in flight
- `pr_lifecycle=v2` entity → nothing

Written test-first and observed red (4 positive-path failures against the unmodified handler). Each guard was then verified individually by neutering it and watching the corresponding test go red — 8 failures with all guards disabled, so no test passes vacuously.

## Verification

- `pnpm test` — daemon 1383 passed (73 files), shared 65, cli 34; 0 failures
- `pnpm typecheck` — clean across shared/daemon/cli
- `pnpm lint` (biome) — 163 files, clean

## Scope

Confined to `webhook-handler.ts` and its test file — `review-utils.ts` is untouched (PR for #361 is open against it).

Closes #362
