### PR TITLE
fix(daemon): refuse to auto-rebase branches carrying merge commits

### DIFF
--- a/packages/daemon/src/__tests__/auto-rebase.test.ts
+++ b/packages/daemon/src/__tests__/auto-rebase.test.ts
@@ -144,6 +144,8 @@ describe("attempt_auto_merge", () => {
       "git remote": () => ({ stdout: "https://github.com/test/repo.git" }),
       "git clone": () => ({ stdout: "" }),
       "git fetch": () => ({ stdout: "" }),
+      // No merge commits in origin/main..HEAD — the #367 guard lets the rebase run.
+      "git rev-list": () => ({ stdout: "" }),
       "git rebase": (args) => {
         if (args.includes("--abort")) return { stdout: "" };
         rebase_attempted = true;
@@ -171,6 +173,8 @@ describe("attempt_auto_merge", () => {
       "git remote": () => ({ stdout: "https://github.com/test/repo.git" }),
       "git clone": () => ({ stdout: "" }),
       "git fetch": () => ({ stdout: "" }),
+      // No merge commits in origin/main..HEAD — the #367 guard lets the rebase run.
+      "git rev-list": () => ({ stdout: "" }),
       "git rebase": (args) => {
         if (args.includes("--abort")) {
           rebase_abort_called = true;
@@ -186,6 +190,51 @@ describe("attempt_auto_merge", () => {
     expect(result.merged).toBe(false);
     expect(result.error).toContain("Rebase conflicts require manual resolution");
     expect(rebase_abort_called).toBe(true);
+  });
+
+  it("never rebases, pushes, or merges a branch carrying merge commits (#367)", async () => {
+    // The v2 merge-gate is not the only caller of try_local_rebase — this
+    // legacy path reaches it too, and must fail closed the same way. Real-git
+    // coverage of the guard itself lives in rebase-merge-commits.integration.test.ts.
+    let rebase_called = false;
+    let push_called = false;
+    let merge_after_rebase = false;
+    let merge_count = 0;
+
+    route_exec({
+      "gh pr merge": () => {
+        merge_count++;
+        if (merge_count > 1) merge_after_rebase = true;
+        return new Error("Pull request is not mergeable");
+      },
+      "gh repo view": () => ({ stdout: "test-org/test-repo" }),
+      "gh api": () => new Error("Merge conflict"),
+      "gh pr view": () => ({
+        stdout: JSON.stringify({ mergeable: "UNKNOWN", mergeStateStatus: "BEHIND" }),
+      }),
+      mktemp: () => ({ stdout: "/tmp/test-rebase-dir" }),
+      "git remote": () => ({ stdout: "https://github.com/test/repo.git" }),
+      "git clone": () => ({ stdout: "" }),
+      "git fetch": () => ({ stdout: "" }),
+      "git rev-list": () => ({ stdout: "abc1234def5678\n9876543210fedc\n" }),
+      "git rebase": () => {
+        rebase_called = true;
+        return { stdout: "" };
+      },
+      "git push": () => {
+        push_called = true;
+        return { stdout: "" };
+      },
+      rm: () => ({ stdout: "" }),
+    });
+
+    const result = await attempt_auto_merge(42, "feature/test", "/repo", "gh");
+
+    expect(rebase_called).toBe(false);
+    expect(push_called).toBe(false);
+    expect(merge_after_rebase).toBe(false);
+    expect(result.merged).toBe(false);
+    expect(result.error).toContain("abc1234def5678");
   });
 
   it("does not attempt update-branch or rebase when direct merge succeeds", async () => {
@@ -251,6 +300,8 @@ describe("attempt_auto_merge", () => {
       mktemp: () => ({ stdout: "/tmp/auto-rebase-test-42" }),
       "git clone": () => ({ stdout: "" }),
       "git fetch": () => ({ stdout: "" }),
+      // No merge commits in origin/main..HEAD — the #367 guard lets the rebase run.
+      "git rev-list": () => ({ stdout: "" }),
       "git rebase": (args) => {
         if (args.includes("--abort")) return { stdout: "" };
         return new Error("CONFLICT");
@@ -444,6 +495,8 @@ describe("attempt_auto_merge", () => {
       "git remote": () => ({ stdout: "https://github.com/test/repo.git" }),
       "git clone": () => ({ stdout: "" }),
       "git fetch": () => ({ stdout: "" }),
+      // No merge commits in origin/main..HEAD — the #367 guard lets the rebase run.
+      "git rev-list": () => ({ stdout: "" }),
       "git rebase": (args) => {
         if (args.includes("--abort")) return { stdout: "" };
         // Simulate a non-conflict git error (e.g. network, timeout).
@@ -548,6 +601,8 @@ describe("attempt_auto_merge", () => {
       "git remote": () => ({ stdout: "https://github.com/test/repo.git" }),
       "git clone": () => ({ stdout: "" }),
       "git fetch": () => ({ stdout: "" }),
+      // No merge commits in origin/main..HEAD — the #367 guard lets the rebase run.
+      "git rev-list": () => ({ stdout: "" }),
       "git rebase": (args) => {
         if (args.includes("--abort")) return { stdout: "" };
         rebase_attempted = true;

--- a/packages/daemon/src/__tests__/merge-gate.test.ts
+++ b/packages/daemon/src/__tests__/merge-gate.test.ts
@@ -262,6 +262,39 @@ describe("run_merge_gate", () => {
     expect(deps.gh_pr_merge).not.toHaveBeenCalled();
   });
 
+  it("BEHIND with merge commits on the branch → rebase_conflict alert, never a merge (#367)", async () => {
+    // The rebase was refused before it started, so there is nothing to retry
+    // and nothing to wait for. This must reach a human on the same alert path
+    // as a real conflict — a silent stall would leave the PR sitting approved
+    // and unmerged with nobody told why.
+    const deps = make_deps({
+      mergeability: {
+        mergeable: "MERGEABLE",
+        merge_state_status: "BEHIND",
+        head_sha: APPROVED_SHA,
+      },
+      rebase: {
+        success: false,
+        kind: "unsafe_merge_commits",
+        merge_shas: ["abc1234def5678", "9876543210fedc"],
+        error:
+          "Branch contains 2 merge commit(s) (abc1234def5678, 9876543210fedc). " +
+          "A plain rebase would drop them and can silently revert work already on main, " +
+          "so no rebase was attempted. Manual resolution required.",
+      },
+    });
+    const result = await run_merge_gate(make_input(), deps);
+
+    expect(result.kind).toBe("rebase_conflict");
+    expect(deps.gh_pr_merge).not.toHaveBeenCalled();
+    // The alert body is this error string, so the SHAs a human needs in order
+    // to resolve the branch have to survive into it.
+    if (result.kind !== "rebase_conflict") throw new Error("unreachable");
+    expect(result.error).toContain("abc1234def5678");
+    expect(result.error).toContain("9876543210fedc");
+    expect(result.error).toMatch(/merge commit/i);
+  });
+
   it("BEHIND with transient rebase failure → merge_failed (not falsely reported as conflict)", async () => {
     // Issue #254 — non-conflict rebase failures must NOT be reported as conflicts.
     const deps = make_deps({

--- a/packages/daemon/src/__tests__/rebase-merge-commits.integration.test.ts
+++ b/packages/daemon/src/__tests__/rebase-merge-commits.integration.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Integration coverage for the pre-merge rebase guard (issue #367).
+ *
+ * Nothing here is mocked: these tests drive real `git` against real temporary
+ * repositories. The bug being guarded against is a *silent* one — plain
+ * `git rebase` drops merge commits, replays the branch's older file versions
+ * on top of main, and exits 0. A mocked exec can never show that, because the
+ * whole failure lives inside git's replay semantics. So we ask git.
+ *
+ * The fixture that matters is `merge_fixture()`. Note what actually causes the
+ * revert, because it is narrower than "the branch merged main": git's 3-way
+ * replay is good at protecting content that exists in a commit it replays, and
+ * raises a conflict when a branch patch collides with main. What it cannot
+ * protect is content that exists *only in the merge commit* — conflict
+ * resolutions and merge-time adaptations, which have no commit to replay from.
+ * Those vanish, the pre-merge version of the file lands on top, and git reports
+ * success. The first test proves that on real git before anything else runs.
+ */
+
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { try_local_rebase } from "../review-utils.js";
+
+const exec = promisify(execFile);
+
+/** Deterministic identity + no user config bleeding in from the host. */
+const GIT_ENV: NodeJS.ProcessEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "Integration Test",
+  GIT_AUTHOR_EMAIL: "test@example.com",
+  GIT_COMMITTER_NAME: "Integration Test",
+  GIT_COMMITTER_EMAIL: "test@example.com",
+  GIT_CONFIG_GLOBAL: "/dev/null",
+  GIT_CONFIG_SYSTEM: "/dev/null",
+};
+
+async function git(cwd: string, args: string[]): Promise<string> {
+  const { stdout } = await exec("git", args, { cwd, env: GIT_ENV, timeout: 30_000 });
+  return stdout;
+}
+
+async function commit(repo: string, file: string, body: string, message: string): Promise<string> {
+  await writeFile(join(repo, file), body);
+  await git(repo, ["add", "-A"]);
+  await git(repo, ["commit", "--quiet", "-m", message]);
+  return (await git(repo, ["rev-parse", "HEAD"])).trim();
+}
+
+/** Tip SHA of a branch as the *remote* sees it — the force-push detector. */
+async function remote_tip(origin: string, branch: string): Promise<string> {
+  return (await git(origin, ["rev-parse", `refs/heads/${branch}`])).trim();
+}
+
+/** Content of a file at a remote ref, without checking anything out. */
+async function remote_file(origin: string, ref: string, path: string): Promise<string> {
+  return await git(origin, ["show", `${ref}:${path}`]);
+}
+
+describe("try_local_rebase merge-commit guard (real git)", () => {
+  let root: string;
+  let origin: string;
+  let repo: string;
+
+  beforeEach(async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    // realpath matters on macOS, where tmpdir() is a symlink into /private.
+    root = await realpath(await mkdtemp(join(tmpdir(), "rebase-guard-")));
+    origin = join(root, "origin.git");
+    repo = join(root, "repo");
+
+    await git(root, ["init", "--quiet", "--bare", "--initial-branch=main", origin]);
+    await git(root, ["clone", "--quiet", origin, repo]);
+    await commit(repo, "app.ts", "base\n", "chore: base");
+    await git(repo, ["push", "--quiet", "-u", "origin", "main"]);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  /**
+   * A branch that merged main and silently reverts a file under plain rebase.
+   *
+   *   main:    base ── fix: helper(a, b) ───────────────── unrelated
+   *                             \
+   *   feature:  ── edits app.ts ─ M(merge main) ── more work
+   *
+   * The load-bearing detail is *where the adapted content lives*. Main changed
+   * `helper`'s signature; the branch, while merging main, updated its own
+   * `app.ts` call site to match. That call site exists in exactly one tree —
+   * the merge commit's. Neither parent has it.
+   *
+   * Plain rebase drops M, so that content has nothing to replay from; the
+   * branch's own pre-merge commit reinstates the one-argument call. Git sees
+   * no conflict, because main never touched `app.ts` — the diff applies
+   * cleanly. What ships is a call site that no longer matches main's helper.
+   *
+   * This is the general shape of the bug: anything recorded only in a merge
+   * commit (conflict resolutions, merge-time adaptations) is dropped, and the
+   * pre-merge version of the file is replayed over the top in silence.
+   *
+   * Returns the SHA of the merge commit that the guard must report.
+   */
+  async function merge_fixture(): Promise<string> {
+    await commit(repo, "lib.ts", "export function helper(a) {\n  return a;\n}\n", "chore: helper");
+    await git(repo, ["push", "--quiet", "origin", "main"]);
+
+    await git(repo, ["checkout", "--quiet", "-b", "feature"]);
+    await commit(repo, "app.ts", "base\nexport const total = helper(1);\n", "feat: call helper");
+
+    // main changes the helper's signature — the fix that must survive.
+    await git(repo, ["checkout", "--quiet", "main"]);
+    await commit(
+      repo,
+      "lib.ts",
+      "export function helper(a, b) {\n  return a + b;\n}\n",
+      "fix: helper takes two args",
+    );
+    await git(repo, ["push", "--quiet", "origin", "main"]);
+
+    // The branch merges main and adapts its call site inside the merge commit.
+    await git(repo, ["checkout", "--quiet", "feature"]);
+    await git(repo, ["merge", "--quiet", "--no-ff", "--no-commit", "main"]);
+    await writeFile(join(repo, "app.ts"), "base\nexport const total = helper(1, 2);\n");
+    await git(repo, ["add", "-A"]);
+    await git(repo, ["commit", "--quiet", "-m", "merge main into feature"]);
+    const merge_sha = (await git(repo, ["rev-parse", "HEAD"])).trim();
+
+    await commit(repo, "feature.ts", "more work\n", "feat: continue feature");
+
+    // main moves on again, so the branch is BEHIND and a rebase is warranted.
+    await git(repo, ["checkout", "--quiet", "main"]);
+    await commit(repo, "unrelated.ts", "unrelated\n", "chore: unrelated");
+    await git(repo, ["push", "--quiet", "origin", "main"]);
+
+    await git(repo, ["checkout", "--quiet", "feature"]);
+    await git(repo, ["push", "--quiet", "-u", "origin", "feature"]);
+    return merge_sha;
+  }
+
+  /** A plain linear branch, behind main, that rebases cleanly. */
+  async function linear_fixture(): Promise<void> {
+    await git(repo, ["checkout", "--quiet", "-b", "feature"]);
+    await commit(repo, "feature.ts", "work\n", "feat: start feature");
+    await git(repo, ["push", "--quiet", "-u", "origin", "feature"]);
+
+    await git(repo, ["checkout", "--quiet", "main"]);
+    await commit(repo, "app.ts", "fixed on main\n", "fix: repair app.ts");
+    await git(repo, ["push", "--quiet", "origin", "main"]);
+
+    await git(repo, ["checkout", "--quiet", "feature"]);
+  }
+
+  /** A linear branch that edits the same lines main edited — a real conflict. */
+  async function conflict_fixture(): Promise<void> {
+    await git(repo, ["checkout", "--quiet", "-b", "feature"]);
+    await commit(repo, "app.ts", "branch version\n", "feat: branch edits app.ts");
+    await git(repo, ["push", "--quiet", "-u", "origin", "feature"]);
+
+    await git(repo, ["checkout", "--quiet", "main"]);
+    await commit(repo, "app.ts", "main version\n", "fix: main edits app.ts");
+    await git(repo, ["push", "--quiet", "origin", "main"]);
+
+    await git(repo, ["checkout", "--quiet", "feature"]);
+  }
+
+  // ── The fixture is real ──
+
+  it("fixture: plain `git rebase origin/main` silently reverts app.ts with no conflict", async () => {
+    // This documents *why* the guard exists. It drives git directly rather
+    // than try_local_rebase, so it keeps proving the hazard after the guard
+    // stops us from ever reaching a plain rebase on such a branch. If a future
+    // git release ever made plain rebase safe here, this test would be the
+    // one to tell us.
+    await merge_fixture();
+
+    // Mirrors try_local_rebase's own setup, so what we prove here is what
+    // would have happened in production.
+    const scratch = join(root, "plain-rebase");
+    await git(root, [
+      "clone",
+      "--quiet",
+      "--single-branch",
+      "--branch",
+      "feature",
+      origin,
+      scratch,
+    ]);
+    await git(scratch, ["fetch", "--quiet", "origin", "+refs/heads/main:refs/remotes/origin/main"]);
+
+    // Before: the branch's call site matches main's two-argument helper.
+    expect(await readFile(join(scratch, "app.ts"), "utf8")).toBe(
+      "base\nexport const total = helper(1, 2);\n",
+    );
+
+    // Plain rebase exits 0 — no conflict, nothing to resolve, nothing to see.
+    await git(scratch, ["rebase", "origin/main"]);
+
+    // After: the pre-merge call site is back, against a helper that now needs
+    // two arguments. This is the regression that shipped a red main.
+    expect(await readFile(join(scratch, "app.ts"), "utf8")).toBe(
+      "base\nexport const total = helper(1);\n",
+    );
+    expect(await readFile(join(scratch, "lib.ts"), "utf8")).toContain("helper(a, b)");
+  });
+
+  // ── The guard ──
+
+  it("refuses to rebase a branch containing a merge commit and reports the SHAs", async () => {
+    const merge_sha = await merge_fixture();
+
+    const result = await try_local_rebase("feature", repo, GIT_ENV);
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.kind).toBe("unsafe_merge_commits");
+    expect(result.merge_shas).toEqual([merge_sha]);
+    expect(result.error).toContain(merge_sha);
+  });
+
+  it("does not force-push a branch containing a merge commit", async () => {
+    await merge_fixture();
+    const tip_before = await remote_tip(origin, "feature");
+
+    await try_local_rebase("feature", repo, GIT_ENV);
+
+    expect(await remote_tip(origin, "feature")).toBe(tip_before);
+    // And the merge-time adaptation is still on the branch, un-reverted.
+    expect(await remote_file(origin, "refs/heads/feature", "app.ts")).toBe(
+      "base\nexport const total = helper(1, 2);\n",
+    );
+  });
+
+  it("rebases and force-pushes a linear branch exactly as before", async () => {
+    await linear_fixture();
+    const tip_before = await remote_tip(origin, "feature");
+
+    const result = await try_local_rebase("feature", repo, GIT_ENV);
+
+    expect(result).toEqual({ success: true });
+    // Force-push happened: the remote tip moved to the rebased commit.
+    expect(await remote_tip(origin, "feature")).not.toBe(tip_before);
+    // The rebased branch carries both main's fix and the branch's own work.
+    expect(await remote_file(origin, "refs/heads/feature", "app.ts")).toBe("fixed on main\n");
+    expect(await remote_file(origin, "refs/heads/feature", "feature.ts")).toBe("work\n");
+  });
+
+  it("still reports a genuine conflict, aborts cleanly, and leaves the remote alone", async () => {
+    await conflict_fixture();
+    const tip_before = await remote_tip(origin, "feature");
+
+    const result = await try_local_rebase("feature", repo, GIT_ENV);
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.kind).toBe("conflict");
+    expect(result.error).toMatch(/manual resolution/i);
+    expect(await remote_tip(origin, "feature")).toBe(tip_before);
+  });
+});

--- a/packages/daemon/src/merge-gate.ts
+++ b/packages/daemon/src/merge-gate.ts
@@ -59,8 +59,10 @@ export interface MergeGateInput {
  *   needed; the next check_suite will fire.
  * - `rebased_awaiting_ci` — branch was behind, rebase succeeded, force-push
  *   done. Waiting for a fresh check_suite on the rebased SHA before merging.
- * - `rebase_conflict` — branch is behind and cannot be cleanly rebased. Real
- *   conflict — needs human resolution.
+ * - `rebase_conflict` — branch is behind and cannot be safely rebased. Either
+ *   a real content conflict, or a branch carrying merge commits that a plain
+ *   rebase would drop (#367). Both need human resolution; neither can be
+ *   retried automatically.
  * - `branch_protected` — branch protection is blocking (missing required review
  *   from a team, etc.). Cannot self-resolve; alert.
  * - `mergeable_unknown` — GitHub hasn't finished computing mergeability. Wait
@@ -188,6 +190,15 @@ async function rebase_then_merge(
 
   if (!result.success) {
     if (result.kind === "conflict") {
+      return { kind: "rebase_conflict", error: result.error };
+    }
+    // The branch carries merge commits, so the rebase was refused before it
+    // started (#367). Like a conflict, this cannot resolve itself and cannot
+    // be retried — it needs a human — so it takes the same alert path. The
+    // distinct signal lives on `LocalRebaseResult.kind`; giving the gate its
+    // own outcome kind would need matching dispatch in webhook-handler.ts,
+    // which is owned by open PR #366. Worth splitting once that lands.
+    if (result.kind === "unsafe_merge_commits") {
       return { kind: "rebase_conflict", error: result.error };
     }
     return {

--- a/packages/daemon/src/review-utils.ts
+++ b/packages/daemon/src/review-utils.ts
@@ -642,9 +642,20 @@ async function poll_mergeable(
  * fetch_failed, push_failed) and a real merge conflict that requires manual
  * resolution. The merge-gate (#257) uses `kind` to decide whether to alert
  * a human or wait for the next CI cycle.
+ *
+ * `unsafe_merge_commits` (#367) is neither: the branch was never rebased at
+ * all, because rebasing it would have been unsafe. It carries the SHAs of the
+ * merge commits that made it so.
  */
 export type LocalRebaseResult =
   | { success: true }
+  | {
+      success: false;
+      kind: "unsafe_merge_commits";
+      /** Merge commits found in `origin/main..HEAD`, newest first. */
+      merge_shas: string[];
+      error: string;
+    }
   | {
       success: false;
       kind:
@@ -711,14 +722,72 @@ export async function try_local_rebase(
       };
     }
 
-    // Fetch main
+    // Fetch main.
+    //
+    // The explicit refspec is load-bearing. The clone above is --single-branch,
+    // so remote.origin.fetch only maps the PR branch; a bare `git fetch origin
+    // main` then writes FETCH_HEAD and nothing else, leaving `origin/main`
+    // unresolvable and every subsequent `git rebase origin/main` dying with
+    // "fatal: invalid upstream 'origin/main'". Naming the destination ref
+    // creates refs/remotes/origin/main, which both the merge-commit scan and
+    // the rebase below address by name.
     try {
-      await exec_async("git", ["fetch", "origin", "main"], { cwd: tmp_dir, env, timeout: 30_000 });
+      await exec_async("git", ["fetch", "origin", "+refs/heads/main:refs/remotes/origin/main"], {
+        cwd: tmp_dir,
+        env,
+        timeout: 30_000,
+      });
     } catch (err) {
       return {
         success: false,
         kind: "fetch_failed",
         error: `Fetch failed: ${String(err instanceof Error ? err.message : err)}`,
+      };
+    }
+
+    // Refuse to rebase a branch that contains merge commits (#367).
+    //
+    // Plain `git rebase` drops merge commits and linearises history. Anything
+    // recorded only in a merge commit — a conflict resolution, or an edit made
+    // while merging main to adapt the branch to it — has no commit to replay
+    // from, so it is simply lost, and the branch's pre-merge version of the
+    // file lands on top instead. Git raises no conflict: it never sees the
+    // collision, because the content it would have collided with is gone. The
+    // rebase reports success and we force-push a regression.
+    //
+    // There is no safe automatic answer. `--rebase-merges` preserves the
+    // topology but brings its own surprises, so we fail closed and hand the
+    // branch to a human rather than guess.
+    let merge_shas: string[];
+    try {
+      const { stdout } = await exec_async("git", ["rev-list", "--merges", "origin/main..HEAD"], {
+        cwd: tmp_dir,
+        env,
+        timeout: 30_000,
+      });
+      merge_shas = stdout
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+    } catch (err) {
+      // Could not establish whether the branch is safe. Fail closed — never
+      // fall through to the rebase on an unanswered question.
+      return {
+        success: false,
+        kind: "other",
+        error: `Could not scan branch for merge commits: ${String(err instanceof Error ? err.message : err)}`,
+      };
+    }
+
+    if (merge_shas.length > 0) {
+      console.log(
+        `[auto-merge] Refusing to rebase ${branch}: ${String(merge_shas.length)} merge commit(s) in origin/main..HEAD`,
+      );
+      return {
+        success: false,
+        kind: "unsafe_merge_commits",
+        merge_shas,
+        error: `Branch contains ${String(merge_shas.length)} merge commit(s) (${merge_shas.join(", ")}). A plain rebase would drop them and can silently revert work already on main, so no rebase was attempted. Manual resolution required.`,
       };
     }
 


### PR DESCRIPTION
## Summary

`try_local_rebase()` ran a plain `git rebase origin/main`, which drops merge commits. A branch that had merged `main` could be rebased, force-pushed with lease and merged while silently reverting a file — no conflict raised, nothing in the loop to catch it.

This makes the daemon fail closed: a branch carrying merge commits is never rebased and never pushed. It returns a new distinct outcome with the offending SHAs, and the merge-gate routes that to a human-facing alert.

## The actual mechanism (narrower than the issue assumed)

The issue describes the branch's older file versions being replayed over a fix live on `main`. Driving real git, that specific shape does **not** reproduce — git's 3-way replay is good at this. Two of three candidate shapes came back safe:

| Fixture | Result |
|---|---|
| Branch patch collides with main's change | **conflict raised** — protected today |
| Branch and main touch non-overlapping regions | clean, both changes kept — no revert |
| Content that exists **only in the merge commit** | **silent revert, exit 0** |

The third is the real bug. A conflict resolution, or an edit made while merging `main` to adapt the branch to it, lives in exactly one tree — the merge commit's. Neither parent has it. Rebase drops the merge, so that content has nothing to replay from; the branch's pre-merge version of the file lands on top. Git raises no conflict because the content it would have collided with is gone.

The fixture in `rebase-merge-commits.integration.test.ts` reproduces this: `main` widens `helper(a)` to `helper(a, b)`, the branch fixes its call site inside the merge commit, and plain rebase reinstates `helper(1)` against a two-argument helper. Verified red before the guard — `try_local_rebase` returned `{ success: true }` **and force-pushed** the reverted branch.

## Second bug found: the rebase never worked at all

The clone is `--single-branch`, so `remote.origin.fetch` only maps the PR branch. A bare `git fetch origin main` then writes `FETCH_HEAD` and nothing else — `refs/remotes/origin/main` is never created. Every `git rebase origin/main` died with `fatal: invalid upstream 'origin/main'`, classified as `kind: "other"`. Present since #181; every test on this path mocked git, so nothing ever caught it.

Fixed by naming the destination ref: `git fetch origin +refs/heads/main:refs/remotes/origin/main`. The guard's `origin/main..HEAD` scan depends on this, and so does the clean-rebase path the issue asks to preserve.

**Worth a reviewer's attention:** this means linear branches now genuinely rebase and force-push, where previously they always failed and alerted. That is the behaviour the issue assumes already exists, and the guard is in place before it is switched on — but it is a real change in what the daemon does, not a no-op.

## Changes

- **`review-utils.ts`** — `git rev-list --merges origin/main..HEAD` before rebasing. Non-empty → new `unsafe_merge_commits` result carrying `merge_shas`, no rebase, no push. A failed scan also fails closed rather than falling through. Fetch refspec fixed.
- **`merge-gate.ts`** — maps `unsafe_merge_commits` onto the existing `rebase_conflict` outcome, so it reaches the same alert with the SHAs in the body.
- No `--rebase-merges` fallback. Preserving merge topology through a rebase has its own surprises; the safe answer is a person.

`webhook-handler.ts` is untouched (open PR #366). Giving the gate its own outcome kind would need matching dispatch there — its switch has no exhaustiveness check, so a new kind would compile and then silently stall. Reusing `rebase_conflict` gets the alert out with zero ripple; a comment marks it as worth splitting once #366 lands.

## Verification

- Daemon suite: **1392 passed** (1385 before, +7), typecheck clean, `biome check` clean, build succeeds.
- New tests drive real git against temp repos — no mocked exec, since the failure lives inside git's replay semantics.
- Red-green verified by disabling the guard: the merge-commit branch is rebased **and force-pushed**; the v1 `attempt_auto_merge` test also goes red.
- Existing conflict handling and transient-error classification unchanged and still covered.

Closes #367
