### PR TITLE
fix(daemon): read the MCP panel cursor, not the session's own transcript

### DIFF
--- a/packages/daemon/src/__tests__/helpers/mcp-pane-fixtures.ts
+++ b/packages/daemon/src/__tests__/helpers/mcp-pane-fixtures.ts
@@ -1,0 +1,210 @@
+/**
+ * Real `tmux capture-pane -p` output from a live pool bot, captured while
+ * driving Claude Code's `/mcp` TUI by hand against a genuinely broken MCP
+ * connection (the plugin's bun server was SIGKILLed first, so the panel shows
+ * the real `✘ failed` state the recovery driver actually meets).
+ *
+ * These are byte-exact captures, not hand-written approximations, and that is
+ * the whole point. Issue #373 went undetected because every fixture in this
+ * suite was a two-line sketch — `"Manage MCP servers\n❯ plugin:discord"` —
+ * that contained none of the pane a real capture contains. A real pane also
+ * holds the transcript above the panel, and every command the transcript
+ * echoes renders as `❯ …` at column 0. That is what the old
+ * `selection_line` matched instead of the cursor.
+ *
+ * Note the nine `❯ /mcp` lines in the transcript below: each one is a
+ * previous failed recovery attempt. The bug was self-reinforcing — every
+ * failure echoed one more decoy above the panel.
+ *
+ * Do not "tidy" these. Re-capture them instead:
+ *   tmux capture-pane -t pool-N -p
+ */
+
+/** The `/mcp` server list, cursor still on the first row (`computer-use`) —
+ * the state the Down-hunt starts from. */
+export const REAL_PANE_SERVER_LIST = `
+✻ Conversation compacted (ctrl+o for history)
+
+
+❯ /compact
+  ⎿  Compacted (ctrl+o to see full summary)
+  ⎿  Read ../../CLAUDE.md (120 lines)
+  ⎿  Referenced file scratch/qs-build-status.html
+  ⎿  Read ../../../.claude/rules/escalation.md (12 lines)
+  ⎿  Read ../../../.claude/rules/collaboration.md (8 lines)
+
+❯ /mcp
+  ⎿  Reconnected to plugin:discord:discord.
+
+❯ /mcp
+  ⎿  MCP dialog dismissed
+
+❯ /mcp
+  ⎿  MCP dialog dismissed
+
+❯ /mcp
+  ⎿  MCP dialog dismissed
+
+❯ /mcp
+  ⎿  MCP dialog dismissed
+
+❯ /mcp
+  ⎿  MCP dialog dismissed
+
+❯ /mcp
+  ⎿  MCP dialog dismissed
+
+❯ /mcp
+  ⎿  Reconnected to plugin:discord:discord.
+
+❯ /mcp
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── gary ─
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  Manage MCP servers
+  2 servers
+
+    Built-in MCPs (always available)
+  ❯ computer-use · ◯ disabled
+    plugin:discord:discord · ✘ failed
+
+  ※ Run claude --debug to see error logs
+  https://code.claude.com/docs/en/mcp for help
+ ↑/↓ to navigate · Enter to confirm · Esc to cancel`;
+
+/** The same list after one Down: cursor on the failed discord server. This is
+ * the row the Down-hunt is looking for. */
+export const REAL_PANE_DISCORD_SELECTED = `
+✻ Conversation compacted (ctrl+o for history)
+
+
+❯ /compact
+  ⎿  Compacted (ctrl+o to see full summary)
+  ⎿  Read ../../CLAUDE.md (120 lines)
+  ⎿  Referenced file scratch/qs-build-status.html
+  ⎿  Read ../../../.claude/rules/escalation.md (12 lines)
+  ⎿  Read ../../../.claude/rules/collaboration.md (8 lines)
+
+❯ /mcp
+  ⎿  Reconnected to plugin:discord:discord.
+
+❯ /mcp
+  ⎿  MCP dialog dismissed
+
+❯ /mcp
+  ⎿  MCP dialog dismissed
+
+❯ /mcp
+  ⎿  MCP dialog dismissed
+
+❯ /mcp
+  ⎿  MCP dialog dismissed
+
+❯ /mcp
+  ⎿  MCP dialog dismissed
+
+❯ /mcp
+  ⎿  MCP dialog dismissed
+
+❯ /mcp
+  ⎿  Reconnected to plugin:discord:discord.
+
+❯ /mcp
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── gary ─
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  Manage MCP servers
+  2 servers
+
+    Built-in MCPs (always available)
+    computer-use · ◯ disabled
+  ❯ plugin:discord:discord · ✘ failed
+
+  ※ Run claude --debug to see error logs
+  https://code.claude.com/docs/en/mcp for help
+ ↑/↓ to navigate · Enter to confirm · Esc to cancel`;
+
+/** The discord server's detail menu, reached by pressing Enter on the row
+ * above. A failed server offers `1. Reconnect` / `2. Disable` with Reconnect
+ * preselected. (A *connected* server offers `1. View tools` / `2. Reconnect` /
+ * `3. Disable` instead — but recovery only ever runs against a failed one.)
+ *
+ * Note what this panel does NOT contain: the string "Manage MCP servers". Its
+ * header is "Plugin:discord:discord MCP Server". Any attempt to scope the
+ * cursor search by slicing at the server-list header would return null here
+ * and break the detail-menu guard. */
+export const REAL_PANE_DETAIL_MENU = `✻ Conversation compacted (ctrl+o for history)
+
+
+❯ /compact
+  ⎿  Compacted (ctrl+o to see full summary)
+  ⎿  Read ../../CLAUDE.md (120 lines)
+  ⎿  Referenced file scratch/qs-build-status.html
+  ⎿  Read ../../../.claude/rules/escalation.md (12 lines)
+  ⎿  Read ../../../.claude/rules/collaboration.md (8 lines)
+
+❯ /mcp
+  ⎿  Reconnected to plugin:discord:discord.
+
+❯ /mcp
+  ⎿  MCP dialog dismissed
+
+❯ /mcp
+  ⎿  MCP dialog dismissed
+
+❯ /mcp
+  ⎿  MCP dialog dismissed
+
+❯ /mcp
+  ⎿  MCP dialog dismissed
+
+❯ /mcp
+  ⎿  MCP dialog dismissed
+
+❯ /mcp
+  ⎿  MCP dialog dismissed
+
+❯ /mcp
+  ⎿  Reconnected to plugin:discord:discord.
+
+❯ /mcp
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── gary ─
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  Plugin:discord:discord MCP Server
+
+  Status:           ✘ failed
+  Command:          bun
+  Args:             run --cwd /Users/farm/.lobsterfarm/shared/claude-config-rengen/plugins/cache/claude-plugins-official/discord/0.0.4 --shell=bun --silent start
+  Config location:  Dynamically configured
+
+  ❯ 1. Reconnect
+    2. Disable
+
+  ↑/↓ to navigate · Enter to select · Esc to back`;
+
+/**
+ * Everything in a real pane above the panel: the transcript (nine `❯ /mcp`
+ * decoys included) plus the composer box, sliced verbatim out of the capture
+ * above so the chrome can never drift from reality.
+ */
+const REAL_PANE_ABOVE_PANEL = (() => {
+  const lines = REAL_PANE_SERVER_LIST.split("\n");
+  let i = lines.length - 1;
+  while (i >= 0 && !/^─{10,}/.test(lines[i] ?? "")) i--;
+  return lines.slice(0, i + 1).join("\n");
+})();
+
+/**
+ * Build a pane showing `panel_lines` below the composer, on top of the real
+ * transcript-and-composer chrome above.
+ *
+ * Scripted driver tests need panel states no live session happened to produce
+ * (a stray keystroke moving the cursor mid-sequence, say). Those states are
+ * synthetic, but the pane they are rendered into is not — which is the part
+ * that mattered for #373. Called with no arguments it yields an idle pane
+ * with no panel open at all.
+ */
+export function real_pane_showing(...panel_lines: string[]): string {
+  return [REAL_PANE_ABOVE_PANEL, ...panel_lines].join("\n");
+}

--- a/packages/daemon/src/__tests__/mcp-health.test.ts
+++ b/packages/daemon/src/__tests__/mcp-health.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   MCP_GIVEUP_THRESHOLD,
   MCP_GRACE_PERIOD_MS,
+  MCP_MAX_DOWN_PRESSES,
   MCP_MAX_RECONNECT_ATTEMPTS,
   MCP_RECOVERY_COOLDOWN_MS,
   attempt_mcp_reconnect,
@@ -19,6 +20,12 @@ import {
   wait_for_mcp_child,
 } from "../mcp-health.js";
 import type { McpDriver, McpRecoveryState, ProcessNode } from "../mcp-health.js";
+import {
+  REAL_PANE_DETAIL_MENU,
+  REAL_PANE_DISCORD_SELECTED,
+  REAL_PANE_SERVER_LIST,
+  real_pane_showing,
+} from "./helpers/mcp-pane-fixtures.js";
 
 // ── has_mcp_child (process-level detection, delegates to has_bun_descendant) ──
 
@@ -214,18 +221,69 @@ describe("encode_cache_slug", () => {
 // ── selection_line ──
 
 describe("selection_line", () => {
-  it("finds the line containing the ❯ selection cursor", () => {
-    const pane = [
-      "Manage MCP servers",
-      "  computer-use",
-      "❯ plugin:discord",
-      "  claude-design",
-    ].join("\n");
-    expect(selection_line(pane)).toBe("❯ plugin:discord");
+  // Guards the fixtures themselves. Every assertion below is only meaningful
+  // because the real captures carry `❯ …` prompt echoes in the transcript
+  // ABOVE the panel — that is exactly what #373 matched by mistake. A fixture
+  // trimmed down to just the panel block would pass against the buggy
+  // implementation and prove nothing, which is how this shipped in the first
+  // place. If this fails, re-capture the fixtures; do not relax the test.
+  it.each([
+    ["server list", REAL_PANE_SERVER_LIST],
+    ["discord selected", REAL_PANE_DISCORD_SELECTED],
+    ["detail menu", REAL_PANE_DETAIL_MENU],
+  ])("fixture guard: the %s capture has ❯ decoys above the panel", (_name, pane) => {
+    const lines = pane.split("\n");
+    const panel_start = lines.findIndex((l) => /^─{10,}/.test(l));
+    const decoys = lines.slice(0, panel_start).filter((l) => l.includes("❯"));
+
+    expect(panel_start).toBeGreaterThan(0);
+    expect(decoys.length).toBeGreaterThanOrEqual(2);
+    // ...and they must be the shape that fooled `.find()`: `❯` at column 0.
+    expect(decoys.every((l) => l.startsWith("❯"))).toBe(true);
   });
 
-  it("returns null when no line has a selection cursor", () => {
+  it("returns the panel cursor, not the transcript's own ❯ prompt echoes (#373)", () => {
+    // The regression. `.find()` returned "❯ /compact" here — the first ❯ in
+    // the pane, nine `❯ /mcp` echoes above the panel and completely unrelated
+    // to the cursor. The Down-hunt could therefore never match, so every
+    // automated reconnect aborted with server_not_found.
+    expect(selection_line(REAL_PANE_DISCORD_SELECTED)).toBe(
+      "  ❯ plugin:discord:discord · ✘ failed",
+    );
+  });
+
+  it("returns the first panel row when the cursor has not moved yet", () => {
+    expect(selection_line(REAL_PANE_SERVER_LIST)).toBe("  ❯ computer-use · ◯ disabled");
+  });
+
+  it("reads the detail menu, which carries no 'Manage MCP servers' header", () => {
+    // The detail panel is headed "Plugin:discord:discord MCP Server". Scoping
+    // the search by slicing at the server-list header would return null here
+    // and break the final guard of the sequence, so the region is anchored on
+    // the composer border instead.
+    expect(REAL_PANE_DETAIL_MENU).not.toContain("Manage MCP servers");
+    expect(selection_line(REAL_PANE_DETAIL_MENU)).toBe("  ❯ 1. Reconnect");
+  });
+
+  it("returns null for an idle pane with no panel open", () => {
+    // Fails closed rather than handing back a transcript line that might
+    // coincidentally match what a caller is looking for.
+    expect(selection_line(real_pane_showing())).toBeNull();
+  });
+
+  it("returns null when the pane has no composer at all", () => {
     expect(selection_line("nothing here\njust text")).toBeNull();
+  });
+
+  it("ignores indented markdown table rules when locating the composer", () => {
+    // Table borders are the only other `─` runs a pane shows; they are
+    // indented and start with a corner glyph, so the anchored pattern skips
+    // them and the composer border is still found.
+    const pane = real_pane_showing("  ❯ plugin:discord:discord · ✘ failed").replace(
+      "✻ Conversation compacted (ctrl+o for history)",
+      "  ┌────────────┬─────────┐\n  ├────────────┼─────────┤\n  └────────────┴─────────┘",
+    );
+    expect(selection_line(pane)).toBe("  ❯ plugin:discord:discord · ✘ failed");
   });
 });
 
@@ -512,14 +570,28 @@ describe("run_mcp_recovery_cycle", () => {
   });
 });
 
-function make_scripted_success_driver(): McpDriver {
-  const panel = "Manage MCP servers";
-  const captures = [
-    panel,
-    `${panel}\n❯ plugin:discord`,
-    `${panel}\n❯ plugin:discord`,
-    "❯ 1. Reconnect",
+/**
+ * The pane sequence a successful reconnect actually walks through, in real
+ * captures: panel opens with the cursor on the first row, one Down lands on
+ * the failed discord server, the pre-Enter guard re-reads the same pane, and
+ * Enter opens the detail menu with Reconnect preselected.
+ *
+ * This is the sequence verified by hand against a live bot whose MCP server
+ * had been killed — the driver drove it end to end and the bun child came
+ * back (#373).
+ */
+function real_success_captures(): string[] {
+  return [
+    REAL_PANE_SERVER_LIST, // panel-open guard
+    REAL_PANE_SERVER_LIST, // hunt: cursor still on computer-use → Down
+    REAL_PANE_DISCORD_SELECTED, // hunt: landed on plugin:discord
+    REAL_PANE_DISCORD_SELECTED, // pre-Enter re-confirm
+    REAL_PANE_DETAIL_MENU, // detail menu, ❯ 1. Reconnect
   ];
+}
+
+function make_scripted_success_driver(): McpDriver {
+  const captures = real_success_captures();
   return {
     capture: vi.fn(() => captures.shift() ?? null),
     send: vi.fn(),
@@ -553,33 +625,60 @@ describe("attempt_mcp_reconnect", () => {
   });
 
   it("hunts with Down until the selection line contains plugin:discord, never counting keystrokes", async () => {
-    const panel = "Manage MCP servers";
-    const captures = [
-      panel, // after /mcp
-      `${panel}\n❯ computer-use`, // 1st nav check — wrong server first (per spec)
-      `${panel}\n  computer-use\n❯ plugin:discord`, // 2nd nav check — found it
-      `${panel}\n  computer-use\n❯ plugin:discord`, // re-confirm before Enter
-      "Manage MCP servers\n❯ 1. Reconnect", // detail menu
-    ];
+    const captures = real_success_captures();
     const capture = vi.fn(() => captures.shift() ?? null);
     const driver = make_driver({ capture, is_healthy: vi.fn().mockReturnValue(true) });
 
     const result = await attempt_mcp_reconnect("pool-1", driver);
 
     expect(result).toEqual({ ok: true });
-    // One Down press to skip past "computer-use" before landing on plugin:discord.
-    expect(driver.send).toHaveBeenCalledWith("pool-1", "Down");
+    // Exactly one Down press to step off computer-use onto plugin:discord.
+    // This count is the driver-level regression assertion for #373: reading
+    // the transcript instead of the panel meant the hunt never matched, so it
+    // burned all MCP_MAX_DOWN_PRESSES presses and then gave up.
+    const downs = (driver.send as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c) => c[1] === "Down",
+    );
+    expect(downs).toHaveLength(1);
     expect(driver.send).toHaveBeenCalledWith("pool-1", "Enter");
     // Final step returns to the prompt.
     expect(driver.send).toHaveBeenLastCalledWith("pool-1", "Escape");
   });
 
+  it("gives up with server_not_found when the panel never lists plugin:discord", async () => {
+    // A real panel, but discord genuinely isn't in it. The hunt should exhaust
+    // its press budget and abort — the correct behaviour for this pane, and
+    // the behaviour #373 produced for every pane.
+    const pane = real_pane_showing(
+      "  Manage MCP servers",
+      "  1 server",
+      "",
+      "  ❯ computer-use · ◯ disabled",
+    );
+    const driver = make_driver({ capture: vi.fn().mockReturnValue(pane) });
+
+    const result = await attempt_mcp_reconnect("pool-1", driver);
+
+    expect(result).toEqual({ ok: false, reason: "server_not_found" });
+    const downs = (driver.send as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c) => c[1] === "Down",
+    );
+    expect(downs).toHaveLength(MCP_MAX_DOWN_PRESSES);
+    expect(driver.send).toHaveBeenCalledWith("pool-1", "Escape");
+  });
+
   it("aborts without pressing Enter when the selection line is wrong right before select", async () => {
-    const panel = "Manage MCP servers";
+    const moved = real_pane_showing(
+      "  Manage MCP servers",
+      "  2 servers",
+      "",
+      "  ❯ computer-use · ◯ disabled",
+      "    plugin:discord:discord · ✘ failed",
+    );
     const captures = [
-      panel, // after /mcp
-      `${panel}\n❯ plugin:discord`, // nav check — found immediately
-      `${panel}\n❯ something-else`, // re-confirm — selection moved (stray key)
+      REAL_PANE_SERVER_LIST, // panel-open guard
+      REAL_PANE_DISCORD_SELECTED, // hunt — found immediately
+      moved, // re-confirm — a stray key moved the cursor
     ];
     const capture = vi.fn(() => captures.shift() ?? null);
     const send = vi.fn();
@@ -594,12 +693,19 @@ describe("attempt_mcp_reconnect", () => {
   });
 
   it("aborts when the detail menu doesn't show Reconnect selected", async () => {
-    const panel = "Manage MCP servers";
+    const wrong_item = real_pane_showing(
+      "  Plugin:discord:discord MCP Server",
+      "",
+      "  Status:           ✘ failed",
+      "",
+      "    1. Reconnect",
+      "  ❯ 2. Disable",
+    );
     const captures = [
-      panel,
-      `${panel}\n❯ plugin:discord`,
-      `${panel}\n❯ plugin:discord`,
-      "some other detail menu\n❯ 2. Disable", // wrong item selected
+      REAL_PANE_SERVER_LIST,
+      REAL_PANE_DISCORD_SELECTED,
+      REAL_PANE_DISCORD_SELECTED,
+      wrong_item,
     ];
     const capture = vi.fn(() => captures.shift() ?? null);
     const send = vi.fn();
@@ -610,19 +716,16 @@ describe("attempt_mcp_reconnect", () => {
     expect(result).toEqual({ ok: false, reason: "detail_menu_not_shown" });
     // The failing capture was after the plugin:discord Enter — that Enter did fire...
     expect(send).toHaveBeenCalledWith("pool-1", "Enter");
-    // ...but the final Reconnect-confirming Enter must never fire.
+    // ...but the final Reconnect-confirming Enter must never fire. Note the
+    // pane *contains* the text "1. Reconnect" on an unselected row: the guard
+    // has to read the cursor, not the panel body.
+    expect(wrong_item).toContain("1. Reconnect");
     expect(send.mock.calls.filter((c) => c[1] === "Enter")).toHaveLength(1);
     expect(send).toHaveBeenCalledWith("pool-1", "Escape");
   });
 
   it("reports child_still_missing when the process signal doesn't recover after Reconnect", async () => {
-    const panel = "Manage MCP servers";
-    const captures = [
-      panel,
-      `${panel}\n❯ plugin:discord`,
-      `${panel}\n❯ plugin:discord`,
-      "❯ 1. Reconnect",
-    ];
+    const captures = real_success_captures();
     const capture = vi.fn(() => captures.shift() ?? null);
     const driver = make_driver({ capture, is_healthy: vi.fn().mockReturnValue(false) });
 
@@ -636,13 +739,7 @@ describe("attempt_mcp_reconnect", () => {
   });
 
   it("happy path: full sequence confirms reconnect and re-verifies the process signal", async () => {
-    const panel = "Manage MCP servers";
-    const captures = [
-      panel,
-      `${panel}\n❯ plugin:discord`,
-      `${panel}\n❯ plugin:discord`,
-      "❯ 1. Reconnect",
-    ];
+    const captures = real_success_captures();
     const capture = vi.fn(() => captures.shift() ?? null);
     const is_healthy = vi.fn().mockReturnValue(true);
     const driver = make_driver({ capture, is_healthy });

--- a/packages/daemon/src/mcp-health.ts
+++ b/packages/daemon/src/mcp-health.ts
@@ -40,7 +40,13 @@
  * (Reconnect x2 + fallback, still unhealthy) within 30 minutes, give up —
  * stop attempting and let the caller alert. The bot is never released.
  *
- * References: issue #345, #347. Template for pane-driving with guards:
+ * 2026-08-21 (#373): the scripted Reconnect above had in fact never worked
+ * in production — `selection_line` was reading the session's own transcript
+ * instead of the panel, so every attempt aborted and fell back to kill +
+ * resume. See that function's comment; it is the reason a long run of
+ * "deaf channel" reports all traced back to one helper.
+ *
+ * References: issue #345, #347, #373. Template for pane-driving with guards:
  * `rate-limit-recovery.ts` (#270) and `econnreset-recovery.ts` (#337, sibling
  * — a different failure mode, deliberately not merged with this detector).
  */
@@ -73,7 +79,15 @@ export const MCP_GIVEUP_THRESHOLD = 3;
 export const MCP_GIVEUP_WINDOW_MS = 30 * 60 * 1000;
 
 /** Wait between each guarded keystroke of the reconnect driver, giving the
- * TUI time to render before the next pane capture. */
+ * TUI time to render before the next pane capture.
+ *
+ * Measured (#373) against a live idle session by polling `capture-pane` every
+ * 50ms: the `/mcp` panel paints 60-81ms after Enter, a Down moves the cursor
+ * in 4-6ms, and the detail menu paints in 59-68ms — four consecutive runs.
+ * 1.5s is ~20x headroom, so this was never the bottleneck it looked like when
+ * the driver appeared to hang; that was `selection_line` failing to match.
+ * Left as-is: it already absorbs a 20x slowdown, and raising it would only
+ * make each *failed* cycle slower (up to MCP_MAX_DOWN_PRESSES waits). */
 export const MCP_RECONNECT_STEP_WAIT_MS = 1_500;
 
 /** After sending the final Reconnect keystroke, wait this long before
@@ -287,9 +301,61 @@ export function send_keys(tmux_session: string, ...keys: string[]): void {
   }
 }
 
-/** Find the line containing the `❯` selection cursor in a TUI list/panel. */
+/**
+ * A full-width horizontal rule at column 0 — one of the two lines Claude Code
+ * draws around the composer. Anchored and unindented on purpose: the only
+ * other `─` runs a pane ever shows are markdown table borders, which are
+ * indented and start with `┌`/`├`/`└`.
+ *
+ * The 10-character floor is a safety margin, not a measurement — real borders
+ * span the terminal width (193-200 chars in the captures this was verified
+ * against) and would still be matched in a very narrow terminal.
+ */
+const COMPOSER_BORDER = /^─{10,}/;
+
+/**
+ * Find the line bearing the `❯` selection cursor in the overlay panel that
+ * Claude Code draws *below* the composer — the `/mcp` server list, or a
+ * single server's detail menu.
+ *
+ * #373: this used to be `.find((line) => line.includes("❯"))` across the
+ * whole pane. But `capture_pane` returns everything visible, and the
+ * transcript above the composer echoes every command the session has run as
+ * `❯ /mcp` at column 0. On any bot that had already attempted a reconnect,
+ * the FIRST `❯` was one of those stale echoes, never the cursor. The
+ * Down-hunt in `attempt_mcp_reconnect` then burned all
+ * MCP_MAX_DOWN_PRESSES iterations without ever matching "plugin:discord",
+ * aborted with `server_not_found`, and pressed Escape — surfacing in the
+ * transcript as "MCP dialog dismissed". The failure was self-reinforcing:
+ * each attempt echoed one more `❯ /mcp` decoy above the panel. Every
+ * automated recovery since had been failing this way; manual recovery always
+ * worked first try because a human reads the actual cursor.
+ *
+ * So the search is scoped to the panel rather than the pane. The panel is
+ * always drawn after the composer's bottom border, which makes the cursor the
+ * first `❯` following the LAST border rule. Scoping by region rather than by
+ * `findLast` is deliberate: it is a statement about where the cursor lives,
+ * not an assumption that nothing below it can ever contain a `❯`. It also
+ * fails closed — a pane with no panel open yields null instead of whatever
+ * `❯` line happened to be last, so the callers' guards abort rather than
+ * matching a transcript line by coincidence.
+ *
+ * Deliberately NOT scoped by slicing at the "Manage MCP servers" header: the
+ * server detail menu is headed "Plugin:discord:discord MCP Server" and
+ * contains no such string, so a header slice would return null for the
+ * `1. Reconnect` guard and break the last step of the sequence.
+ *
+ * Returns null when no panel is open (or the pane is unreadable enough to
+ * have lost its composer) — same fail-closed posture as `capture_pane`.
+ */
 export function selection_line(pane_output: string): string | null {
-  return pane_output.split("\n").find((line) => line.includes("❯")) ?? null;
+  const lines = pane_output.split("\n");
+  let composer_bottom = lines.length - 1;
+  while (composer_bottom >= 0 && !COMPOSER_BORDER.test(lines[composer_bottom] ?? "")) {
+    composer_bottom--;
+  }
+  if (composer_bottom < 0) return null;
+  return lines.slice(composer_bottom + 1).find((line) => line.includes("❯")) ?? null;
 }
 
 // ── Reconnect driver (Step 1) ──
@@ -334,6 +400,10 @@ export type ReconnectResult = { ok: true } | { ok: false; reason: ReconnectFailu
  *   4. Re-confirm the selection line before Enter (guards against a stray
  *      keystroke moving the cursor between capture and send).
  *   5. Confirm the detail menu shows "❯ 1. Reconnect" selected, else abort.
+ *      Verified against a real failed server (#373): its menu is
+ *      "❯ 1. Reconnect / 2. Disable", Reconnect preselected. A *connected*
+ *      server shows "1. View tools / 2. Reconnect / 3. Disable" instead, but
+ *      recovery only ever runs against a failed one.
  *   6. Enter, wait ~6s, then re-verify the process-level signal.
  */
 export async function attempt_mcp_reconnect(


### PR DESCRIPTION
## The bug

`selection_line` took the **first** line containing `❯` from the whole captured pane:

```ts
return pane_output.split("\n").find((line) => line.includes("❯")) ?? null;
```

`capture_pane` returns everything visible, and Claude Code echoes every command the session has run into the transcript *above* the composer as `❯ /mcp` at column 0. On any bot that had already attempted a reconnect, the first match was one of those stale echoes — never the panel cursor.

So the Down-hunt in `attempt_mcp_reconnect` could never match `plugin:discord`. It burned all 20 presses, returned `server_not_found`, and pressed Escape — which is what surfaced in transcripts as `MCP dialog dismissed`. Self-reinforcing: each attempt echoed one more `❯ /mcp` decoy above the panel.

**The scripted Reconnect step has therefore never worked in production.** Every recovery since it shipped fell through to kill + resume. All three call sites inherited the flaw, so the `wrong_selection` guard was incapable of firing correctly.

Verified live — this is a real capture from a bot whose MCP server had just been killed:

```
❯ /compact          ← what selection_line returned
...
❯ /mcp              ← nine of these, one per failed attempt
❯ /mcp
──────────────────────────────────────────────── gary ─
──────────────────────────────────────────────────────
  Manage MCP servers
    computer-use · ◯ disabled
  ❯ plugin:discord:discord · ✘ failed     ← the actual cursor
```

## The fix

Scope the search to the panel rather than the pane. Claude Code draws overlay panels below the composer, so the cursor is the first `❯` after the last composer border rule.

Region-scoping rather than `findLast` is deliberate: it states where the cursor lives instead of assuming nothing below it can hold a `❯`, and it fails closed — a pane with no panel open returns `null` instead of an arbitrary transcript line. Scored against 17 real captures (15 live pool/pat sessions plus both dialog states), the region approach and `findLast` agree wherever a panel is open; they differ on the 9 captures with no panel, where `findLast` hands back the composer's own prompt and region-scoping correctly returns `null`.

**Not** scoped by slicing at the `Manage MCP servers` header, which was the obvious candidate. The server detail menu is headed `Plugin:discord:discord MCP Server` and contains no such string, so a header slice would return `null` for the `1. Reconnect` guard and break the final step of the sequence. Confirmed against a real capture, not assumed.

## Testing

The previous fixtures were two-line sketches (`"Manage MCP servers\n❯ plugin:discord"`) with no transcript above the panel — they passed against the broken code and proved nothing. Same failure mode as the CI fixtures in #374.

They are replaced with byte-exact `tmux capture-pane -p` output taken while driving the TUI by hand against a genuinely failed MCP server (the plugin's bun process was SIGKILLed first, so the panel shows the real `✘ failed` state). A fixture-guard test asserts the captures still carry `❯` decoys above the panel, so they cannot be quietly tidied back into uselessness.

**Red/green verified.** Against the old one-liner: 11 failures, including every `attempt_mcp_reconnect` test. After the fix: 62 pass.

```
× selection_line > returns the panel cursor, not the transcript's own ❯ prompt echoes (#373)
  → expected '❯ /compact' to be '  ❯ plugin:discord:discord · ✘ failed'
```

The driver-level assertion is the Down-press count: exactly 1 on the real sequence, versus the full `MCP_MAX_DOWN_PRESSES` budget the bug produced.

The whole sequence was also driven end-to-end against a live bot twice: kill the MCP child → 0 bun descendants → drive `/mcp` → Reconnect → 1 bun descendant. `has_mcp_child` is untouched.

Full suite green: daemon 1518, shared 65, cli 34. Typecheck, lint, build all pass. Rebased on `472e110` (#374).

## `MCP_RECONNECT_STEP_WAIT_MS`

Measured rather than guessed, by polling `capture-pane` every 50ms on a live session: the panel paints **60-81ms** after Enter, a Down moves the cursor in **4-6ms**, and the detail menu paints in **59-68ms**, over four consecutive runs. The existing 1.5s already carries ~20x headroom, so it is **left unchanged** and the measurement is recorded on the constant. The driver only *looked* slow because `selection_line` never matched.

## Out of scope, filed separately

Two things turned up in the live captures that this PR does not touch:

1. **The failed driver leaves panels open on arbitrary servers.** pool-4 was sitting in claude.ai Booking.com's *tools* list; pool-6 was sitting in the computer-use detail menu with `❯ 1. Enable` selected — one Enter from enabling computer-use on a production bot.
2. **Seven bots had `/mcp` stranded unsent in the composer**, which would corrupt the next injected Discord message.

Both were left by failed reconnect attempts, and both make a bot deaf while `has_mcp_child` still reads healthy. I could not reproduce either mechanism on demand, so I am not guessing at a fix here. Panels dismissed and composers cleared by hand on the affected sessions.

Closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXmCMcshYx5ytSSb68GCk2
